### PR TITLE
Railway 배포 설정과 리소스 제한을 정리한다

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,4 +1,4 @@
-# Synced from the live Railway `server` service on 2026-03-30.
+# Synced from the live Railway `server` service on 2026-04-02.
 # This file intentionally mirrors only the explicit build/deploy settings.
 
 "$schema" = "https://railway.com/railway.schema.json"
@@ -6,12 +6,16 @@
 [environments.dev.build]
 builder = "RAILPACK"
 
+[environments.dev.deploy]
+startCommand = "java -jar $(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' -print -quit)"
+sleepApplication = true
+
 [environments.dev.deploy.multiRegionConfig."asia-southeast1-eqsg3a"]
 numReplicas = 1
 
 [environments.dev.deploy.limitOverride.containers]
-cpu = 0.5
-memoryBytes = 500_000_000
+cpu = 0.1
+memoryBytes = 256_000_000
 
 [environments.production.build]
 builder = "RAILPACK"
@@ -19,10 +23,12 @@ builder = "RAILPACK"
 [environments.production.deploy]
 healthcheckPath = "/actuator/health"
 drainingSeconds = 30
+startCommand = "java -jar $(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' -print -quit)"
+sleepApplication = true
 
 [environments.production.deploy.multiRegionConfig."asia-southeast1-eqsg3a"]
 numReplicas = 1
 
 [environments.production.deploy.limitOverride.containers]
-cpu = 1.0
-memoryBytes = 2_000_000_000
+cpu = 0.5
+memoryBytes = 500_000_000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ logging:
     com.naminhyeok.fantazzk: DEBUG
 
 server:
+  port: ${PORT:8080}
   shutdown: graceful
   tomcat:
     mbeanregistry:

--- a/src/test/kotlin/com/naminhyeok/fantazzk/bootstrap/root/FantazzkApplicationConfigTest.kt
+++ b/src/test/kotlin/com/naminhyeok/fantazzk/bootstrap/root/FantazzkApplicationConfigTest.kt
@@ -6,6 +6,13 @@ import org.yaml.snakeyaml.Yaml
 
 class FantazzkApplicationConfigTest {
     @Test
+    fun `애플리케이션은 PORT 환경 변수를 우선 사용한다`() {
+        val defaultDocument = readYamlDocuments().first()
+
+        assertThat(nestedValue(defaultDocument, "server", "port")).isEqualTo("\${PORT:8080}")
+    }
+
+    @Test
     fun `프로덕션 프로필은 actuator health만 노출한다`() {
         val productionDocument =
             readYamlDocuments()


### PR DESCRIPTION
## 변경 내용
- Railway start command를 명시해 배포 컨테이너가 boot jar를 정확히 찾도록 수정했습니다.
- 애플리케이션이 PORT 환경 변수를 우선 사용하도록 설정했습니다.
- dev는 serverless를 켜고 0.1 CPU / 256MB로 맞추도록 정리했습니다.
- production도 serverless를 켜고 0.5 CPU / 500MB로 맞추도록 정리했습니다.
- 설정 회귀를 막기 위해 application.yml 검증 테스트를 유지했습니다.

## 변경 이유
- Railway 최신 production 배포가 build는 성공하지만 시작 단계에서 boot jar를 찾지 못해 healthcheck에 실패하고 있었습니다.
- 배포 플랫폼이 주입하는 PORT를 명시적으로 사용해야 기동 포트가 안정적으로 맞춰집니다.
- 현재는 개발 위주 단계라 dev는 비용 절감을 우선하고, production은 필요한 리소스만 유지한 채 serverless로 운영하도록 정리했습니다.

## 검증
- ./gradlew test --tests 'com.naminhyeok.fantazzk.bootstrap.root.FantazzkApplicationConfigTest'
- railway.toml 파싱으로 dev/prod 리소스 값과 sleepApplication 값을 확인
