### PR TITLE
feat: Graceful Shutdown 설정 추가

### DIFF
--- a/application-api/src/main/resources/application.yml
+++ b/application-api/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: fantazzk-server
+  lifecycle:
+    timeout-per-shutdown-phase: 25s
   datasource:
     url: jdbc:postgresql://localhost:54322/postgres
     username: postgres
@@ -14,6 +16,7 @@ cors:
     - http://localhost:5173
 
 server:
+  shutdown: graceful
   tomcat:
     mbeanregistry:
       enabled: true


### PR DESCRIPTION
## Summary
- Spring Boot `server.shutdown=graceful` + `timeout-per-shutdown-phase=25s` 설정 추가
- Railway 서비스에 `drainingSeconds=30`, `healthcheckPath=/actuator/health` 설정 완료 (CLI로 적용됨)

## 동작 방식
1. Railway가 새 인스턴스 health check 통과 후 기존 인스턴스에 SIGTERM 전송
2. Spring Boot가 새 요청 수락 중단, 진행 중인 요청 최대 25초 대기
3. Railway는 30초간 draining 후 SIGKILL (5초 마진)

## Test plan
- [ ] 배포 후 `/actuator/health` 정상 응답 확인
- [ ] 재배포 시 기존 요청이 끊기지 않는지 확인

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)