### PR TITLE
드래프트 진행 규칙과 room 공개 snapshot을 반영한다

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.naminhyeok.fantazzk.template.TemplateCatalog.DraftOrderStrategy;
 import com.naminhyeok.fantazzk.template.TemplateFixture;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ class RoomDraftIntegrationTest {
     private final SelectDraftPosition selectDraftPosition;
     private final PickDraft pickDraft;
     private final Rooms rooms;
+    private final EntityManager entityManager;
 
     @Test
     @Transactional
@@ -63,5 +66,50 @@ class RoomDraftIntegrationTest {
         assertThat(reloaded.getPlayers().stream().filter(it -> it.getName().equals("선수1")).findFirst().orElseThrow().getStatus())
             .isEqualTo(PlayerStatus.ASSIGNED);
         assertThat(reloaded.getCurrentTurnIndex()).isEqualTo(1);
+    }
+
+    @Test
+    @Transactional
+    void SNAKE_드래프트는_재조회_후에도_2라운드가_역순으로_진행된다() {
+        var template =
+            templateFixture.createDraftTemplateId(
+                "드래프트전",
+                2,
+                3,
+                DraftOrderStrategy.SNAKE,
+                List.of("선수1", "선수2", "선수3", "선수4")
+            );
+
+        Room created = createRoom.create(template, "호스트");
+        RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
+        RoomTeamLeader host = created.getLeaders().getFirst();
+        selectDraftPosition.select(created.getCode(), host.getActionToken(), 1);
+        selectDraftPosition.select(created.getCode(), guest.getActionToken(), 2);
+        startRoom.start(created.getCode(), host.getActionToken());
+
+        pickDraft.pick(created.getCode(), host.getTeamLeaderId(), "선수1");
+        pickDraft.pick(created.getCode(), guest.getTeamLeaderId(), "선수2");
+
+        entityManager.flush();
+        entityManager.clear();
+        Room reloadedAfterSecondPick = rooms.findByCode(created.getCode()).orElseThrow();
+
+        assertThat(reloadedAfterSecondPick.getCurrentTurnIndex()).isEqualTo(2);
+
+        RoomTeamMember thirdPick = pickDraft.pick(created.getCode(), guest.getTeamLeaderId(), "선수3");
+
+        entityManager.flush();
+        entityManager.clear();
+        Room reloadedAfterThirdPick = rooms.findByCode(created.getCode()).orElseThrow();
+
+        assertThat(thirdPick.getTeamLeaderId()).isEqualTo(guest.getTeamLeaderId());
+        assertThat(reloadedAfterThirdPick.getMembers())
+            .extracting(RoomTeamMember::getTeamLeaderId, RoomTeamMember::getPlayerName)
+            .containsExactly(
+                tuple(host.getTeamLeaderId(), "선수1"),
+                tuple(guest.getTeamLeaderId(), "선수2"),
+                tuple(guest.getTeamLeaderId(), "선수3")
+            );
+        assertThat(reloadedAfterThirdPick.getCurrentTurnIndex()).isEqualTo(3);
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftProgress.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftProgress.java
@@ -1,0 +1,49 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+record DraftProgress(
+    int currentTurnIndex,
+    int currentRound,
+    String currentLeaderId,
+    List<String> currentRoundLeaderIds
+) {
+    static DraftProgress from(
+        List<String> roundOneLeaderIds,
+        RoomTemplateSpec.DraftOrderStrategy strategy,
+        int currentTurnIndex
+    ) {
+        List<String> baseOrder = List.copyOf(roundOneLeaderIds);
+        if (baseOrder.isEmpty()) {
+            throw new IllegalArgumentException("드래프트 순서가 비어 있습니다");
+        }
+
+        int roundSize = baseOrder.size();
+        int currentRound = currentTurnIndex / roundSize + 1;
+        int turnOffsetInRound = currentTurnIndex % roundSize;
+        List<String> currentRoundLeaderIds = currentRoundLeaderIds(baseOrder, strategy, currentRound);
+
+        return new DraftProgress(
+            currentTurnIndex,
+            currentRound,
+            currentRoundLeaderIds.get(turnOffsetInRound),
+            currentRoundLeaderIds
+        );
+    }
+
+    private static List<String> currentRoundLeaderIds(
+        List<String> baseOrder,
+        RoomTemplateSpec.DraftOrderStrategy strategy,
+        int currentRound
+    ) {
+        if (strategy == RoomTemplateSpec.DraftOrderStrategy.FIXED || currentRound % 2 == 1) {
+            return baseOrder;
+        }
+
+        List<String> reversed = new ArrayList<>(baseOrder);
+        Collections.reverse(reversed);
+        return List.copyOf(reversed);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -261,13 +261,8 @@ class Room implements AggregateRoot<Room, RoomId> {
         if (mode != RoomMode.DRAFT) {
             throw CoreException.of(RoomErrorType.ROOM_PICK_REQUIRES_DRAFT_MODE);
         }
-        if (currentTurnIndex == null) {
-            throw new IllegalStateException("현재 드래프트 턴이 없습니다");
-        }
-
-        List<RoomTeamLeader> orderedLeaders = getLeadersInDraftOrder();
-        String currentLeaderId = orderedLeaders.get(currentTurnIndex % orderedLeaders.size()).getTeamLeaderId();
-        if (!currentLeaderId.equals(teamLeaderId)) {
+        DraftProgress progress = requireCurrentDraftProgress();
+        if (!progress.currentLeaderId().equals(teamLeaderId)) {
             throw CoreException.of(RoomErrorType.ROOM_PICK_OUT_OF_TURN);
         }
 
@@ -288,6 +283,14 @@ class Room implements AggregateRoot<Room, RoomId> {
         }
 
         return member;
+    }
+
+    DraftProgress currentDraftProgress() {
+        if (mode != RoomMode.DRAFT || status != RoomStatus.IN_PROGRESS || currentTurnIndex == null) {
+            return null;
+        }
+
+        return DraftProgress.from(getLeaderIdsInDraftOrder(), draftOrderStrategy, currentTurnIndex);
     }
 
     private void validateDraftPositionChange(int draftPosition) {
@@ -315,6 +318,18 @@ class Room implements AggregateRoot<Room, RoomId> {
         return leaders.stream()
             .sorted(Comparator.comparingInt(RoomTeamLeader::getDraftPosition))
             .toList();
+    }
+
+    private DraftProgress requireCurrentDraftProgress() {
+        DraftProgress progress = currentDraftProgress();
+        if (progress == null) {
+            throw new IllegalStateException("현재 드래프트 턴이 없습니다");
+        }
+        return progress;
+    }
+
+    private List<String> getLeaderIdsInDraftOrder() {
+        return getLeadersInDraftOrder().stream().map(RoomTeamLeader::getTeamLeaderId).toList();
     }
 
     private RoomTeamLeader getLeader(String teamLeaderId) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomMemberResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomMemberResponse.java
@@ -1,0 +1,15 @@
+package com.naminhyeok.fantazzk.room;
+
+record RoomMemberResponse(
+    String teamLeaderId,
+    String playerName,
+    int assignOrder
+) {
+    static RoomMemberResponse from(RoomTeamMember member) {
+        return new RoomMemberResponse(
+            member.getTeamLeaderId(),
+            member.getPlayerName(),
+            member.getAssignOrder()
+        );
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
@@ -1,0 +1,15 @@
+package com.naminhyeok.fantazzk.room;
+
+record RoomPlayerResponse(
+    String name,
+    int displayOrder,
+    String status
+) {
+    static RoomPlayerResponse from(RoomPlayer player) {
+        return new RoomPlayerResponse(
+            player.getName(),
+            player.getDisplayOrder(),
+            player.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomProgressResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomProgressResponse.java
@@ -1,0 +1,28 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+
+record RoomProgressResponse(
+    Integer currentTurnIndex,
+    Integer currentRound,
+    String currentLeaderId,
+    List<String> currentRoundLeaderIds
+) {
+    static RoomProgressResponse from(Room room) {
+        if (room.getStatus() != RoomStatus.IN_PROGRESS) {
+            return new RoomProgressResponse(null, null, null, null);
+        }
+
+        if (room.getMode() == RoomMode.AUCTION) {
+            return new RoomProgressResponse(null, room.getCurrentAuctionRound(), null, null);
+        }
+
+        DraftProgress progress = room.currentDraftProgress();
+        return new RoomProgressResponse(
+            room.getCurrentTurnIndex(),
+            progress.currentRound(),
+            progress.currentLeaderId(),
+            progress.currentRoundLeaderIds()
+        );
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
@@ -6,8 +6,14 @@ record RoomResponse(
     String status,
     String mode,
     int teamCount,
+    int teamSize,
+    Integer budget,
+    String draftOrderStrategy,
     String startReadiness,
-    List<TeamLeaderResponse> teamLeaders
+    List<TeamLeaderResponse> teamLeaders,
+    List<RoomPlayerResponse> players,
+    List<RoomMemberResponse> members,
+    RoomProgressResponse progress
 ) {
     static RoomResponse from(Room room) {
         return new RoomResponse(
@@ -15,8 +21,14 @@ record RoomResponse(
             room.getStatus().name(),
             room.getMode().name(),
             room.getTeamCount(),
+            room.getTeamSize(),
+            room.getBudget(),
+            room.getDraftOrderStrategy() == null ? null : room.getDraftOrderStrategy().name(),
             room.getStartReadiness().name(),
-            room.getLeaders().stream().map(TeamLeaderResponse::from).toList()
+            room.getLeaders().stream().map(TeamLeaderResponse::from).toList(),
+            room.getPlayers().stream().map(RoomPlayerResponse::from).toList(),
+            room.getMembers().stream().map(RoomMemberResponse::from).toList(),
+            RoomProgressResponse.from(room)
         );
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/DraftProgressTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/DraftProgressTest.java
@@ -1,0 +1,37 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DraftProgressTest {
+    @Test
+    void fixed전략은_라운드가_바뀌어도_같은_순서를_유지한다() {
+        DraftProgress progress =
+            DraftProgress.from(List.of("host-1", "guest-1"), RoomTemplateSpec.DraftOrderStrategy.FIXED, 2);
+
+        assertThat(progress.currentTurnIndex()).isEqualTo(2);
+        assertThat(progress.currentRound()).isEqualTo(2);
+        assertThat(progress.currentLeaderId()).isEqualTo("host-1");
+        assertThat(progress.currentRoundLeaderIds()).containsExactly("host-1", "guest-1");
+    }
+
+    @Test
+    void snake전략은_짝수_라운드에서_역순을_사용한다() {
+        DraftProgress progress =
+            DraftProgress.from(List.of("host-1", "guest-1"), RoomTemplateSpec.DraftOrderStrategy.SNAKE, 2);
+
+        assertThat(progress.currentTurnIndex()).isEqualTo(2);
+        assertThat(progress.currentRound()).isEqualTo(2);
+        assertThat(progress.currentLeaderId()).isEqualTo("guest-1");
+        assertThat(progress.currentRoundLeaderIds()).containsExactly("guest-1", "host-1");
+    }
+
+    @Test
+    void 빈_리더_목록은_거부한다() {
+        assertThatThrownBy(() -> DraftProgress.from(List.of(), RoomTemplateSpec.DraftOrderStrategy.FIXED, 0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(RoomApiController.class)
@@ -124,18 +125,94 @@ class RoomApiWebMvcTest {
         var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
 
         result.assertThat().hasStatusOk();
-        assertThat(readBody(result, RoomResponseApiResponse.class))
-            .satisfies(response -> {
-                assertThat(response.resultType()).isEqualTo("SUCCESS");
-                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
-                assertThat(response.success().status()).isEqualTo("WAITING");
-                assertThat(response.success().mode()).isEqualTo("DRAFT");
-                assertThat(response.success().teamCount()).isEqualTo(2);
-                assertThat(response.success().startReadiness()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
-                assertThat(response.success().teamLeaders()).extracting(TeamLeaderResponse::draftPosition)
-                    .containsExactly(1, null);
-            });
+        JsonNode body = readTree(result);
+        assertThat(body.at("/resultType").asText()).isEqualTo("SUCCESS");
+        assertThat(body.at("/success/code").asText()).isEqualTo(ROOM_CODE);
+        assertThat(body.at("/success/status").asText()).isEqualTo("WAITING");
+        assertThat(body.at("/success/mode").asText()).isEqualTo("DRAFT");
+        assertThat(body.at("/success/teamCount").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/teamSize").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/budget").isNull()).isTrue();
+        assertThat(body.at("/success/draftOrderStrategy").asText()).isEqualTo("SNAKE");
+        assertThat(body.at("/success/startReadiness").asText()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
+        assertThat(body.at("/success/teamLeaders/0/draftPosition").asInt()).isEqualTo(1);
+        assertThat(body.at("/success/teamLeaders/1/draftPosition").isNull()).isTrue();
+        assertThat(body.at("/success/players/0/name").asText()).isEqualTo("선수1");
+        assertThat(body.at("/success/players/0/displayOrder").asInt()).isEqualTo(0);
+        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("AVAILABLE");
+        assertThat(body.at("/success/players/1/name").asText()).isEqualTo("선수2");
+        assertThat(body.at("/success/members").isArray()).isTrue();
+        assertThat(body.at("/success/members")).hasSize(0);
+        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRound").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
         assertThat(result.getResponse().getContentAsString()).doesNotContain("teamLeaderSession");
+    }
+
+    @Test
+    void get은_드래프트_진행중_스냅샷을_반환한다() throws Exception {
+        given(getRoom.get(ROOM_CODE)).willReturn(inProgressDraftRoom());
+
+        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
+
+        result.assertThat().hasStatusOk();
+        JsonNode body = readTree(result);
+        assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
+        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
+        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("ASSIGNED");
+        assertThat(body.at("/success/players/2/status").asText()).isEqualTo("AVAILABLE");
+        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
+        assertThat(body.at("/success/members/0/playerName").asText()).isEqualTo("선수1");
+        assertThat(body.at("/success/members/0/assignOrder").asInt()).isEqualTo(0);
+        assertThat(body.at("/success/members/1/teamLeaderId").asText()).isEqualTo(GUEST_ID);
+        assertThat(body.at("/success/members/1/playerName").asText()).isEqualTo("선수2");
+        assertThat(body.at("/success/members/1/assignOrder").asInt()).isEqualTo(1);
+        assertThat(body.at("/success/progress/currentTurnIndex").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/progress/currentRound").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/progress/currentLeaderId").asText()).isEqualTo(GUEST_ID);
+        assertThat(body.at("/success/progress/currentRoundLeaderIds/0").asText()).isEqualTo(GUEST_ID);
+        assertThat(body.at("/success/progress/currentRoundLeaderIds/1").asText()).isEqualTo(HOST_ID);
+    }
+
+    @Test
+    void get은_완료된_방도_players_members_progress_null로_결과를_렌더링할_수_있다() throws Exception {
+        given(getRoom.get(ROOM_CODE)).willReturn(completedDraftRoom());
+
+        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
+
+        result.assertThat().hasStatusOk();
+        JsonNode body = readTree(result);
+        assertThat(body.at("/success/status").asText()).isEqualTo("COMPLETED");
+        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
+        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("ASSIGNED");
+        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
+        assertThat(body.at("/success/members/1/teamLeaderId").asText()).isEqualTo(GUEST_ID);
+        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRound").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
+    }
+
+    @Test
+    void get은_경매_진행중_스냅샷에서_currentRound를_currentAuctionRound로_반환한다() throws Exception {
+        given(getRoom.get(ROOM_CODE)).willReturn(inProgressAuctionRoom());
+
+        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
+
+        result.assertThat().hasStatusOk();
+        JsonNode body = readTree(result);
+        assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
+        assertThat(body.at("/success/budget").asInt()).isEqualTo(300);
+        assertThat(body.at("/success/draftOrderStrategy").isNull()).isTrue();
+        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
+        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("AVAILABLE");
+        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
+        assertThat(body.at("/success/members/0/playerName").asText()).isEqualTo("선수1");
+        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRound").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
+        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
     }
 
     @Test
@@ -301,6 +378,10 @@ class RoomApiWebMvcTest {
         return objectMapper.readValue(result.getResponse().getContentAsString(), bodyType);
     }
 
+    private JsonNode readTree(MvcTestResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
     private Room waitingAuctionRoom() {
         return Room.createFromTemplate(
             ROOM_CODE,
@@ -354,6 +435,73 @@ class RoomApiWebMvcTest {
     private Room startedAuctionRoom() {
         Room room = joinedAuctionRoom();
         room.start(HOST_ID);
+        return room;
+    }
+
+    private Room inProgressAuctionRoom() {
+        Room room =
+            Room.createFromTemplate(
+                ROOM_CODE,
+                HOST_ID,
+                "호스트",
+                HOST_TOKEN,
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.AUCTION,
+                    2,
+                    3,
+                    300,
+                    null,
+                    List.of(
+                        new RoomTemplateSpec.Player("선수1", 0),
+                        new RoomTemplateSpec.Player("선수2", 1),
+                        new RoomTemplateSpec.Player("선수3", 2),
+                        new RoomTemplateSpec.Player("선수4", 3)
+                    )
+                )
+            );
+        room.join(GUEST_ID, "게스트", GUEST_TOKEN);
+        room.start(HOST_ID);
+        room.placeBid(HOST_ID, 100);
+        room.settleAuction();
+        return room;
+    }
+
+    private Room inProgressDraftRoom() {
+        Room room =
+            Room.createFromTemplate(
+                ROOM_CODE,
+                HOST_ID,
+                "호스트",
+                HOST_TOKEN,
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.DRAFT,
+                    2,
+                    3,
+                    null,
+                    RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                    List.of(
+                        new RoomTemplateSpec.Player("선수1", 0),
+                        new RoomTemplateSpec.Player("선수2", 1),
+                        new RoomTemplateSpec.Player("선수3", 2),
+                        new RoomTemplateSpec.Player("선수4", 3)
+                    )
+                )
+            );
+        room.join(GUEST_ID, "게스트", GUEST_TOKEN);
+        room.selectDraftPosition(HOST_ID, 1);
+        room.selectDraftPosition(GUEST_ID, 2);
+        room.start(HOST_ID);
+        room.pick(HOST_ID, "선수1");
+        room.pick(GUEST_ID, "선수2");
+        return room;
+    }
+
+    private Room completedDraftRoom() {
+        Room room = waitingDraftRoom();
+        room.selectDraftPosition(GUEST_ID, 2);
+        room.start(HOST_ID);
+        room.pick(HOST_ID, "선수1");
+        room.pick(GUEST_ID, "선수2");
         return room;
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.naminhyeok.fantazzk.CoreException;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class RoomDraftTest {
@@ -101,6 +102,39 @@ class RoomDraftTest {
         assertThat(room.getMembers()).hasSize(2);
     }
 
+    void SNAKE_드래프트는_2라운드에서_역순으로_진행된다() {
+        Room room = startedDraftRoom(RoomTemplateSpec.DraftOrderStrategy.SNAKE, 3, List.of("선수1", "선수2", "선수3", "선수4"));
+
+        room.pick(HOST_ID, "선수1");
+        room.pick(GUEST_ID, "선수2");
+
+        assertThatThrownBy(() -> room.pick(HOST_ID, "선수3"))
+            .isInstanceOf(CoreException.class)
+            .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_OUT_OF_TURN));
+
+        RoomTeamMember thirdPick = room.pick(GUEST_ID, "선수3");
+
+        assertThat(thirdPick.getTeamLeaderId()).isEqualTo(GUEST_ID);
+        assertThat(room.getCurrentTurnIndex()).isEqualTo(3);
+    }
+
+    @Test
+    void FIXED_드래프트는_2라운드에서도_같은_순서로_진행된다() {
+        Room room = startedDraftRoom(RoomTemplateSpec.DraftOrderStrategy.FIXED, 3, List.of("선수1", "선수2", "선수3", "선수4"));
+
+        room.pick(HOST_ID, "선수1");
+        room.pick(GUEST_ID, "선수2");
+
+        assertThatThrownBy(() -> room.pick(GUEST_ID, "선수3"))
+            .isInstanceOf(CoreException.class)
+            .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_OUT_OF_TURN));
+
+        RoomTeamMember thirdPick = room.pick(HOST_ID, "선수3");
+
+        assertThat(thirdPick.getTeamLeaderId()).isEqualTo(HOST_ID);
+        assertThat(room.getCurrentTurnIndex()).isEqualTo(3);
+    }
+
     private static void assertRoomError(CoreException ex, RoomErrorType expected) {
         assertThat(ex.getError()).isEqualTo(expected);
     }
@@ -121,7 +155,32 @@ class RoomDraftTest {
         return room;
     }
 
+    private static Room startedDraftRoom(
+        RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy,
+        int teamSize,
+        List<String> playerNames
+    ) {
+        Room room = waitingDraftRoom(draftOrderStrategy, teamSize, playerNames);
+        room.join(GUEST_ID, "게스트", GUEST_ACTION_TOKEN);
+        room.selectDraftPosition(HOST_ID, 1);
+        room.selectDraftPosition(GUEST_ID, 2);
+        room.start(HOST_ID);
+        return room;
+    }
+
     private static Room waitingDraftRoom() {
+        return waitingDraftRoom(
+            RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+            2,
+            List.of("선수1", "선수2")
+        );
+    }
+
+    private static Room waitingDraftRoom(
+        RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy,
+        int teamSize,
+        List<String> playerNames
+    ) {
         Room room =
             Room.createFromTemplate(
                 "DRF001",
@@ -131,13 +190,12 @@ class RoomDraftTest {
                 new RoomTemplateSpec(
                     RoomTemplateSpec.Mode.DRAFT,
                     2,
-                    2,
+                    teamSize,
                     null,
-                    RoomTemplateSpec.DraftOrderStrategy.SNAKE,
-                    List.of(
-                        new RoomTemplateSpec.Player("선수1", 0),
-                        new RoomTemplateSpec.Player("선수2", 1)
-                    )
+                    draftOrderStrategy,
+                    IntStream.range(0, playerNames.size())
+                        .mapToObj(index -> new RoomTemplateSpec.Player(playerNames.get(index), index))
+                        .toList()
                 )
             );
         return room;


### PR DESCRIPTION
## 요약
- `DraftProgress`를 도입하고 `Room.pick()`이 `SNAKE` / `FIXED` 전략을 실제 픽 순서에 반영하도록 정리했습니다.
- `GET /api/v1/rooms/{code}` 공개 snapshot에 `players`, `members`, `progress`와 필요한 메타데이터를 추가했습니다.
- 드래프트 진행 규칙과 room snapshot 계약을 단위 테스트, WebMvc 테스트, 통합 테스트로 보강했습니다.

## 범위
- `#43`의 드래프트 순서 전략 반영을 포함합니다.
- `#45` 전체가 아니라, 공개 room snapshot 확장 범위만 선반영합니다.
- `create` / `join`의 `room + teamLeaderSession` 구조는 유지합니다.

## 테스트
- [x] `./gradlew test --tests com.naminhyeok.fantazzk.room.DraftProgressTest --tests com.naminhyeok.fantazzk.room.RoomDraftTest --tests com.naminhyeok.fantazzk.room.RoomApiWebMvcTest`
- [x] `./gradlew integrationTest --tests com.naminhyeok.fantazzk.room.RoomDraftIntegrationTest`
- [x] `./gradlew check`
- [x] `./gradlew integrationTest`