### PR TITLE
[codex] 참여 가능한 대기 룸 목록 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,7 @@ tasks.register('integrationTest', Test) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
-    environment 'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE', '/var/run/docker.sock'
-    environment 'TESTCONTAINERS_HOST_OVERRIDE', 'localhost'
+    environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
     shouldRunAfter(tasks.test)
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,8 @@ dependencies {
     integrationTestImplementation 'org.springframework.boot:spring-boot-restclient'
     integrationTestImplementation 'org.springframework.boot:spring-boot-resttestclient'
     integrationTestImplementation 'org.springframework.boot:spring-boot-jdbc-test'
+    integrationTestRuntimeOnly 'org.testcontainers:jdbc:1.21.4'
+    integrationTestRuntimeOnly 'org.testcontainers:postgresql:1.21.4'
     integrationTestRuntimeOnly 'com.h2database:h2'
     integrationTestRuntimeOnly 'org.postgresql:postgresql'
     integrationTestCompileOnly 'org.projectlombok:lombok'
@@ -100,6 +102,8 @@ tasks.register('integrationTest', Test) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+    environment 'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE', '/var/run/docker.sock'
+    environment 'TESTCONTAINERS_HOST_OVERRIDE', 'localhost'
     shouldRunAfter(tasks.test)
     useJUnitPlatform()
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
@@ -1,0 +1,90 @@
+package com.naminhyeok.fantazzk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    properties = {
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "sentry.enabled=false"
+    }
+)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class LiquibasePostgresSmokeTest {
+    private final JdbcTemplate jdbcTemplate;
+
+    LiquibasePostgresSmokeTest(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Test
+    void liquibase_실제_postgresql_스키마에서_rooms_변경을_검증한다() {
+        assertThat(countTable("rooms")).isEqualTo(1);
+        assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
+        assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
+        assertThat(indexColumns("rooms", "idx_rooms_status_created_at")).containsExactly("status", "created_at");
+    }
+
+    private Integer countTable(String tableName) {
+        return jdbcTemplate.queryForObject(
+            "select count(*) from information_schema.tables where table_schema = current_schema() and table_name = ?",
+            Integer.class,
+            tableName
+        );
+    }
+
+    private Integer countColumn(String tableName, String columnName) {
+        return jdbcTemplate.queryForObject(
+            "select count(*) from information_schema.columns where table_schema = current_schema() and table_name = ? and column_name = ?",
+            Integer.class,
+            tableName,
+            columnName
+        );
+    }
+
+    private Integer countIndex(String tableName, String indexName) {
+        return jdbcTemplate.queryForObject(
+            "select count(*) from pg_indexes where schemaname = current_schema() and tablename = ? and indexname = ?",
+            Integer.class,
+            tableName,
+            indexName
+        );
+    }
+
+    private List<String> indexColumns(String tableName, String indexName) {
+        return jdbcTemplate.execute((Connection connection) -> {
+            var columnsByOrdinal = new TreeMap<Integer, String>();
+            try (ResultSet resultSet = connection.getMetaData().getIndexInfo(null, currentSchema(connection), tableName, false, false)) {
+                while (resultSet.next()) {
+                    var currentIndexName = resultSet.getString("INDEX_NAME");
+                    var columnName = resultSet.getString("COLUMN_NAME");
+                    if (indexName.equalsIgnoreCase(currentIndexName) && columnName != null) {
+                        columnsByOrdinal.put(resultSet.getInt("ORDINAL_POSITION"), columnName);
+                    }
+                }
+            }
+            return new ArrayList<>(columnsByOrdinal.values());
+        });
+    }
+
+    private String currentSchema(Connection connection) {
+        try (ResultSet resultSet = connection.createStatement().executeQuery("select current_schema()")) {
+            resultSet.next();
+            return resultSet.getString(1);
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -30,6 +30,8 @@ class LiquibaseSmokeTest {
         assertThat(countTable("template")).isEqualTo(1);
         assertThat(countTable("template_player")).isEqualTo(1);
         assertThat(countTable("rooms")).isEqualTo(1);
+        assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
+        assertThat(countIndex("idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(countTable("room_player")).isEqualTo(1);
         assertThat(countTable("room_team_leader")).isEqualTo(1);
         assertThat(countColumn("room_team_leader", "action_token")).isEqualTo(1);
@@ -53,6 +55,14 @@ class LiquibaseSmokeTest {
             Integer.class,
             tableName,
             columnName
+        );
+    }
+
+    private Integer countIndex(String indexName) {
+        return jdbcTemplate.queryForObject(
+            "select count(*) from information_schema.indexes where index_name = upper(?)",
+            Integer.class,
+            indexName
         );
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -2,6 +2,12 @@ package com.naminhyeok.fantazzk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -32,6 +38,7 @@ class LiquibaseSmokeTest {
         assertThat(countTable("rooms")).isEqualTo(1);
         assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
         assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
+        assertThat(indexColumns("rooms", "idx_rooms_status_created_at")).containsExactly("STATUS", "CREATED_AT");
         assertThat(countTable("room_player")).isEqualTo(1);
         assertThat(countTable("room_team_leader")).isEqualTo(1);
         assertThat(countColumn("room_team_leader", "action_token")).isEqualTo(1);
@@ -65,5 +72,21 @@ class LiquibaseSmokeTest {
             tableName,
             indexName
         );
+    }
+
+    private List<String> indexColumns(String tableName, String indexName) {
+        return jdbcTemplate.execute((Connection connection) -> {
+            var columnsByOrdinal = new TreeMap<Integer, String>();
+            try (ResultSet resultSet = connection.getMetaData().getIndexInfo(null, null, tableName.toUpperCase(Locale.ROOT), false, false)) {
+                while (resultSet.next()) {
+                    var currentIndexName = resultSet.getString("INDEX_NAME");
+                    var columnName = resultSet.getString("COLUMN_NAME");
+                    if (indexName.equalsIgnoreCase(currentIndexName) && columnName != null) {
+                        columnsByOrdinal.put(resultSet.getInt("ORDINAL_POSITION"), columnName);
+                    }
+                }
+            }
+            return new ArrayList<>(columnsByOrdinal.values());
+        });
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -31,7 +31,6 @@ class LiquibaseSmokeTest {
         assertThat(countTable("template_player")).isEqualTo(1);
         assertThat(countTable("rooms")).isEqualTo(1);
         assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
-        assertThat(countIndex("idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(countTable("room_player")).isEqualTo(1);
         assertThat(countTable("room_team_leader")).isEqualTo(1);
         assertThat(countColumn("room_team_leader", "action_token")).isEqualTo(1);
@@ -55,14 +54,6 @@ class LiquibaseSmokeTest {
             Integer.class,
             tableName,
             columnName
-        );
-    }
-
-    private Integer countIndex(String indexName) {
-        return jdbcTemplate.queryForObject(
-            "select count(*) from information_schema.indexes where index_name = upper(?)",
-            Integer.class,
-            indexName
         );
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -31,6 +31,7 @@ class LiquibaseSmokeTest {
         assertThat(countTable("template_player")).isEqualTo(1);
         assertThat(countTable("rooms")).isEqualTo(1);
         assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
+        assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(countTable("room_player")).isEqualTo(1);
         assertThat(countTable("room_team_leader")).isEqualTo(1);
         assertThat(countColumn("room_team_leader", "action_token")).isEqualTo(1);
@@ -54,6 +55,15 @@ class LiquibaseSmokeTest {
             Integer.class,
             tableName,
             columnName
+        );
+    }
+
+    private Integer countIndex(String tableName, String indexName) {
+        return jdbcTemplate.queryForObject(
+            "select count(*) from information_schema.indexes where table_name = upper(?) and index_name = upper(?)",
+            Integer.class,
+            tableName,
+            indexName
         );
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(
+    properties = {
+        "spring.datasource.url=jdbc:h2:mem:find-joinable-rooms-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.liquibase.enabled=false",
+        "sentry.enabled=false"
+    }
+)
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class FindJoinableRoomsIntegrationTest {
+    private final FindJoinableRooms findJoinableRooms;
+    private final Rooms rooms;
+
+    @Test
+    void 참여_가능한_waiting_room만_최신순으로_반환한다() {
+        rooms.save(waitingRoom("ROOM01", Instant.parse("2026-04-09T00:00:00Z")));
+
+        Room full = waitingRoom("ROOM02", Instant.parse("2026-04-09T00:01:00Z"));
+        full.join("guest-1", "게스트", "guest-action-token");
+        rooms.save(full);
+
+        Room started = waitingRoom("ROOM03", Instant.parse("2026-04-09T00:02:00Z"));
+        started.join("guest-2", "게스트", "guest-action-token-2");
+        started.start("host-ROOM03");
+        rooms.save(started);
+
+        rooms.save(waitingRoom("ROOM04", Instant.parse("2026-04-09T00:03:00Z")));
+
+        assertThat(findJoinableRooms.list()).extracting(Room::getCode)
+            .containsExactly("ROOM04", "ROOM01");
+    }
+
+    @Test
+    void 참여_가능한_room은_최대_다섯개까지만_반환한다() {
+        List.of("ROOM01", "ROOM02", "ROOM03", "ROOM04", "ROOM05", "ROOM06")
+            .forEach(
+                code ->
+                    rooms.save(
+                        waitingRoom(code, Instant.parse("2026-04-09T00:00:00Z").plusSeconds(code.charAt(5)))
+                    )
+            );
+
+        assertThat(findJoinableRooms.list())
+            .hasSize(5)
+            .extracting(Room::getCode)
+            .containsExactly("ROOM06", "ROOM05", "ROOM04", "ROOM03", "ROOM02");
+    }
+
+    private Room waitingRoom(String code, Instant createdAt) {
+        return Room.createFromTemplate(
+            code,
+            "host-" + code,
+            "호스트-" + code,
+            "token-" + code,
+            new RoomTemplateSpec(
+                RoomTemplateSpec.Mode.AUCTION,
+                2,
+                2,
+                300,
+                null,
+                List.of(
+                    new RoomTemplateSpec.Player("선수1", 0),
+                    new RoomTemplateSpec.Player("선수2", 1)
+                )
+            ),
+            createdAt
+        );
+    }
+}

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -53,6 +53,21 @@ class FindJoinableRoomsIntegrationTest {
             .containsExactly("ROOM09", "ROOM07", "ROOM05", "ROOM03", "ROOM01");
     }
 
+    @Test
+    void 참여_가능한_room은_createdAt_내림차순을_우선하고_code는_동률_보조정렬로_쓴다() {
+        rooms.save(waitingRoom("ROOM99", Instant.parse("2026-04-09T00:00:00Z")));
+        rooms.save(waitingRoom("ROOM01", Instant.parse("2026-04-09T00:02:00Z")));
+        rooms.save(waitingRoom("ROOM50", Instant.parse("2026-04-09T00:01:00Z")));
+
+        assertThat(rooms.findJoinableWaitingRooms(PageRequest.of(0, 5)))
+            .extracting(Room::getCode)
+            .containsExactly("ROOM01", "ROOM50", "ROOM99");
+
+        assertThat(findJoinableRooms.list())
+            .extracting(Room::getCode)
+            .containsExactly("ROOM01", "ROOM50", "ROOM99");
+    }
+
     private Room waitingRoom(String code, Instant createdAt) {
         return Room.createFromTemplate(
             code,

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
     }
 )
 @Transactional
-@Import(FindJoinableRooms.class)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 class FindJoinableRoomsIntegrationTest {
@@ -32,42 +30,27 @@ class FindJoinableRoomsIntegrationTest {
     private final Rooms rooms;
 
     @Test
-    void 참여_가능한_waiting_room만_최신순으로_반환한다() {
-        rooms.save(waitingRoom("ROOM01", Instant.parse("2026-04-09T00:00:00Z")));
+    void 참여_가능한_waiting_room만_최신순과_안정적인_tie_break로_반환한다() {
+        Instant createdAt = Instant.parse("2026-04-09T00:00:00Z");
+        rooms.save(fullWaitingRoom("ROOM10", createdAt));
+        rooms.save(waitingRoom("ROOM09", createdAt));
+        rooms.save(fullWaitingRoom("ROOM08", createdAt));
+        rooms.save(waitingRoom("ROOM07", createdAt));
+        rooms.save(fullWaitingRoom("ROOM06", createdAt));
+        rooms.save(waitingRoom("ROOM05", createdAt));
+        rooms.save(fullWaitingRoom("ROOM04", createdAt));
+        rooms.save(waitingRoom("ROOM03", createdAt));
+        rooms.save(fullWaitingRoom("ROOM02", createdAt));
+        rooms.save(waitingRoom("ROOM01", createdAt));
 
-        Room full = waitingRoom("ROOM02", Instant.parse("2026-04-09T00:01:00Z"));
-        full.join("guest-1", "게스트", "guest-action-token");
-        rooms.save(full);
-
-        Room started = waitingRoom("ROOM03", Instant.parse("2026-04-09T00:02:00Z"));
-        started.join("guest-2", "게스트", "guest-action-token-2");
-        started.start("host-ROOM03");
-        rooms.save(started);
-
-        rooms.save(waitingRoom("ROOM04", Instant.parse("2026-04-09T00:03:00Z")));
-
-        assertThat(findJoinableRooms.list()).extracting(Room::getCode)
-            .containsExactly("ROOM04", "ROOM01");
-    }
-
-    @Test
-    void 참여_가능한_room은_최대_다섯개까지만_반환한다() {
-        List.of("ROOM01", "ROOM02", "ROOM03", "ROOM04", "ROOM05", "ROOM06")
-            .forEach(
-                code ->
-                    rooms.save(
-                        waitingRoom(code, Instant.parse("2026-04-09T00:00:00Z").plusSeconds(code.charAt(5)))
-                    )
-            );
-
-        assertThat(rooms.findByStatusOrderByCreatedAtDesc(RoomStatus.WAITING, PageRequest.of(0, 5)).getContent())
+        assertThat(rooms.findJoinableWaitingRooms(PageRequest.of(0, 5)))
             .extracting(Room::getCode)
-            .containsExactly("ROOM06", "ROOM05", "ROOM04", "ROOM03", "ROOM02");
+            .containsExactly("ROOM09", "ROOM07", "ROOM05", "ROOM03", "ROOM01");
 
         assertThat(findJoinableRooms.list())
             .hasSize(5)
             .extracting(Room::getCode)
-            .containsExactly("ROOM06", "ROOM05", "ROOM04", "ROOM03", "ROOM02");
+            .containsExactly("ROOM09", "ROOM07", "ROOM05", "ROOM03", "ROOM01");
     }
 
     private Room waitingRoom(String code, Instant createdAt) {
@@ -89,5 +72,11 @@ class FindJoinableRoomsIntegrationTest {
             ),
             createdAt
         );
+    }
+
+    private Room fullWaitingRoom(String code, Instant createdAt) {
+        Room room = waitingRoom(code, createdAt);
+        room.join("guest-" + code, "게스트-" + code, "guest-action-token-" + code);
+        return room;
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
     }
 )
 @Transactional
+@Import(FindJoinableRooms.class)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 class FindJoinableRoomsIntegrationTest {
@@ -56,6 +59,10 @@ class FindJoinableRoomsIntegrationTest {
                         waitingRoom(code, Instant.parse("2026-04-09T00:00:00Z").plusSeconds(code.charAt(5)))
                     )
             );
+
+        assertThat(rooms.findByStatusOrderByCreatedAtDesc(RoomStatus.WAITING, PageRequest.of(0, 5)).getContent())
+            .extracting(Room::getCode)
+            .containsExactly("ROOM06", "ROOM05", "ROOM04", "ROOM03", "ROOM02");
 
         assertThat(findJoinableRooms.list())
             .hasSize(5)

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -1,0 +1,137 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestConstructor;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.datasource.url=jdbc:h2:mem:room-api-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.liquibase.enabled=false",
+        "sentry.enabled=false"
+    }
+)
+@AutoConfigureTestRestTemplate
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class RoomApiIntegrationTest {
+    private final TestRestTemplate restTemplate;
+    private final Rooms rooms;
+
+    @Test
+    void list는_joinable_waiting_room만_응답하고_정렬과_JSON_필드를_보장한다() {
+        rooms.save(joinableAuctionRoom("ROOM99", Instant.parse("2026-04-09T00:03:00Z")));
+        rooms.save(fullWaitingAuctionRoom("ROOM08", Instant.parse("2026-04-09T00:02:00Z")));
+        rooms.save(inProgressAuctionRoom("ROOM07", Instant.parse("2026-04-09T00:01:00Z")));
+        rooms.save(joinableDraftRoom("ROOM01", Instant.parse("2026-04-09T00:00:00Z")));
+
+        var response = restTemplate.getForEntity("/api/v1/rooms", JoinableRoomListApiResponse.class);
+        JoinableRoomListApiResponse body = response.getBody();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(body).isNotNull();
+        assertThat(body.resultType()).isEqualTo("SUCCESS");
+        assertThat(body.success()).hasSize(2);
+        assertThat(body.success())
+            .extracting(
+                JoinableRoomResponse::code,
+                JoinableRoomResponse::mode,
+                JoinableRoomResponse::teamCount,
+                JoinableRoomResponse::joinedLeaderCount,
+                JoinableRoomResponse::remainingSlotCount,
+                JoinableRoomResponse::startReadiness
+            )
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(
+                    "ROOM99",
+                    "AUCTION",
+                    2,
+                    1,
+                    1,
+                    "WAITING_FOR_LEADERS"
+                ),
+                org.assertj.core.groups.Tuple.tuple(
+                    "ROOM01",
+                    "DRAFT",
+                    2,
+                    1,
+                    1,
+                    "WAITING_FOR_LEADERS"
+                )
+            );
+    }
+
+    private Room joinableAuctionRoom(String code, Instant createdAt) {
+        return Room.createFromTemplate(
+            code,
+            "host-" + code,
+            "호스트-" + code,
+            "host-action-token-" + code,
+            new RoomTemplateSpec(
+                RoomTemplateSpec.Mode.AUCTION,
+                2,
+                2,
+                300,
+                null,
+                List.of(
+                    new RoomTemplateSpec.Player("선수1", 0),
+                    new RoomTemplateSpec.Player("선수2", 1)
+                )
+            ),
+            createdAt
+        );
+    }
+
+    private Room fullWaitingAuctionRoom(String code, Instant createdAt) {
+        Room room = joinableAuctionRoom(code, createdAt);
+        room.join("guest-" + code, "게스트-" + code, "guest-action-token-" + code);
+        return room;
+    }
+
+    private Room inProgressAuctionRoom(String code, Instant createdAt) {
+        Room room = fullWaitingAuctionRoom(code, createdAt);
+        room.start("host-" + code);
+        return room;
+    }
+
+    private Room joinableDraftRoom(String code, Instant createdAt) {
+        return Room.createFromTemplate(
+            code,
+            "host-" + code,
+            "호스트-" + code,
+            "host-action-token-" + code,
+            new RoomTemplateSpec(
+                RoomTemplateSpec.Mode.DRAFT,
+                2,
+                2,
+                null,
+                RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                List.of(
+                    new RoomTemplateSpec.Player("선수1", 0),
+                    new RoomTemplateSpec.Player("선수2", 1)
+                )
+            ),
+            createdAt
+        );
+    }
+
+    private record JoinableRoomListApiResponse(
+        String resultType,
+        List<JoinableRoomResponse> success,
+        Object error
+    ) {
+    }
+}

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 class RoomRepositoryIntegrationTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private final Rooms rooms;
 
     @Test
@@ -44,7 +46,8 @@ class RoomRepositoryIntegrationTest {
                         new RoomTemplateSpec.Player("선수1", 0),
                         new RoomTemplateSpec.Player("선수2", 1)
                     )
-                )
+                ),
+                CREATED_AT
             );
         room.join("guest-1", "게스트", "guest-action-token");
         room.selectDraftPosition("host-1", 2);
@@ -56,6 +59,7 @@ class RoomRepositoryIntegrationTest {
 
         assertThat(reloaded.getId()).isEqualTo(saved.getId());
         assertThat(reloaded.getCode()).isEqualTo("ROOM01");
+        assertThat(reloaded.getCreatedAt()).isEqualTo(CREATED_AT);
         assertThat(reloaded.getPlayers().stream().map(RoomPlayer::getName)).containsExactly("선수1", "선수2");
         assertThat(reloaded.getLeaders())
             .extracting(RoomTeamLeader::getNickname, RoomTeamLeader::getActionToken, RoomTeamLeader::getDraftPosition)
@@ -63,5 +67,34 @@ class RoomRepositoryIntegrationTest {
                 org.assertj.core.groups.Tuple.tuple("호스트", "host-action-token", 2),
                 org.assertj.core.groups.Tuple.tuple("게스트", "guest-action-token", 1)
             );
+    }
+
+    @Test
+    @Transactional
+    void 방의_createdAt을_저장하고_다시_읽는다() {
+        Room room =
+            Room.createFromTemplate(
+                "ROOM02",
+                "host-1",
+                "호스트",
+                "host-action-token",
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.DRAFT,
+                    2,
+                    2,
+                    null,
+                    RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                    List.of(
+                        new RoomTemplateSpec.Player("선수1", 0),
+                        new RoomTemplateSpec.Player("선수2", 1)
+                    )
+                ),
+                CREATED_AT
+            );
+
+        Room saved = rooms.save(room);
+        Room reloaded = rooms.findById(saved.getId()).orElseThrow();
+
+        assertThat(reloaded.getCreatedAt()).isEqualTo(CREATED_AT);
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 class RoomRepositoryIntegrationTest {
     private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private final Rooms rooms;
+    private final EntityManager entityManager;
 
     @Test
     @Transactional
@@ -54,9 +57,12 @@ class RoomRepositoryIntegrationTest {
         room.selectDraftPosition("guest-1", 1);
 
         Room saved = rooms.save(room);
+        entityManager.flush();
+        entityManager.clear();
 
         Room reloaded = rooms.findById(saved.getId()).orElseThrow();
 
+        assertThat(reloaded).isNotSameAs(saved);
         assertThat(reloaded.getId()).isEqualTo(saved.getId());
         assertThat(reloaded.getCode()).isEqualTo("ROOM01");
         assertThat(reloaded.getCreatedAt()).isEqualTo(CREATED_AT);
@@ -93,8 +99,34 @@ class RoomRepositoryIntegrationTest {
             );
 
         Room saved = rooms.save(room);
+        entityManager.flush();
+        entityManager.clear();
         Room reloaded = rooms.findById(saved.getId()).orElseThrow();
 
         assertThat(reloaded.getCreatedAt()).isEqualTo(CREATED_AT);
+    }
+
+    @Test
+    void 방의_createdAt은_null일_수_없다() {
+        assertThatThrownBy(() ->
+            Room.createFromTemplate(
+                "ROOM03",
+                "host-1",
+                "호스트",
+                "host-action-token",
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.DRAFT,
+                    2,
+                    2,
+                    null,
+                    RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                    List.of(
+                        new RoomTemplateSpec.Player("선수1", 0),
+                        new RoomTemplateSpec.Player("선수2", 1)
+                    )
+                ),
+                null
+            )
+        ).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
@@ -2,6 +2,8 @@ package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.template.TemplateCatalog;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ class CreateRoom {
     private final Rooms rooms;
     private final TemplateCatalog templateCatalog;
     private final TeamLeaderIdentityIssuer teamLeaderIdentityIssuer;
+    private final Clock clock;
 
     @Transactional
     public Room create(UUID templateId, String hostNickname) {
@@ -38,7 +41,8 @@ class CreateRoom {
                     template.players().stream()
                         .map(player -> new RoomTemplateSpec.Player(player.name(), player.displayOrder()))
                         .toList()
-                )
+                ),
+                Instant.now(clock)
             );
 
         return rooms.save(room);

--- a/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
@@ -1,10 +1,8 @@
 package com.naminhyeok.fantazzk.room;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,25 +15,9 @@ class FindJoinableRooms {
 
     @Transactional(readOnly = true)
     public List<Room> list() {
-        List<Room> joinableRooms = new ArrayList<>(JOINABLE_ROOM_LIMIT);
-
-        for (int page = 0; joinableRooms.size() < JOINABLE_ROOM_LIMIT; page++) {
-            Slice<Room> waitingRooms =
-                rooms.findByStatusOrderByCreatedAtDesc(RoomStatus.WAITING, PageRequest.of(page, JOINABLE_ROOM_LIMIT));
-
-            if (waitingRooms.isEmpty()) {
-                break;
-            }
-
-            waitingRooms.stream()
-                .filter(Room::isJoinable)
-                .forEach(joinableRooms::add);
-
-            if (!waitingRooms.hasNext()) {
-                break;
-            }
-        }
-
-        return joinableRooms.stream().limit(JOINABLE_ROOM_LIMIT).toList();
+        return rooms.findJoinableWaitingRooms(PageRequest.of(0, JOINABLE_ROOM_LIMIT)).stream()
+            .filter(Room::isJoinable)
+            .limit(JOINABLE_ROOM_LIMIT)
+            .toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
@@ -1,7 +1,10 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,9 +17,25 @@ class FindJoinableRooms {
 
     @Transactional(readOnly = true)
     public List<Room> list() {
-        return rooms.findAllByStatusOrderByCreatedAtDesc(RoomStatus.WAITING).stream()
-            .filter(Room::isJoinable)
-            .limit(JOINABLE_ROOM_LIMIT)
-            .toList();
+        List<Room> joinableRooms = new ArrayList<>(JOINABLE_ROOM_LIMIT);
+
+        for (int page = 0; joinableRooms.size() < JOINABLE_ROOM_LIMIT; page++) {
+            Slice<Room> waitingRooms =
+                rooms.findByStatusOrderByCreatedAtDesc(RoomStatus.WAITING, PageRequest.of(page, JOINABLE_ROOM_LIMIT));
+
+            if (waitingRooms.isEmpty()) {
+                break;
+            }
+
+            waitingRooms.stream()
+                .filter(Room::isJoinable)
+                .forEach(joinableRooms::add);
+
+            if (!waitingRooms.hasNext()) {
+                break;
+            }
+        }
+
+        return joinableRooms.stream().limit(JOINABLE_ROOM_LIMIT).toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
@@ -1,0 +1,22 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class FindJoinableRooms {
+    private static final int JOINABLE_ROOM_LIMIT = 5;
+
+    private final Rooms rooms;
+
+    @Transactional(readOnly = true)
+    public List<Room> list() {
+        return rooms.findAllByStatusOrderByCreatedAtDesc(RoomStatus.WAITING).stream()
+            .filter(Room::isJoinable)
+            .limit(JOINABLE_ROOM_LIMIT)
+            .toList();
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomResponse.java
@@ -1,0 +1,22 @@
+package com.naminhyeok.fantazzk.room;
+
+record JoinableRoomResponse(
+    String code,
+    String mode,
+    int teamCount,
+    int joinedLeaderCount,
+    int remainingSlotCount,
+    String startReadiness
+) {
+    static JoinableRoomResponse from(Room room) {
+        int joinedLeaderCount = room.getLeaders().size();
+        return new JoinableRoomResponse(
+            room.getCode(),
+            room.getMode().name(),
+            room.getTeamCount(),
+            joinedLeaderCount,
+            room.getTeamCount() - joinedLeaderCount,
+            room.getStartReadiness().name()
+        );
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.Getter;
 import org.jmolecules.ddd.types.AggregateRoot;
@@ -49,7 +50,7 @@ class Room implements AggregateRoot<Room, RoomId> {
     ) {
         this.id = new RoomId(UUID.randomUUID());
         this.code = code;
-        this.createdAt = createdAt;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt must not be null");
         this.hostId = hostId;
         this.status = RoomStatus.WAITING;
         this.mode = mode;

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -2,8 +2,10 @@ package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
 import jakarta.persistence.EnumType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -16,6 +18,8 @@ import org.jmolecules.ddd.types.AggregateRoot;
 class Room implements AggregateRoot<Room, RoomId> {
     private final RoomId id;
     private final String code;
+    @Column(nullable = false, updatable = false)
+    private final Instant createdAt;
     private final String hostId;
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
@@ -35,6 +39,7 @@ class Room implements AggregateRoot<Room, RoomId> {
 
     Room(
         String code,
+        Instant createdAt,
         String hostId,
         RoomMode mode,
         int teamCount,
@@ -44,6 +49,7 @@ class Room implements AggregateRoot<Room, RoomId> {
     ) {
         this.id = new RoomId(UUID.randomUUID());
         this.code = code;
+        this.createdAt = createdAt;
         this.hostId = hostId;
         this.status = RoomStatus.WAITING;
         this.mode = mode;
@@ -64,11 +70,13 @@ class Room implements AggregateRoot<Room, RoomId> {
         String hostId,
         String hostNickname,
         String hostActionToken,
-        RoomTemplateSpec spec
+        RoomTemplateSpec spec,
+        Instant createdAt
     ) {
         Room room =
             new Room(
                 code,
+                createdAt,
                 hostId,
                 spec.mode() == RoomTemplateSpec.Mode.AUCTION ? RoomMode.AUCTION : RoomMode.DRAFT,
                 spec.teamCount(),
@@ -109,6 +117,10 @@ class Room implements AggregateRoot<Room, RoomId> {
             return RoomStartReadiness.WAITING_FOR_DRAFT_POSITIONS;
         }
         return RoomStartReadiness.STARTABLE;
+    }
+
+    boolean isJoinable() {
+        return status == RoomStatus.WAITING && leaders.size() < teamCount;
     }
 
     public void join(String teamLeaderId, String nickname, String actionToken) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomApiController.java
@@ -2,6 +2,7 @@ package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,10 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 class RoomApiController {
     private final CreateRoom createRoom;
     private final GetRoom getRoom;
+    private final FindJoinableRooms findJoinableRooms;
     private final JoinRoom joinRoom;
     private final StartRoom startRoom;
     private final SelectDraftPosition selectDraftPosition;
     private final ClearDraftPosition clearDraftPosition;
+
+    @GetMapping
+    ApiResponse<List<JoinableRoomResponse>> list() {
+        return ApiResponse.success(
+            findJoinableRooms.list().stream()
+                .map(JoinableRoomResponse::from)
+                .toList()
+        );
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
@@ -1,5 +1,6 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.List;
 import java.util.Optional;
 import org.jmolecules.ddd.types.Repository;
 
@@ -9,4 +10,6 @@ interface Rooms extends Repository<Room, RoomId> {
     Optional<Room> findById(RoomId id);
 
     Optional<Room> findByCode(String code);
+
+    List<Room> findAllByStatusOrderByCreatedAtDesc(RoomStatus status);
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
@@ -1,8 +1,9 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Query;
 import org.jmolecules.ddd.types.Repository;
 
 interface Rooms extends Repository<Room, RoomId> {
@@ -12,5 +13,12 @@ interface Rooms extends Repository<Room, RoomId> {
 
     Optional<Room> findByCode(String code);
 
-    Slice<Room> findByStatusOrderByCreatedAtDesc(RoomStatus status, Pageable pageable);
+    @Query("""
+        select r
+        from Room r
+        where r.status = com.naminhyeok.fantazzk.room.RoomStatus.WAITING
+          and size(r.leaders) < r.teamCount
+        order by r.createdAt desc, r.code desc
+        """)
+    List<Room> findJoinableWaitingRooms(Pageable pageable);
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
@@ -1,7 +1,8 @@
 package com.naminhyeok.fantazzk.room;
 
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.jmolecules.ddd.types.Repository;
 
 interface Rooms extends Repository<Room, RoomId> {
@@ -11,5 +12,5 @@ interface Rooms extends Repository<Room, RoomId> {
 
     Optional<Room> findByCode(String code);
 
-    List<Room> findAllByStatusOrderByCreatedAtDesc(RoomStatus status);
+    Slice<Room> findByStatusOrderByCreatedAtDesc(RoomStatus status, Pageable pageable);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -32,3 +32,14 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-team-leader-draft-position.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 4-room-created-at
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-created-at.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -43,3 +43,14 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-created-at.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 5-room-created-at-index
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-created-at-index.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-room-created-at-index.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-created-at-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_rooms_status_created_at ON rooms (status, created_at);

--- a/src/main/resources/db/changelog/db.changelog-room-created-at.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-created-at.sql
@@ -1,4 +1,2 @@
 ALTER TABLE rooms
     ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
-
-CREATE INDEX idx_rooms_status_created_at ON rooms (status, created_at);

--- a/src/main/resources/db/changelog/db.changelog-room-created-at.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-created-at.sql
@@ -1,2 +1,4 @@
 ALTER TABLE rooms
     ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX idx_rooms_status_created_at ON rooms (status, created_at);

--- a/src/main/resources/db/changelog/db.changelog-room-created-at.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-created-at.sql
@@ -1,0 +1,4 @@
+ALTER TABLE rooms
+    ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX idx_rooms_status_created_at ON rooms (status, created_at);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAggregateTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAggregateTest.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.naminhyeok.fantazzk.CoreException;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class RoomAggregateTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private static final String HOST_ID = "host-1";
     private static final String HOST_ACTION_TOKEN = "host-action-token";
     private static final String GUEST_ID = "guest-1";
@@ -33,10 +35,12 @@ class RoomAggregateTest {
                         new RoomTemplateSpec.Player("선수B", 1),
                         new RoomTemplateSpec.Player("선수A", 0)
                     )
-                )
+                ),
+                CREATED_AT
             );
 
         assertThat(room.getCode()).isEqualTo("ROOM01");
+        assertThat(room.getCreatedAt()).isEqualTo(CREATED_AT);
         assertThat(room.getStatus()).isEqualTo(RoomStatus.WAITING);
         assertThat(room.getMode()).isEqualTo(RoomMode.AUCTION);
         assertThat(room.getPlayers().stream().map(RoomPlayer::getName)).containsExactly("선수A", "선수B");
@@ -45,6 +49,22 @@ class RoomAggregateTest {
         assertThat(hostLeader.getNickname()).isEqualTo("호스트");
         assertThat(hostLeader.getRemainingBudget()).isEqualTo(300);
         assertThat(hostLeader.getActionToken()).isEqualTo(HOST_ACTION_TOKEN);
+    }
+
+    @Test
+    void 참여_가능한_대기룸만_joinable이다() {
+        Room joinable = auctionWaitingRoom(CREATED_AT);
+
+        Room full = auctionWaitingRoom(CREATED_AT.plusSeconds(60));
+        full.join(GUEST_ID, "게스트", GUEST_ACTION_TOKEN);
+
+        Room started = auctionWaitingRoom(CREATED_AT.plusSeconds(120));
+        started.join(GUEST_ID, "게스트", GUEST_ACTION_TOKEN);
+        started.start(HOST_ID);
+
+        assertThat(joinable.isJoinable()).isTrue();
+        assertThat(full.isJoinable()).isFalse();
+        assertThat(started.isJoinable()).isFalse();
     }
 
     @Test
@@ -137,7 +157,8 @@ class RoomAggregateTest {
                         new RoomTemplateSpec.Player("선수1", 0),
                         new RoomTemplateSpec.Player("선수2", 1)
                     )
-                )
+                ),
+                CREATED_AT
         );
 
         assertThatThrownBy(() -> room.join(GUEST_ID, "게스트", GUEST_ACTION_TOKEN))
@@ -222,6 +243,10 @@ class RoomAggregateTest {
     }
 
     private static Room auctionWaitingRoom() {
+        return auctionWaitingRoom(CREATED_AT);
+    }
+
+    private static Room auctionWaitingRoom(Instant createdAt) {
         return Room.createFromTemplate(
             "ROOM01",
             HOST_ID,
@@ -237,7 +262,8 @@ class RoomAggregateTest {
                     new RoomTemplateSpec.Player("선수1", 0),
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
-            )
+            ),
+            createdAt
         );
     }
 
@@ -249,6 +275,10 @@ class RoomAggregateTest {
     }
 
     private static Room waitingDraftRoom() {
+        return waitingDraftRoom(CREATED_AT);
+    }
+
+    private static Room waitingDraftRoom(Instant createdAt) {
         return Room.createFromTemplate(
             "ROOM02",
             HOST_ID,
@@ -264,7 +294,8 @@ class RoomAggregateTest {
                     new RoomTemplateSpec.Player("선수1", 0),
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
-            )
+            ),
+            createdAt
         );
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -52,6 +52,9 @@ class RoomApiWebMvcTest {
     private GetRoom getRoom;
 
     @MockitoBean
+    private FindJoinableRooms findJoinableRooms;
+
+    @MockitoBean
     private JoinRoom joinRoom;
 
     @MockitoBean
@@ -232,6 +235,27 @@ class RoomApiWebMvcTest {
     }
 
     @Test
+    void list는_참여_가능한_room_목록을_반환한다() throws Exception {
+        Room latest = waitingAuctionRoom("ROOM99", Instant.parse("2026-04-09T00:03:00Z"));
+        Room older = waitingDraftRoom("ROOM01", Instant.parse("2026-04-09T00:01:00Z"));
+
+        given(findJoinableRooms.list()).willReturn(List.of(latest, older));
+
+        var result = mockMvcTester().perform(get("/api/v1/rooms"));
+
+        result.assertThat().hasStatusOk();
+        assertThat(readBody(result, JoinableRoomListApiResponse.class))
+            .satisfies(response -> {
+                assertThat(response.resultType()).isEqualTo("SUCCESS");
+                assertThat(response.success()).hasSize(2);
+                assertThat(response.success().getFirst().code()).isEqualTo("ROOM99");
+                assertThat(response.success().getFirst().joinedLeaderCount()).isEqualTo(1);
+                assertThat(response.success().getFirst().remainingSlotCount()).isEqualTo(1);
+                assertThat(response.success().getFirst().startReadiness()).isEqualTo("WAITING_FOR_LEADERS");
+            });
+    }
+
+    @Test
     void join은_room과_teamLeaderSession을_반환한다() throws Exception {
         Room room = joinedAuctionRoom();
         RoomTeamLeader guest = room.getLeaders().getLast();
@@ -385,8 +409,12 @@ class RoomApiWebMvcTest {
     }
 
     private Room waitingAuctionRoom() {
+        return waitingAuctionRoom(ROOM_CODE, CREATED_AT);
+    }
+
+    private Room waitingAuctionRoom(String code, Instant createdAt) {
         return Room.createFromTemplate(
-            ROOM_CODE,
+            code,
             HOST_ID,
             "호스트",
             HOST_TOKEN,
@@ -401,7 +429,7 @@ class RoomApiWebMvcTest {
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
             ),
-            CREATED_AT
+            createdAt
         );
     }
 
@@ -412,9 +440,13 @@ class RoomApiWebMvcTest {
     }
 
     private Room waitingDraftRoom() {
+        return waitingDraftRoom(ROOM_CODE, CREATED_AT);
+    }
+
+    private Room waitingDraftRoom(String code, Instant createdAt) {
         Room room =
             Room.createFromTemplate(
-                ROOM_CODE,
+                code,
                 HOST_ID,
                 "호스트",
                 HOST_TOKEN,
@@ -429,7 +461,7 @@ class RoomApiWebMvcTest {
                         new RoomTemplateSpec.Player("선수2", 1)
                     )
                 ),
-                CREATED_AT
+                createdAt
             );
         room.join(GUEST_ID, "게스트", GUEST_TOKEN);
         room.selectDraftPosition(HOST_ID, 1);
@@ -526,6 +558,13 @@ class RoomApiWebMvcTest {
     private record VoidApiResponse(
         String resultType,
         Void success,
+        ErrorMessage error
+    ) {
+    }
+
+    private record JoinableRoomListApiResponse(
+        String resultType,
+        List<JoinableRoomResponse> success,
         ErrorMessage error
     ) {
     }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.ErrorMessage;
 import com.naminhyeok.fantazzk.GlobalExceptionHandler;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,7 @@ import tools.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc(addFilters = false)
 @Import(GlobalExceptionHandler.class)
 class RoomApiWebMvcTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private static final String ROOM_CODE = "ROOM01";
     private static final String HOST_ID = "host-1";
     private static final String HOST_TOKEN = "host-action-token";
@@ -398,7 +400,8 @@ class RoomApiWebMvcTest {
                     new RoomTemplateSpec.Player("선수1", 0),
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
-            )
+            ),
+            CREATED_AT
         );
     }
 
@@ -425,7 +428,8 @@ class RoomApiWebMvcTest {
                         new RoomTemplateSpec.Player("선수1", 0),
                         new RoomTemplateSpec.Player("선수2", 1)
                     )
-                )
+                ),
+                CREATED_AT
             );
         room.join(GUEST_ID, "게스트", GUEST_TOKEN);
         room.selectDraftPosition(HOST_ID, 1);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -493,7 +493,8 @@ class RoomApiWebMvcTest {
                         new RoomTemplateSpec.Player("선수3", 2),
                         new RoomTemplateSpec.Player("선수4", 3)
                     )
-                )
+                ),
+                CREATED_AT
             );
         room.join(GUEST_ID, "게스트", GUEST_TOKEN);
         room.start(HOST_ID);
@@ -521,7 +522,8 @@ class RoomApiWebMvcTest {
                         new RoomTemplateSpec.Player("선수3", 2),
                         new RoomTemplateSpec.Player("선수4", 3)
                     )
-                )
+                ),
+                CREATED_AT
             );
         room.join(GUEST_ID, "게스트", GUEST_TOKEN);
         room.selectDraftPosition(HOST_ID, 1);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.naminhyeok.fantazzk.CoreException;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class RoomAuctionTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private static final String HOST_ID = "host-1";
     private static final String HOST_ACTION_TOKEN = "host-action-token";
     private static final String GUEST_ID = "guest-1";
@@ -132,7 +134,8 @@ class RoomAuctionTest {
                     new RoomTemplateSpec.Player("선수1", 0),
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
-            )
+            ),
+            CREATED_AT
         );
     }
 
@@ -153,7 +156,8 @@ class RoomAuctionTest {
                         new RoomTemplateSpec.Player("선수1", 0),
                         new RoomTemplateSpec.Player("선수2", 1)
                     )
-                )
+                ),
+                CREATED_AT
             );
         room.join(GUEST_ID, "게스트", GUEST_ACTION_TOKEN);
         room.selectDraftPosition(HOST_ID, 1);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.naminhyeok.fantazzk.CoreException;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class RoomDraftTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
     private static final String HOST_ID = "host-1";
     private static final String HOST_ACTION_TOKEN = "host-action-token";
     private static final String GUEST_ID = "guest-1";
@@ -196,7 +198,8 @@ class RoomDraftTest {
                     IntStream.range(0, playerNames.size())
                         .mapToObj(index -> new RoomTemplateSpec.Player(playerNames.get(index), index))
                         .toList()
-                )
+                ),
+                CREATED_AT
             );
         return room;
     }
@@ -217,7 +220,8 @@ class RoomDraftTest {
                     new RoomTemplateSpec.Player("선수1", 0),
                     new RoomTemplateSpec.Player("선수2", 1)
                 )
-            )
+            ),
+            CREATED_AT
         );
     }
 }


### PR DESCRIPTION
## 요약
- 참여 가능한 대기 룸 목록 조회 API `GET /api/v1/rooms`를 추가했습니다.
- `Room.createdAt`, 참여 가능 조회 use case, 공개 응답 DTO를 도입하고 최신 생성순/최대 5개 규칙을 반영했습니다.
- Liquibase `created_at`/인덱스 변경을 checksum-safe changeset으로 추가하고, H2 및 PostgreSQL smoke test와 HTTP integration test를 보강했습니다.

## 변경 이유
기존 room API는 단건 생성/조회/참여/시작 중심이어서, 클라이언트가 즉시 참여 가능한 대기 룸을 탐색할 수 있는 lobby/discovery read API가 없었습니다. 이번 변경은 그 read use case를 room 모듈 안에서 공개 계약으로 추가하기 위한 것입니다.

## 영향
- 클라이언트가 참여 가능한 대기 룸만 별도 API로 조회할 수 있습니다.
- 응답에는 `code`, `mode`, `teamCount`, `joinedLeaderCount`, `remainingSlotCount`, `startReadiness`가 포함됩니다.
- 정렬은 최신 생성순이고, 응답 수는 최대 5개로 제한됩니다.

## 검증
- [x] `./gradlew check`
- [x] `./gradlew integrationTest`