### PR TITLE
설정(ci): OpenAPI sync PR 타겟을 dev로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_PATH: ${{ steps.sync-config.outputs.web_fe_openapi_path }}
         run: |
-          pr_number="$(gh pr list --repo "${WEB_FE_REPOSITORY}" --head "${WEB_FE_BRANCH}" --base main --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --repo "${WEB_FE_REPOSITORY}" --head "${WEB_FE_BRANCH}" --base dev --json number --jq '.[0].number')"
           pr_body="$(cat <<EOF
           Automated OpenAPI sync from ${GITHUB_REPOSITORY}.
 
@@ -231,7 +231,7 @@ jobs:
 
           gh pr create \
             --repo "${WEB_FE_REPOSITORY}" \
-            --base main \
+            --base dev \
             --head "${WEB_FE_BRANCH}" \
             --title "chore(api): sync OpenAPI spec" \
             --body "${pr_body}"


### PR DESCRIPTION
## Summary
- OpenAPI spec 동기화 PR의 타겟 브랜치를 `main` → `dev`로 변경
- web-fe 레포의 기본 개발 브랜치가 `dev`이므로 직접 dev로 PR 생성

## 변경 내용
- `gh pr list --base main` → `--base dev`
- `gh pr create --base main` → `--base dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)