### PR TITLE
Railway 운영 환경을 production만 유지하도록 정리

### DIFF
--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -2,6 +2,8 @@
 
 `railway.toml` is the code-owned copy of the live Railway build/deploy settings for the `server` service in the `fantazzk` project.
 
+The current live setup keeps only the `production` environment on Railway. If a non-production environment is reintroduced later, mirror its explicit build/deploy settings under `environments.<name>` in `railway.toml`.
+
 ## What lives in code
 
 - `builder`
@@ -17,15 +19,12 @@
 
 1. Link this repository to the Railway project/service if needed.
    Run: `railway link -p <project-id> -s <service-id> -e production`
-2. Inspect the live dev settings.
-   Run: `railway environment config -e dev --json`
-3. Inspect the live production settings.
+2. Inspect the live production settings.
    Run: `railway environment config -e production --json`
-4. Update `railway.toml` to match the current explicit `build` and `deploy` settings.
+3. Update `railway.toml` to match the current explicit `build` and `deploy` settings.
 
 ## Variables
 
-To inspect variables without opening the dashboard:
+To inspect production variables without opening the dashboard:
 
-- `railway variable list -e dev --json`
 - `railway variable list -e production --json`

--- a/railway.toml
+++ b/railway.toml
@@ -1,21 +1,7 @@
-# Synced from the live Railway `server` service on 2026-04-02.
+# Synced from the live Railway `server` service on 2026-04-05.
 # This file intentionally mirrors only the explicit build/deploy settings.
 
 "$schema" = "https://railway.com/railway.schema.json"
-
-[environments.dev.build]
-builder = "RAILPACK"
-
-[environments.dev.deploy]
-startCommand = "java -jar $(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' -print -quit)"
-sleepApplication = true
-
-[environments.dev.deploy.multiRegionConfig."asia-southeast1-eqsg3a"]
-numReplicas = 1
-
-[environments.dev.deploy.limitOverride.containers]
-cpu = 0.5
-memoryBytes = 500_000_000
 
 [environments.production.build]
 builder = "RAILPACK"
@@ -24,7 +10,7 @@ builder = "RAILPACK"
 healthcheckPath = "/actuator/health"
 drainingSeconds = 30
 startCommand = "java -jar $(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' -print -quit)"
-sleepApplication = true
+sleepApplication = false
 
 [environments.production.deploy.multiRegionConfig."asia-southeast1-eqsg3a"]
 numReplicas = 1


### PR DESCRIPTION
## 변경 내용
- 더 이상 사용하지 않는 Railway `dev` 환경 관련 설정을 코드와 배포 문서에서 제거했습니다.
- Railway production이 슬립되지 않도록 `sleepApplication = false`로 변경했습니다.
- 현재 운영 방식이 production 단일 환경이라는 점이 배포 문서에 드러나도록 정리했습니다.

## 변경 이유
- 지금은 별도의 Railway `dev` 환경이 필요하지 않습니다.
- `dev` 환경을 남겨두면 이후 배포나 외부 요청으로 다시 비용이 발생할 여지가 있어, 환경 자체를 제거하는 편이 더 안전합니다.
- production은 서버리스처럼 잠들지 않고 계속 떠 있어야 합니다.

## 영향
- Railway production은 슬립 없이 계속 실행됩니다.
- `railway.toml`과 실제 운영 환경 구성이 production 단일 환경 기준으로 맞춰집니다.
- 이후 `railway.toml` 기반 배포에서도 production non-sleep 설정이 유지됩니다.

## 검증
- `railway service status --json`
- `railway deployment list -e production -s server --json | jq '.[0] | {id, status, sleep: .meta.serviceManifest.deploy.sleepApplication, createdAt}'`
- `railway environment config -e dev --json` 결과가 `Environment "dev" not found.` 인지 확인
- `railway status --json | jq '.environments.edges[].node.name'`
- `git diff --cached --check`