### PR TITLE
OpenAPI 동기화 워크플로의 export 프로필 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         if: steps.sync-config.outputs.enabled == 'true'
         run: |
           source "$HOME/.sdkman/bin/sdkman-init.sh"
-          ./gradlew bootRun --args='--spring.profiles.active=test --server.port=8080' > app.log 2>&1 &
+          SPRING_PROFILES_ACTIVE=openapi PORT=8080 ./gradlew openapiBootRun --no-daemon > app.log 2>&1 &
           app_pid=$!
           trap 'kill "${app_pid}" || true' EXIT
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,14 @@ tasks.register('integrationTest', Test) {
     useJUnitPlatform()
 }
 
+tasks.register('openapiBootRun', JavaExec) {
+    description = 'Runs the application with the test runtime classpath for OpenAPI export.'
+    group = 'documentation'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.naminhyeok.fantazzk.FantazzkApplication'
+    dependsOn(tasks.testClasses)
+}
+
 tasks.named('processIntegrationTestResources') {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,23 @@ sentry:
 spring:
   config:
     activate:
+      on-profile: openapi
+  datasource:
+    url: jdbc:h2:mem:openapi;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  liquibase:
+    enabled: false
+
+sentry:
+  enabled: false
+
+---
+
+spring:
+  config:
+    activate:
       on-profile: dev
   datasource:
     url: ${DATABASE_URL}

--- a/src/test/java/com/naminhyeok/fantazzk/FantazzkApplicationBootTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/FantazzkApplicationBootTest.java
@@ -10,12 +10,8 @@ import org.springframework.test.context.TestConstructor;
 
 @SpringBootTest(
     properties = {
-        "spring.datasource.url=jdbc:h2:mem:boot-test;DB_CLOSE_DELAY=-1",
-        "spring.datasource.driver-class-name=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.datasource.password=",
-        "spring.liquibase.enabled=false",
-        "sentry.enabled=false"
+        "spring.profiles.active=openapi",
+        "server.port=0"
     }
 )
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -24,7 +20,7 @@ class FantazzkApplicationBootTest {
     private final Clock clock;
 
     @Test
-    void 루트_애플리케이션이_최소_설정으로_부팅된다() {
+    void openapi_프로필로_애플리케이션이_부팅된다() {
         assertThat(clock).isNotNull();
     }
 }


### PR DESCRIPTION
## 변경 내용
- OpenAPI export 전용 `openapi` 프로필을 추가해 H2 기반으로 애플리케이션을 기동하도록 수정했습니다.
- 테스트 런타임 클래스패스로 앱을 띄우는 `openapiBootRun` Gradle task를 추가했습니다.
- CI의 OpenAPI 동기화 job이 `test` 프로필 대신 전용 export 경로를 사용하도록 바꿨습니다.
- `openapi` 프로필이 실제로 부팅되는지 확인하는 부팅 테스트로 회귀를 고정했습니다.

## 원인
기존 워크플로는 `bootRun --spring.profiles.active=test`로 앱을 띄웠습니다. 하지만 `test` 프로필은 `jdbc:tc:`를 사용하고, `bootRun`의 런타임 클래스패스에는 `org.testcontainers.jdbc.ContainerDatabaseDriver`가 없어 메인 머지 후 CI에서 앱 기동이 실패했습니다.

## 검증
- `./gradlew test --tests com.naminhyeok.fantazzk.FantazzkApplicationBootTest --no-daemon`
- `SPRING_PROFILES_ACTIVE=openapi PORT=18080 ./gradlew openapiBootRun --no-daemon` 후 `curl http://127.0.0.1:18080/v3/api-docs.yaml`
- `/Users/naminhyeok/.codex/tmp/bin/actionlint .github/workflows/ci.yml`
- `./gradlew check --parallel --no-daemon`
- `./gradlew integrationTest --no-daemon`