### PR TITLE
railway에서 부팅가능한 최소스펙을 사용한다

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -14,8 +14,8 @@ sleepApplication = true
 numReplicas = 1
 
 [environments.dev.deploy.limitOverride.containers]
-cpu = 0.1
-memoryBytes = 256_000_000
+cpu = 0.5
+memoryBytes = 500_000_000
 
 [environments.production.build]
 builder = "RAILPACK"


### PR DESCRIPTION
GUI상 가능한 가장 낮은 스펙으로 조정