### PR TITLE
dev/prod Hikari 풀 조정 및 dev DB 분리

### DIFF
--- a/application-api/src/main/resources/application.yml
+++ b/application-api/src/main/resources/application.yml
@@ -53,6 +53,9 @@ spring:
     url: ${DATABASE_URL}
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 0
   liquibase:
     default-schema: dev
 
@@ -90,6 +93,9 @@ spring:
     url: ${DATABASE_URL}
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 0
   liquibase:
     default-schema: production
 

--- a/application-api/src/test/kotlin/com/naminhyeok/fantazzk/bootstrap/root/FantazzkApplicationConfigTest.kt
+++ b/application-api/src/test/kotlin/com/naminhyeok/fantazzk/bootstrap/root/FantazzkApplicationConfigTest.kt
@@ -16,6 +16,42 @@ class FantazzkApplicationConfigTest {
         assertThat(exposedEndpoints).isEqualTo(listOf("health"))
     }
 
+    @Test
+    fun `dev 프로필은 hikari maximum pool size를 5로 제한한다`() {
+        val devDocument =
+            readYamlDocuments()
+                .first { nestedValue(it, "spring", "config", "activate", "on-profile") == "dev" }
+
+        assertThat(nestedValue(devDocument, "spring", "datasource", "hikari", "maximum-pool-size")).isEqualTo(5)
+    }
+
+    @Test
+    fun `dev 프로필은 hikari minimum idle을 0으로 유지한다`() {
+        val devDocument =
+            readYamlDocuments()
+                .first { nestedValue(it, "spring", "config", "activate", "on-profile") == "dev" }
+
+        assertThat(nestedValue(devDocument, "spring", "datasource", "hikari", "minimum-idle")).isEqualTo(0)
+    }
+
+    @Test
+    fun `프로덕션 프로필은 hikari maximum pool size를 5로 제한한다`() {
+        val productionDocument =
+            readYamlDocuments()
+                .first { nestedValue(it, "spring", "config", "activate", "on-profile") == "production" }
+
+        assertThat(nestedValue(productionDocument, "spring", "datasource", "hikari", "maximum-pool-size")).isEqualTo(5)
+    }
+
+    @Test
+    fun `프로덕션 프로필은 hikari minimum idle을 0으로 유지한다`() {
+        val productionDocument =
+            readYamlDocuments()
+                .first { nestedValue(it, "spring", "config", "activate", "on-profile") == "production" }
+
+        assertThat(nestedValue(productionDocument, "spring", "datasource", "hikari", "minimum-idle")).isEqualTo(0)
+    }
+
     private fun readYamlDocuments(): List<Map<*, *>> =
         checkNotNull(javaClass.classLoader.getResourceAsStream("application.yml"))
             .use { inputStream ->


### PR DESCRIPTION
## 변경 내용
- `dev`, `production` 프로필에 Hikari 설정을 명시적으로 추가했습니다 (`maximum-pool-size: 5`, `minimum-idle: 0`).
- 위 설정을 고정하는 구성 테스트를 추가했습니다.
- 운영 작업으로 Railway `dev`를 전용 Supabase 프로젝트로 분리해 `dev`와 `production`이 같은 커넥션 예산을 쓰지 않도록 정리했습니다.

## 변경 이유
production 배포가 Liquibase 초기화 단계에서 `MaxClientsInSessionMode`로 실패하고 있었습니다. 원인은 크게 두 가지였습니다.
- `dev`와 `production`이 같은 Supabase session pooler 예산을 공유하고 있던 점
- 배포 overlap 구간에서 기본 Hikari 동작이 idle connection을 과하게 유지하던 점

## 영향
- `dev`는 이제 별도 Supabase 프로젝트를 사용합니다.
- `production`은 조정된 Hikari 설정으로 정상 배포됩니다.
- 최신 production deployment `7fb26f08-2503-402b-a2b7-5a370b522dd7`는 정상 상태이며, deploy 로그에서 `MaxClientsInSessionMode`가 더 이상 나타나지 않습니다.

## 검증
- `./gradlew :application-api:test :application-api:integrationTest`
- Railway `dev` health check가 `UP`
- Railway `production` 최신 deployment가 `SUCCESS`
- production의 `/actuator/health`, `/actuator/health/liveness`, `/actuator/health/readiness`가 모두 `UP`

Closes #21
