### PR TITLE
AI 가이드와 팀 스킬 운영 기준을 정리한다

### DIFF
--- a/.claude/skills/domain-modeling-playbook/SKILL.md
+++ b/.claude/skills/domain-modeling-playbook/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: domain-modeling-playbook
+description: Use when introducing or refactoring aggregates, value objects, domain policies, or application-service/domain boundaries in this repository.
+user-invocable: false
+paths:
+  - src/main/java/**
+---
+
+# Domain Modeling Playbook
+
+## Overview
+
+Model the business language and consistency rules first. Keep infrastructure at the edge, keep the domain deterministic, and let aggregates own invariants instead of turning application services into decision engines.
+
+Read `references/modeling-smells.md` when you need concrete examples of anemic models, oversized aggregates, or misplaced orchestration.
+
+## When To Use
+
+- introducing a new aggregate or major domain type
+- deciding whether something is an entity, value object, service, or policy
+- moving business rules between aggregate and application layers
+- reviewing whether a model is becoming an anemic data bag
+
+## When Not To Use
+
+- mechanical controller, DTO, or repository wiring with no domain decision
+- pure test-layer questions better handled by `server-testing-playbook`
+
+## Modeling Flow
+
+1. Name the rule or invariant in domain language
+2. Decide what must stay consistent together
+3. Choose the smallest aggregate that can protect that consistency boundary
+4. Keep orchestration outside the aggregate and rules inside it
+5. Push time, randomness, and external state to explicit boundaries
+
+## Entities, Value Objects, Aggregates
+
+- Use a value object when identity does not matter and equality is by value
+- Use an entity when continuity and identity matter over time
+- Use an aggregate only when you need a consistency boundary with behavior and invariants
+- Prefer references by identifier across aggregate boundaries instead of rich object graphs
+
+## Application Services
+
+- Default flow: `load -> invoke aggregate -> save`
+- Keep application services thin when they only orchestrate
+- Put branching business rules on the aggregate or a domain policy when they belong to the domain model
+- Do not let application services become decision dumps that move all invariants out of the model
+
+## Deterministic Design
+
+- Domain behavior should be testable without Spring
+- Use `Clock` for time
+- Do not wrap every technical UUID by default
+- Use explicit generators only when the produced identifier or code has business meaning
+- Do not call random APIs directly inside domain rules when the random outcome changes behavior
+
+## Modeling Smells
+
+- setters that allow invalid intermediate states
+- aggregate methods that only expose data and leave all decisions to services
+- application services that contain all the real rules
+- public methods or hooks added only for tests or persistence convenience
+- aggregates that are too large because unrelated consistency rules were grouped together
+
+## Review Questions
+
+- What invariant is this model protecting?
+- Does this type need identity, or is it really a value object?
+- Is this aggregate the smallest boundary that can keep the rule true?
+- Is the application service orchestrating, or secretly owning domain policy?
+- Would this still be easy to test if Spring disappeared from the picture?

--- a/.claude/skills/domain-modeling-playbook/references/modeling-smells.md
+++ b/.claude/skills/domain-modeling-playbook/references/modeling-smells.md
@@ -1,0 +1,19 @@
+# Modeling Smells
+
+## Likely Anemic Model
+
+- aggregate methods only expose data
+- application service contains all branching and rule decisions
+- invariants are checked only in controllers or services
+
+## Aggregate Too Large
+
+- unrelated rules change together only because data lives in one object
+- many commands touch disjoint parts of the aggregate without shared consistency needs
+- tests require huge fixtures to exercise small pieces of behavior
+
+## Boundary Leakage
+
+- domain methods depend directly on Spring or persistence infrastructure
+- time, randomness, or external state is pulled from globals inside domain code
+- production API surface grows only to make tests easier

--- a/.claude/skills/modulith-boundary-review/SKILL.md
+++ b/.claude/skills/modulith-boundary-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: modulith-boundary-review
+description: Use when reviewing or changing Spring Modulith package boundaries, cross-module contracts, events, or module tests in this repository.
+user-invocable: false
+paths:
+  - src/main/java/**
+  - src/test/java/**/architecture/**
+---
+
+# Modulith Boundary Review
+
+## Overview
+
+Spring Modulith boundaries should make dependency direction and collaboration style obvious. Keep module contracts narrow, keep subpackages internal, and use synchronous contracts and asynchronous events for different reasons rather than interchangeably.
+
+Read `references/boundary-smells.md` when you need concrete examples of overexposed module APIs, RPC-by-event, or coupling-heavy module tests.
+
+## When To Use
+
+- creating or splitting a module
+- exposing a new cross-module contract
+- deciding between direct contract and domain event
+- reviewing a package structure or module test for coupling problems
+
+## When Not To Use
+
+- local refactors that stay fully inside one module and do not touch published contracts
+- domain invariant questions better handled by `domain-modeling-playbook`
+
+## Boundary Rules
+
+- Application modules are defined by package roots
+- Only public types in a module root are cross-module contracts
+- Subpackages are internal implementation details
+- Keep public surface minimal
+- Do not depend directly on another module’s internal types, repositories, queries, or application internals
+
+## Direct Contract vs Event
+
+- Use an explicit contract bean when the collaboration is synchronous and required for consistency
+- Use a domain event when the collaboration is a follow-up reaction and can be decoupled
+- Do not use events as an RPC replacement
+- Do not add an event if there is no real consumer
+
+## Packaging And Coupling
+
+- Use `application`, `api`, `repository`, `query`, and `infrastructure` only when the role is clear
+- Do not create interface/impl pairs with no boundary value
+- Avoid `spi` as a default pattern
+- If a module test needs many mocked neighboring modules, treat that as a coupling smell
+
+## Query And Read Model Guidance
+
+- CQRS is a tool, not a goal
+- Keep `query` packages only when they add real decoupling or API value
+- Do not build read models that merely wrap the write model again
+- Keep read-side details internal unless they are a true external contract
+
+## What To Test
+
+- `ApplicationModules.verify()` should always pass
+- Use `@ApplicationModuleTest` only when module interaction itself matters
+- Strengthen structural tests before adding cross-module behavior tests that freeze implementation details
+
+## Review Questions
+
+- Is this type really part of the module’s public contract?
+- Is this collaboration required now, or is it a later reaction?
+- Would another module still work if this internal package moved tomorrow?
+- Is this event carrying a real decoupled reaction, or hiding a synchronous dependency?
+- Did this test prove a boundary, or just preserve current wiring?

--- a/.claude/skills/modulith-boundary-review/references/boundary-smells.md
+++ b/.claude/skills/modulith-boundary-review/references/boundary-smells.md
@@ -1,0 +1,19 @@
+# Boundary Smells
+
+## Overexposed Contract
+
+- public types exist in a module root without real cross-module value
+- another module imports subpackage implementation details
+- query or repository types are used as ad-hoc cross-module APIs
+
+## RPC By Event
+
+- an event exists only because a synchronous dependency was avoided cosmetically
+- a producer assumes exactly one consumer must react immediately
+- event payload is too thin, forcing consumers to reload write-side state
+
+## Coupling-Heavy Tests
+
+- `@ApplicationModuleTest` needs many mocked neighboring modules
+- the test mainly preserves current wiring rather than a module contract
+- structural rules could prove the boundary more cheaply than behavior tests

--- a/.claude/skills/server-testing-playbook/SKILL.md
+++ b/.claude/skills/server-testing-playbook/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: server-testing-playbook
+description: Use when choosing, reviewing, refactoring, or deleting tests in this repository, especially to decide test layers, doubles, fixtures, or regression coverage.
+user-invocable: false
+---
+
+# Server Testing Playbook
+
+## Overview
+
+Tests in this repository are executable docs that protect domain rules, module boundaries, external contracts, and regression risk. Prefer the cheapest test that can prove the behavior without freezing the current implementation.
+
+Read `references/regression-and-layers.md` when you need concrete examples of test-layer choices or good and bad regression tests.
+
+## When To Use
+
+- writing a new test
+- choosing between `test` and `integrationTest`
+- deciding whether to keep or delete an existing test
+- reviewing fixture design, test doubles, or regression coverage
+
+## When Not To Use
+
+- basic command lookup already covered by `AGENTS.md` or `CLAUDE.md`
+- purely production modeling questions with no testing tradeoff
+
+## Choose The Test Type
+
+- Unit test: aggregates, value objects, domain policies, deterministic orchestration
+- `@WebMvcTest`: controller contract, validation, serialization, status codes
+- `@DataJpaTest`: JPA mapping, repository queries, persistence behavior that H2 can represent
+- `@ApplicationModuleTest`: module interaction itself is the subject under test
+- `integrationTest`: external boundaries or runtime combinations that unit tests cannot sufficiently prove
+
+Use `integrationTest` for things like:
+
+- Testcontainers-backed database behavior
+- locking and transaction isolation
+- vendor-specific SQL, schema, or migration behavior
+- HTTP integration using MockServer, WireMock, or similar boundary tooling
+
+## Test Doubles
+
+- Default to `fake` and `stub`
+- Use `spy` only when the side effect itself is part of the contract and state assertions are not enough
+- Use Mockito sparingly
+- Use `@MockitoBean` only in Spring slice tests when boundary control matters
+
+Smells:
+
+- multiple `@MockitoBean` declarations in one test class
+- tests that mainly verify call order or call count
+- thin orchestration tests that only prove delegation
+
+## Determinism
+
+- Domain logic should be testable without Spring
+- Push time, randomness, and external state to boundaries
+- Use `Clock` for time
+- Do not wrap every technical UUID by default
+- When an identifier or code has business meaning, use an explicit generator such as `RoomCodeGenerator`
+- Do not call random APIs directly inside domain rules when the random outcome changes business behavior
+
+## Fixtures
+
+- Default to test data builders
+- Allow small static helpers when they remove obvious noise
+- Do not use large object mothers as the primary strategy
+- Important scenario values must stay visible in the test body
+- If a reader has to open multiple files to understand the setup, the fixture abstraction is too deep
+- Do not distort production code just to make fixture setup easier
+
+## Regression Tests
+
+- A bug fix should usually add regression protection
+- Regression protection can be a new test, a stronger existing test, or a stronger structural rule
+- Protect the observable result or contract, not the current implementation shape
+- Add the regression at the lowest-cost layer that can prove the behavior
+
+Bad regression tests:
+
+- freezing helper calls, call order, or method decomposition
+- asserting implementation choreography instead of business outcome
+
+## Thin Application Services
+
+Keep explicit tests when the service owns meaningful policy, for example:
+
+- branching rules
+- transaction boundaries
+- permission checks
+- event publication
+- idempotency, retry, or lock-sensitive orchestration
+
+Treat tests as optional or removable when the service is only:
+
+- `load -> invoke aggregate -> save`
+- trivial delegation already covered by lower-cost tests
+
+## Test Refactoring
+
+- Test code is a maintained asset and can be refactored
+- Fixture code is also subject to cleanup or deletion
+- If harmless production refactors break many tests, the tests are probably too implementation-coupled
+- Remove low-value tests that no longer protect real risk
+
+## Verification Workflow
+
+- During implementation: run targeted tests or `./gradlew test`
+- Before concluding local work: run `./gradlew check`
+- Before commit or review: run `./gradlew integrationTest`
+
+`integrationTest` is excluded from the default inner loop because it lengthens feedback, not because it is optional.

--- a/.claude/skills/server-testing-playbook/references/regression-and-layers.md
+++ b/.claude/skills/server-testing-playbook/references/regression-and-layers.md
@@ -1,0 +1,20 @@
+# Regression And Layer Examples
+
+## Layer Choice
+
+- Use a unit test when an aggregate or policy can prove the rule without Spring.
+- Use `@WebMvcTest` when the contract under review is request mapping, validation, serialization, or status code behavior.
+- Use `@DataJpaTest` when H2 is enough to validate mapping and repository behavior.
+- Escalate to `integrationTest` when you need real database semantics, external HTTP boundaries, or realistic runtime composition.
+
+## Good Regression Tests
+
+- A tie-break rule test that proves the winner selection result
+- A controller test that proves an invalid request returns the expected status and payload
+- A persistence test that proves a locking or isolation rule with the real database
+
+## Bad Regression Tests
+
+- Verifying helper call order after a bug fix
+- Freezing private method decomposition
+- Adding a broad end-to-end test when a focused lower-cost test could prove the same rule

--- a/.codex/skills/domain-modeling-playbook/SKILL.md
+++ b/.codex/skills/domain-modeling-playbook/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: domain-modeling-playbook
+description: Use when creating or refactoring aggregates, entities, value objects, application services, or domain boundaries in this repository.
+---
+
+# Domain Modeling Playbook
+
+Canonical team guidance lives in `.claude/skills/domain-modeling-playbook/SKILL.md`.
+
+When this skill triggers:
+
+- read the canonical Claude skill first
+- apply the same rules in Codex
+- prefer the canonical file over this bridge if wording ever diverges
+
+Use this bridge so Codex and Claude Code follow the same repository-shared domain-modeling playbook.

--- a/.codex/skills/modulith-boundary-review/SKILL.md
+++ b/.codex/skills/modulith-boundary-review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: modulith-boundary-review
+description: Use when creating, reviewing, or refactoring Spring Modulith package boundaries, cross-module contracts, events, and module tests in this repository.
+---
+
+# Modulith Boundary Review
+
+Canonical team guidance lives in `.claude/skills/modulith-boundary-review/SKILL.md`.
+
+When this skill triggers:
+
+- read the canonical Claude skill first
+- apply the same rules in Codex
+- prefer the canonical file over this bridge if wording ever diverges
+
+Use this bridge so Codex and Claude Code follow the same repository-shared Modulith boundary playbook.

--- a/.codex/skills/server-testing-playbook/SKILL.md
+++ b/.codex/skills/server-testing-playbook/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: server-testing-playbook
+description: Use when writing, reviewing, refactoring, or deleting tests in this repository, especially to choose test types, test doubles, fixtures, and regression coverage.
+---
+
+# Server Testing Playbook
+
+Canonical team guidance lives in `.claude/skills/server-testing-playbook/SKILL.md`.
+
+When this skill triggers:
+
+- read the canonical Claude skill first
+- apply the same rules in Codex
+- prefer the canonical file over this bridge if wording ever diverges
+
+Use this bridge so Codex and Claude Code follow the same repository-shared testing playbook.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,91 +1,79 @@
 # Fantazzk Server
 
-## 기본 구조
+## 프로젝트 형태
 
 - 이 저장소는 단일 Gradle 프로젝트, 단일 Spring Boot 애플리케이션을 가진 Spring Modulith다.
 - 루트 엔트리포인트는 `com.naminhyeok.fantazzk.FantazzkApplication` 하나만 둔다.
-- 핵심 애플리케이션 모듈은 `room`, `template`다.
-- 각 모듈은 패키지로 경계를 나누며, 기본적으로 `CLOSED` 모듈로 취급한다.
-
-## 패키지 규칙
-
-- 애플리케이션 모듈은 모듈 루트 패키지로 정의한다.
-- 모듈 루트 패키지의 public 타입만 다른 모듈에 공개되는 기본 계약으로 본다.
-- 모듈 하위 패키지는 기본적으로 내부 구현으로 취급한다.
-- aggregate와 핵심 도메인 개념은 모듈 루트 또는 `domain` 아래에 둘 수 있다. 한 모듈 안에서는 한 가지 스타일을 일관되게 유지한다.
-- `application`은 유스케이스 오케스트레이션을 둔다. 기본 흐름은 `load -> invoke aggregate -> save`다.
-- `api`, `repository`, `query`, `infrastructure`는 필요할 때만 둔다. Modulith가 요구하는 필수 구조는 아니다.
-- DTO, exception, helper는 특정 패키지 배치를 강제하지 않는다. 다만 한 모듈 안에서는 일관성을 유지한다.
-- cross-module contract는 모듈 루트 패키지에 최소 개수만 공개한다.
-- `spi` 패키지는 사용하지 않는다.
-- 의미 없는 port/adapter, interface/impl 쌍은 두지 않는다. 추상화는 모듈 경계, 도메인 개념, 기술적 제약을 분명히 드러낼 때만 유지한다.
-- 새로 손대는 파일은 경로와 패키지 선언을 맞춘다. 기존 어긋남은 점진적으로 해소한다.
+- 애플리케이션 모듈은 패키지 루트로 정의한다.
+- 최상위 문서는 현재 모듈 목록 같은 스냅샷보다 오래 가는 규칙만 설명한다.
+- 상세한 팀 공유 플레이북은 `.claude/skills/` 아래에 두고, 이 문서는 짧은 운영 규칙만 유지한다.
 
 ## 모듈 경계
 
-- 다른 모듈은 모듈 루트에 공개된 계약 외 타입에 직접 의존하지 않는다.
-- `room`은 `template` 모듈 루트에 공개된 계약만 참조할 수 있다.
-- `template`는 `room` 내부 타입을 직접 참조하지 않는다.
-- `api`, `application`, `repository`, `query` 같은 하위 패키지는 모듈 내부 구현 세부사항으로 본다.
-- 모듈 간 필수 동기 협력은 명시적 contract bean 으로 표현한다.
-- 모듈 간 후속 반응은 실제 consumer 가 있을 때만 event 로 표현한다.
-- 이벤트는 RPC 대체재로 사용하지 않는다.
-- named interface 는 기본적으로 도입하지 않는다.
+- 모듈 루트 패키지의 public 타입만 다른 모듈에 공개되는 기본 계약으로 본다.
+- 모듈 하위 패키지는 기본적으로 내부 구현으로 취급한다.
+- 공개 surface는 최소로 유지한다.
+- aggregate와 핵심 도메인 개념은 모듈 루트 또는 `domain` 아래에 둘 수 있다. 한 모듈 안에서는 한 가지 스타일을 일관되게 유지한다.
+- `application`, `api`, `repository`, `query`, `infrastructure`는 역할이 분명할 때만 둔다.
+- `spi` 패키지는 기본 선택지로 두지 않는다.
+- 의미 없는 port/adapter, interface/impl 쌍은 두지 않는다. 추상화는 모듈 경계, 도메인 개념, 기술적 제약을 분명히 드러낼 때만 유지한다.
+- 새로 손대는 파일은 경로와 패키지 선언을 맞춘다. 기존 어긋남은 점진적으로 해소한다.
 
-## 빈 등록 규칙
-
-- 루트 애플리케이션은 `@SpringBootApplication`을 사용한다.
-- 컴포넌트 스캔 기반 등록을 기본으로 한다. `@Service`, `@Component`, `@RestController` 사용 가능
-- `@Configuration`은 실제 bean 조립이 필요한 경우에만 둔다.
-  예: JDBC repository adapter 조립, SPI adapter 노출, 보안/인프라 설정
-- 단순히 이미 스캔 가능한 타입을 `@Import`만 하는 wrapper configuration은 만들지 않는다.
-- `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` 기반 등록은 사용하지 않는다.
-
-## 도메인 간 협력
+## 협력 규칙
 
 - 같은 모듈 내부 협력은 direct call 을 기본으로 한다.
-- 모듈 간 필수 동기 협력은 explicit contract bean 을 기본으로 한다.
-- 모듈 간 후속 반응이나 비동기 협력은 domain event 를 사용한다.
+- 모듈 간 필수 동기 협력은 explicit contract bean 으로 표현한다.
+- 모듈 간 후속 반응이나 비동기 협력은 실제 consumer 가 있을 때만 domain event 로 표현한다.
 - 다른 모듈의 repository, application service, query service를 직접 찌르지 않는다.
 - 이벤트는 RPC 대체재처럼 쓰지 않는다. required consistency 는 direct contract 로 표현한다.
-- aggregate는 자신의 규칙과 상태 전이를 우선 책임진다. 이벤트는 실제 consumer 가 있을 때만 유지한다.
-- application service는 manual publisher 를 들고 same-module orchestration 을 하지 않는다.
-- listener/projection 이 필요하면 event payload 만으로 처리하고, read-side 갱신을 위해 write repository 를 다시 조회하는 구조는 피한다.
+- application service의 기본 흐름은 `load -> invoke aggregate -> save` 다.
+- application service는 same-module orchestration 을 위해 manual publisher 를 들고 다니지 않는다.
+- listener 나 projection 은 가능한 한 event payload 만으로 처리하고, read-side 갱신만을 위해 write model 을 다시 조회하는 구조는 피한다.
 
-## CQRS / Read Model
+## Java 와 Spring 규칙
 
-- CQRS는 목표가 아니라 수단이다.
-- `query` 패키지는 API 조회나 모듈 decoupling에 실질적 가치가 있을 때만 유지한다.
-- write model을 그대로 다시 감싼 수준이면 projection을 늘리지 않는다.
-- read-side는 모듈 내부 구현으로 유지하고, 외부 모듈 계약으로 승격하지 않는다.
-
-## 테스트 기준
-
-- 테스트는 구현 세부보다 설계 규칙과 모듈 경계를 우선 검증한다.
-- 테스트는 특정 클래스 이름이나 패키지 배치를 고정하기보다, 공개 surface, 의존 방향, 협력 방식 같은 구조 규칙을 검증해야 한다.
-- `ApplicationModules.verify()`가 항상 통과해야 한다.
-- module canvas / PlantUML 문서 생성 테스트를 유지한다.
-- 모듈 간 협력은 `@ApplicationModuleTest`로 검증한다.
-- `PublishedEvents`, `Scenario`는 실제 module event 와 listener 가 있을 때만 사용한다.
-- module event 가 없다면 direct state assertion 으로 검증한다.
-- aggregate 정책은 단위 테스트로 검증한다.
-- 저장소/HTTP 동작은 통합 테스트로 검증한다.
-
-## 문서화 기준
-
-- 새 구조 판단 기준은 Oliver Drotbohm의 Spring Modulith 철학이다.
-- 판단 우선순위는 다음과 같다.
-  1. 모듈 경계가 분명한가
-  2. 공개 surface가 최소인가
-  3. required consistency 와 decoupled reaction 이 정직하게 구분되는가
-  4. projection이 정말 필요한가
-  5. 테스트가 모듈 경계를 증명하는가
-
-## jMolecules 기준
-
-- 도메인 개념은 가능하면 `jMolecules` 타입과 annotation으로 먼저 표현한다.
+- package-private 을 기본으로 하고, `public` 은 모듈 루트 계약, 외부 API, 프레임워크가 요구하는 타입에만 사용한다.
+- 루트 애플리케이션은 `@SpringBootApplication`을 사용한다.
+- 컴포넌트 스캔 기반 등록을 기본으로 한다.
+- `@Configuration`은 실제 bean 조립이 필요한 경우에만 둔다.
+- 단순히 이미 스캔 가능한 타입을 다시 export 하기 위한 wrapper configuration 은 만들지 않는다.
+- 생성자 주입을 기본으로 한다.
+- 도메인 개념은 가능하면 `jMolecules` 타입과 인터페이스로 먼저 표현하고, annotation 은 역할을 보강할 때만 사용한다.
 - aggregate root 와 identifier 는 `org.jmolecules.ddd.types`를 우선 사용한다.
 - application / query service 구현은 `org.jmolecules.ddd.annotation.Service`로 역할을 드러낸다.
 - repository abstraction 은 `org.jmolecules.ddd.annotation.Repository`로 역할을 드러낸다.
-- `room.internal.*` 같은 우산 패키지는 강제하지 않는다. Modulith 기준에서 모듈 하위 패키지는 이미 internal 이므로 역할 중심 패키지(`application`, `api`, `query`, `repository`, `spi`)를 유지한다.
-- JPA 전환 여부와 `jMolecules` 도입 여부는 분리해서 판단한다. `jMolecules` 도입이 곧 JPA 전환을 의미하지는 않는다.
+
+## 테스트와 검증
+
+- 테스트는 구현 과정을 기록하는 용도가 아니라 설계 규칙, 도메인 규칙, 외부 계약, 회귀 위험을 보호하는 실행 가능한 문서다.
+- 테스트는 구현 세부보다 공개 계약과 관찰 가능한 결과를 우선 검증한다.
+- domain 로직은 가능하면 Spring 없이 deterministic 한 unit test 로 검증할 수 있어야 한다.
+- 시간, 난수, 사용자에게 의미 있는 코드 생성, 외부 상태 같은 비결정 요소는 경계 밖으로 밀어내고 주입 가능하게 만든다.
+- 단순 기술적 UUID 생성까지 모두 래핑할 필요는 없다. 다만 규칙이 붙는 코드나 결과를 바꾸는 랜덤성은 명시적 generator 나 strategy 로 분리한다.
+- 기본 test double 은 fake 와 stub 이다. mock 과 spy 는 제한적으로 사용한다.
+- `@MockitoBean`은 `@WebMvcTest` 같은 Spring slice 나 모듈 경계 테스트에서 scope 제어가 필요할 때만 제한적으로 사용한다.
+- fixture 는 builder 를 기본으로 하고, 테스트의 의미를 바꾸는 값은 테스트 본문에서 직접 드러낸다.
+- fixture 가 반복되는 잡음을 줄이는 것은 좋지만, 핵심 전제를 숨기면 안 된다.
+- 테스트 편의를 위해 production code 를 왜곡하지 않는다.
+- 테스트 코드와 fixture 도 관리와 리팩토링의 대상이다. 구현 리팩토링에 과도하게 깨지는 테스트는 설계도 다시 본다.
+- 유지할 테스트는 모듈 규칙, 도메인 invariant, 외부 계약, 실제 regression risk 를 보호해야 한다.
+- thin delegation 이나 일회성 TDD scaffolding, 구현 choreography 만 보존하는 테스트는 정리 대상이다.
+- 버그를 수정했다면 그 문제가 다시 발생하지 않도록 자동 검증을 추가하는 것을 기본 원칙으로 한다.
+- regression test 는 내부 구현이 아니라 외부 계약, 도메인 규칙, 관찰 가능한 결과를 고정해야 한다.
+- repository 테스트의 기본값은 `@DataJpaTest` 와 H2 다. 락, 격리 수준, DB vendor 고유 동작, 실제 migration 결과처럼 H2 로 충분히 증명할 수 없는 것은 `integrationTest` 에서 실제 데이터베이스로 검증한다.
+- web contract 는 `@WebMvcTest` 로 검증한다.
+- 모듈 구조는 `ApplicationModules.verify()` 로 항상 검증 가능해야 한다.
+- 모듈 간 협력이 중요한 경우에만 `@ApplicationModuleTest`를 사용한다.
+- 구현 중에는 대상 테스트나 `./gradlew test` 를 우선 사용한다.
+- 로컬 작업을 마무리하기 전에는 `./gradlew check` 를 실행한다.
+- commit 직전이나 review 전에는 `./gradlew integrationTest` 를 실행한다.
+- `integrationTest` 는 unit test 만으로 충분히 증명할 수 없는 외부 경계와 실제 런타임 조합을 검증한다. 피드백 루프는 더 길지만 중요한 검증이므로 commit 전과 CI 에서는 반드시 포함한다.
+
+## 에이전트가 피해야 할 것
+
+- 현재 모듈 목록이나 임시 구조를 최상위 규칙으로 문서화하는 것
+- 다른 모듈의 내부 패키지나 구현 타입에 직접 결합하는 것
+- mock 을 기본값처럼 남발하는 것
+- 구현 리팩토링을 막는 brittle test 를 늘리는 것
+- 테스트 편의를 위해 production code 에 test-only hook 을 추가하는 것
+- 이미 lower-cost test 가 보호하는 규칙을 다른 레이어에서 반복 검증하는 것

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,124 +1,79 @@
 # Fantazzk Server
 
-## 모듈 구조
+## 프로젝트 형태
 
-도메인 하나는 기본적으로 다음 모듈로 구성된다.
+- 이 저장소는 단일 Gradle 프로젝트, 단일 Spring Boot 애플리케이션을 가진 Spring Modulith다.
+- 루트 엔트리포인트는 `com.naminhyeok.fantazzk.FantazzkApplication` 하나만 둔다.
+- 애플리케이션 모듈은 패키지 루트로 정의한다.
+- 최상위 문서는 현재 모듈 목록 같은 스냅샷보다 오래 가는 규칙만 설명한다.
+- 상세한 팀 공유 플레이북은 `.claude/skills/` 아래에 두고, 이 문서는 짧은 운영 규칙만 유지한다.
 
-- `model` — 도메인 모델, 값 객체, 순수 도메인 규칙
-- `exception` — 도메인 예외
-- `schema` — Liquibase 마이그레이션
-- `infrastructure` — repository port, 외부 도메인과 통신하기 위한 out-port 계약
-- `service` — 유스케이스와 비즈니스 로직
-- `repository-{type}` — `infrastructure`에 정의된 persistence port 구현
-- `api` — REST controller, request/response DTO
-- `application-{type}` — 실행 환경 설정과 모듈 조립
-- `integration:X-Y` — 소비자 도메인 `X`의 out-port를 제공자 도메인 `Y`에 연결하는 어댑터
+## 모듈 경계
 
-## 의존성 규칙
+- 모듈 루트 패키지의 public 타입만 다른 모듈에 공개되는 기본 계약으로 본다.
+- 모듈 하위 패키지는 기본적으로 내부 구현으로 취급한다.
+- 공개 surface는 최소로 유지한다.
+- aggregate와 핵심 도메인 개념은 모듈 루트 또는 `domain` 아래에 둘 수 있다. 한 모듈 안에서는 한 가지 스타일을 일관되게 유지한다.
+- `application`, `api`, `repository`, `query`, `infrastructure`는 역할이 분명할 때만 둔다.
+- `spi` 패키지는 기본 선택지로 두지 않는다.
+- 의미 없는 port/adapter, interface/impl 쌍은 두지 않는다. 추상화는 모듈 경계, 도메인 개념, 기술적 제약을 분명히 드러낼 때만 유지한다.
+- 새로 손대는 파일은 경로와 패키지 선언을 맞춘다. 기존 어긋남은 점진적으로 해소한다.
 
-| 모듈 | 허용된 의존성 |
-|------|-------------|
-| model, exception, schema | 없음 |
-| infrastructure | model |
-| service | model, infrastructure, exception |
-| repository-{type} | infrastructure |
-| api | service, exception |
-| integration:X-Y | X:infrastructure, Y:service |
-| application-{type} | schema, api, repository-{type}, integration:* |
+## 협력 규칙
 
-역방향 의존 금지.
+- 같은 모듈 내부 협력은 direct call 을 기본으로 한다.
+- 모듈 간 필수 동기 협력은 explicit contract bean 으로 표현한다.
+- 모듈 간 후속 반응이나 비동기 협력은 실제 consumer 가 있을 때만 domain event 로 표현한다.
+- 다른 모듈의 repository, application service, query service를 직접 찌르지 않는다.
+- 이벤트는 RPC 대체재처럼 쓰지 않는다. required consistency 는 direct contract 로 표현한다.
+- application service의 기본 흐름은 `load -> invoke aggregate -> save` 다.
+- application service는 same-module orchestration 을 위해 manual publisher 를 들고 다니지 않는다.
+- listener 나 projection 은 가능한 한 event payload 만으로 처리하고, read-side 갱신만을 위해 write model 을 다시 조회하는 구조는 피한다.
 
-상위 레이어가 하위 레이어를 침범하면 안 된다.
+## Java 와 Spring 규칙
 
-도메인 간 직접 의존은 허용하지 않는다.
-도메인 간 연결은 반드시 소비자 소유 port + `integration:X-Y` 어댑터로 표현한다.
+- package-private 을 기본으로 하고, `public` 은 모듈 루트 계약, 외부 API, 프레임워크가 요구하는 타입에만 사용한다.
+- 루트 애플리케이션은 `@SpringBootApplication`을 사용한다.
+- 컴포넌트 스캔 기반 등록을 기본으로 한다.
+- `@Configuration`은 실제 bean 조립이 필요한 경우에만 둔다.
+- 단순히 이미 스캔 가능한 타입을 다시 export 하기 위한 wrapper configuration 은 만들지 않는다.
+- 생성자 주입을 기본으로 한다.
+- 도메인 개념은 가능하면 `jMolecules` 타입과 인터페이스로 먼저 표현하고, annotation 은 역할을 보강할 때만 사용한다.
+- aggregate root 와 identifier 는 `org.jmolecules.ddd.types`를 우선 사용한다.
+- application / query service 구현은 `org.jmolecules.ddd.annotation.Service`로 역할을 드러낸다.
+- repository abstraction 은 `org.jmolecules.ddd.annotation.Repository`로 역할을 드러낸다.
 
-## 역할 원칙
+## 테스트와 검증
 
-### Model Module (`model`)
+- 테스트는 구현 과정을 기록하는 용도가 아니라 설계 규칙, 도메인 규칙, 외부 계약, 회귀 위험을 보호하는 실행 가능한 문서다.
+- 테스트는 구현 세부보다 공개 계약과 관찰 가능한 결과를 우선 검증한다.
+- domain 로직은 가능하면 Spring 없이 deterministic 한 unit test 로 검증할 수 있어야 한다.
+- 시간, 난수, 사용자에게 의미 있는 코드 생성, 외부 상태 같은 비결정 요소는 경계 밖으로 밀어내고 주입 가능하게 만든다.
+- 단순 기술적 UUID 생성까지 모두 래핑할 필요는 없다. 다만 규칙이 붙는 코드나 결과를 바꾸는 랜덤성은 명시적 generator 나 strategy 로 분리한다.
+- 기본 test double 은 fake 와 stub 이다. mock 과 spy 는 제한적으로 사용한다.
+- `@MockitoBean`은 `@WebMvcTest` 같은 Spring slice 나 모듈 경계 테스트에서 scope 제어가 필요할 때만 제한적으로 사용한다.
+- fixture 는 builder 를 기본으로 하고, 테스트의 의미를 바꾸는 값은 테스트 본문에서 직접 드러낸다.
+- fixture 가 반복되는 잡음을 줄이는 것은 좋지만, 핵심 전제를 숨기면 안 된다.
+- 테스트 편의를 위해 production code 를 왜곡하지 않는다.
+- 테스트 코드와 fixture 도 관리와 리팩토링의 대상이다. 구현 리팩토링에 과도하게 깨지는 테스트는 설계도 다시 본다.
+- 유지할 테스트는 모듈 규칙, 도메인 invariant, 외부 계약, 실제 regression risk 를 보호해야 한다.
+- thin delegation 이나 일회성 TDD scaffolding, 구현 choreography 만 보존하는 테스트는 정리 대상이다.
+- 버그를 수정했다면 그 문제가 다시 발생하지 않도록 자동 검증을 추가하는 것을 기본 원칙으로 한다.
+- regression test 는 내부 구현이 아니라 외부 계약, 도메인 규칙, 관찰 가능한 결과를 고정해야 한다.
+- repository 테스트의 기본값은 `@DataJpaTest` 와 H2 다. 락, 격리 수준, DB vendor 고유 동작, 실제 migration 결과처럼 H2 로 충분히 증명할 수 없는 것은 `integrationTest` 에서 실제 데이터베이스로 검증한다.
+- web contract 는 `@WebMvcTest` 로 검증한다.
+- 모듈 구조는 `ApplicationModules.verify()` 로 항상 검증 가능해야 한다.
+- 모듈 간 협력이 중요한 경우에만 `@ApplicationModuleTest`를 사용한다.
+- 구현 중에는 대상 테스트나 `./gradlew test` 를 우선 사용한다.
+- 로컬 작업을 마무리하기 전에는 `./gradlew check` 를 실행한다.
+- commit 직전이나 review 전에는 `./gradlew integrationTest` 를 실행한다.
+- `integrationTest` 는 unit test 만으로 충분히 증명할 수 없는 외부 경계와 실제 런타임 조합을 검증한다. 피드백 루프는 더 길지만 중요한 검증이므로 commit 전과 CI 에서는 반드시 포함한다.
 
-- 도메인의 핵심 개념과 규칙을 포함한다.
-- 외부 기술, 저장소, 네트워크에 대한 관심사를 가지지 않는다.
-- 가능한 한 순수하게 유지한다.
-- Identity + Props → Model 인터페이스 패턴
-- Props = 순수 프로퍼티만. 비즈니스 메서드는 확장 함수로 분리
-- data class는 순수 값 객체. 검증(init)은 허용
+## 에이전트가 피해야 할 것
 
-### Service Module (`service`)
-
-- 유스케이스와 비즈니스 흐름을 구현한다.
-- 외부 시스템 접근은 직접 하지 않고 `infrastructure`의 port를 통해서만 수행한다.
-- 다른 도메인의 내부 구현이나 타입에 직접 의존하지 않는다.
-- public interface + `internal` impl
-- 도메인 서비스가 개념 간 협업 조율. 서비스끼리 직접 호출 금지
-
-### Infrastructure Module (`infrastructure`)
-
-- persistence port와 external out-port의 계약만 정의한다.
-- 구현을 포함하지 않는다.
-- 소비자 도메인이 외부에 요구하는 최소 계약만 소유한다.
-
-### Repository Module (`repository-{type}`)
-
-- `infrastructure`에 정의된 persistence port를 구현한다.
-- JDBC, JPA, Document DB 등 기술 세부사항은 이 계층에 머문다.
-- Entity가 Model 인터페이스 직접 구현
-- `@Column` bare annotation. enum 직접 매핑 (커스텀 컨버터)
-- RepositoryImpl에서 `.toModel()`로 도메인 data class 반환. Entity 직접 반환 금지
-- `@EnableJdbcRepositories`
-
-### API Module (`api`)
-
-- 외부 입력을 받는 driving adapter다.
-- REST controller와 request/response DTO를 포함한다.
-- 비즈니스 판단은 `service`에 위임한다.
-- `@Import`로 컨트롤러 등록
-- DTO는 `dto` 패키지, 파일별 분리
-
-### Integration Module (`integration:X-Y`)
-
-- 소비자 `X`의 out-port를 제공자 `Y`의 공개된 use case에 연결하는 adapter를 구현한다.
-- 도메인 간 번역, 매핑, 예외 변환, 재시도, 캐시, 통신 기술 세부사항은 이 모듈에 위치한다.
-- 현재 구현은 in-process 동기 호출일 수 있고, 이후 HTTP/gRPC/MQ/event/projection 기반으로 바뀔 수 있다.
-- 통신 방식이 바뀌어도 소비자 도메인의 `service`와 `infrastructure` 계약은 유지되어야 한다.
-
-### Application Module (`application-{type}`)
-
-- 실행 환경 설정과 모듈 조립만 담당한다.
-- 비즈니스 로직과 도메인 간 adapter 구현을 포함하지 않는다.
-- 필요한 `integration` 모듈을 가져와 wiring만 수행한다.
-
-## 도메인 간 통신
-
-도메인 간 통신은 Consumer-Owned Port 패턴을 따른다.
-
-- 소비자 도메인이 자신의 `infrastructure` 모듈에 out-port 인터페이스와 계약 타입을 소유한다.
-- 제공자 도메인은 소비자 도메인의 존재를 몰라야 한다.
-- 제공자 도메인 접근은 제공자 도메인의 공개된 `service` interface를 통해서만 이뤄진다.
-- 도메인 간 adapter 구현은 항상 `integration:X-Y` 모듈에 위치한다.
-- `application-*`는 integration 모듈을 조립만 하며, 통신 정책과 번역 로직을 직접 가지지 않는다.
-- 소비자 도메인은 제공자 도메인의 entity, repository, controller, 내부 패키지를 직접 참조하면 안 된다.
-
-## 이벤트와 통신 방식
-
-이벤트, MQ, RPC, HTTP, in-process 호출은 모두 통신 구현 방식이다.
-이들은 아키텍처 경계 자체가 아니라 `integration` 내부의 구현 선택이다.
-
-- 즉시 응답과 강한 일관성이 필요하면 동기 호출을 사용한다.
-- 느슨한 결합, fan-out, projection, eventual consistency가 필요하면 이벤트/MQ를 사용한다.
-- 어떤 방식을 선택하더라도 도메인 경계는 port와 integration 모듈로 유지해야 한다.
-
-## 빈 등록 규칙
-
-- `@SpringBootApplication` 사용 금지
-- 런처는 `@SpringBootConfiguration` + `@EnableAutoConfiguration`
-- 모든 빈은 `@AutoConfiguration` + `@Bean`으로 명시적 등록
-- `.imports` 파일에 반드시 등록
-- `@ComponentScan`, `@Component`, `@Service`, `@Repository` 사용 금지
-
-## 테스트
-
-- AssertJ, 한글 테스트명
-- 테스트 대상은 `cut` (Class Under Test) 명명
-- repository 통합 테스트: `@DataJdbcTest` + `@ImportAutoConfiguration` + `@TestConstructor`
-- application 통합 테스트: `@SpringBootTest` + `@AutoConfigureTestRestTemplate` + `@TestConstructor`
+- 현재 모듈 목록이나 임시 구조를 최상위 규칙으로 문서화하는 것
+- 다른 모듈의 내부 패키지나 구현 타입에 직접 결합하는 것
+- mock 을 기본값처럼 남발하는 것
+- 구현 리팩토링을 막는 brittle test 를 늘리는 것
+- 테스트 편의를 위해 production code 에 test-only hook 을 추가하는 것
+- 이미 lower-cost test 가 보호하는 규칙을 다른 레이어에서 반복 검증하는 것

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,3 @@ tasks.register('integrationTest', Test) {
 tasks.named('processIntegrationTestResources') {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
-
-tasks.named('check') {
-    dependsOn(tasks.named('integrationTest'))
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,2 @@
 group=com.naminhyeok.fantazzk
 version=1.0.0-SNAPSHOT
-
-kotlin.code.style=official


### PR DESCRIPTION
## 변경 내용
- `AGENTS.md`와 `CLAUDE.md`를 현재 Java/Spring Modulith 구조에 맞는 짧은 운영 문서로 정리했습니다.
- `check`에서 `integrationTest` 의존을 제거하고, 빠른 검증 루프와 무거운 경계 검증을 분리했습니다.
- `.claude/skills` 아래에 testing, domain modeling, modulith boundary 관련 팀 공유 skill을 추가하고, `.codex/skills`에는 같은 규칙을 따르기 위한 bridge skill을 추가했습니다.

## 변경 이유
- 기존 문서에는 Kotlin 시절 규칙과 현재 코드베이스가 섞여 있어 에이전트가 잘못된 기준을 읽을 여지가 있었습니다.
- 테스트, 도메인 모델링, 모듈 경계에 대한 깊은 판단 기준을 최상위 문서가 아닌 팀 공유 skill로 분리해 유지보수성을 높이려 했습니다.
- `integrationTest`를 기본 반복 루프에서 분리해 빠른 피드백과 무거운 경계 검증의 목적을 명확히 나누려 했습니다.

## 검증
- `./gradlew test`
- `./gradlew check --console=plain`
- `./gradlew integrationTest --console=plain`
- `.claude/skills/*/SKILL.md` frontmatter YAML 파싱 확인
