### PR TITLE
템플릿 설정 확장 및 경매 타이밍 반영

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/CreateRoomRetryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/CreateRoomRetryIntegrationTest.java
@@ -69,7 +69,16 @@ class CreateRoomRetryIntegrationTest {
         assertThat(TestTransaction.isFlaggedForRollback()).isFalse();
 
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         inNewTransaction(() -> rooms.saveAndFlush(existingRoom("ROOM01")));
         roomCodeGenerator.reset("ROOM01", "ROOM02");
@@ -100,7 +109,16 @@ class CreateRoomRetryIntegrationTest {
     @Test
     void 중복_방코드_충돌이_반복되면_방_코드_생성_실패를_반환한다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         inNewTransaction(() -> rooms.saveAndFlush(existingRoom("ROOM01")));
         roomCodeGenerator.reset("ROOM01", "ROOM01", "ROOM01");
@@ -127,10 +145,11 @@ class CreateRoomRetryIntegrationTest {
                 2,
                 2,
                 300,
+                15,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             java.time.Instant.parse("2026-04-10T00:00:00Z")

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -70,10 +70,11 @@ class FindJoinableRoomsIntegrationTest {
                 2,
                 2,
                 300,
+                15,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -90,7 +90,7 @@ class RoomApiIntegrationTest {
 
     @Test
     void auctionProgress는_due된_경매를_정산한_latest_snapshot을_반환한다() {
-        Room room = startedAuctionRoom("ROOM10", CREATED_AT);
+        Room room = startedAuctionRoom("ROOM10", CREATED_AT.minusSeconds(30));
         room.placeBid(new TeamLeaderId("host-ROOM10"), 100, CREATED_AT.plusSeconds(1));
         rooms.save(room);
 
@@ -110,7 +110,8 @@ class RoomApiIntegrationTest {
         assertThat(body.success().status()).isEqualTo("IN_PROGRESS");
         assertThat(body.success().progress().currentRound()).isEqualTo(2);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
-            .isAfter(CREATED_AT.plusSeconds(15));
+            .isAfter(CREATED_AT.plusSeconds(45));
+        assertThat(body.success().players().getFirst().position()).isEqualTo("TOP");
         assertThat(body.success().members()).singleElement()
             .extracting(RoomMemberResponse::playerName)
             .isEqualTo("선수1");
@@ -129,7 +130,8 @@ class RoomApiIntegrationTest {
         assertThat(body.resultType()).isEqualTo("SUCCESS");
         assertThat(body.success().progress().currentRound()).isEqualTo(1);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
-            .isEqualTo(Instant.parse("2026-04-09T00:00:15Z"));
+            .isEqualTo(Instant.parse("2026-04-09T00:00:45Z"));
+        assertThat(body.success().players().getFirst().position()).isEqualTo("TOP");
     }
 
     private Room startedAuctionRoom(String code, Instant createdAt) {
@@ -143,10 +145,11 @@ class RoomApiIntegrationTest {
                 2,
                 2,
                 300,
+                45,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt
@@ -167,10 +170,11 @@ class RoomApiIntegrationTest {
                 2,
                 2,
                 300,
+                45,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt
@@ -200,10 +204,11 @@ class RoomApiIntegrationTest {
                 2,
                 2,
                 null,
+                30,
                 RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
@@ -63,7 +63,16 @@ class RoomAuctionIntegrationTest {
     @Transactional
     void 입찰과_정산을_처리하면_선수_배정과_예산_차감이_반영된다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -84,6 +93,7 @@ class RoomAuctionIntegrationTest {
         assertThat(reloaded.getBids()).singleElement()
             .extracting(RoomBid::teamLeaderId, RoomBid::amount)
             .containsExactly(guest.getId(), 150);
+        assertThat(reloaded.getPlayers().getFirst().getPosition()).isEqualTo("TOP");
         assertThat(reloaded.getMembers()).singleElement()
             .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerName)
             .containsExactly(guest.getId(), "선수1");
@@ -95,7 +105,16 @@ class RoomAuctionIntegrationTest {
     @Test
     void 같은_라운드의_입찰_순번은_재조회_후에도_누적된다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -113,7 +132,16 @@ class RoomAuctionIntegrationTest {
     @Test
     void catchUpAndReschedule는_due_room을_즉시_정산한다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -128,13 +156,22 @@ class RoomAuctionIntegrationTest {
 
         Room reloaded = rooms.findByCode(created.getCode()).orElseThrow();
         assertThat(reloaded.getCurrentAuctionRound()).isEqualTo(2);
-        assertThat(reloaded.getCurrentAuctionRoundEndsAt()).isEqualTo(Instant.parse("2000-01-01T00:00:15Z"));
+        assertThat(reloaded.getCurrentAuctionRoundEndsAt()).isEqualTo(Instant.parse("2000-01-01T00:00:45Z"));
     }
 
     @Test
     void legacy_null_deadline_방에_입찰하면_deadline을_복구하고_commit후_재예약한다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -148,14 +185,23 @@ class RoomAuctionIntegrationTest {
         placeBid.place(created.getCode(), guest.getActionToken(), 150);
 
         Room reloaded = rooms.findByCode(created.getCode()).orElseThrow();
-        assertThat(reloaded.getCurrentAuctionRoundEndsAt()).isEqualTo(Instant.parse("2000-01-01T00:00:15Z"));
-        assertThat(recordingTaskScheduler.scheduledInstants()).containsExactly(Instant.parse("2000-01-01T00:00:15Z"));
+        assertThat(reloaded.getCurrentAuctionRoundEndsAt()).isEqualTo(Instant.parse("2000-01-01T00:00:45Z"));
+        assertThat(recordingTaskScheduler.scheduledInstants()).containsExactly(Instant.parse("2000-01-01T00:00:45Z"));
     }
 
     @Test
     void start_rollback되면_deadline_task는_등록되지_않는다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         joinRoom.join(created.getCode(), "게스트");

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
@@ -47,7 +47,10 @@ class RoomDraftIntegrationTest {
                 2,
                 2,
                 DraftOrderStrategy.SNAKE,
-                List.of("선수1", "선수2")
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
             );
 
         Room created = createRoom.create(template, "호스트");
@@ -77,7 +80,10 @@ class RoomDraftIntegrationTest {
                 2,
                 2,
                 DraftOrderStrategy.SNAKE,
-                List.of("선수1", "선수2")
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
             );
 
         Room created = createRoom.create(template, "호스트");
@@ -100,7 +106,12 @@ class RoomDraftIntegrationTest {
                 2,
                 3,
                 DraftOrderStrategy.SNAKE,
-                List.of("선수1", "선수2", "선수3", "선수4")
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE"),
+                    new TemplateFixture.PlayerSpec("선수3", "MID"),
+                    new TemplateFixture.PlayerSpec("선수4", "ADC")
+                )
             );
 
         Room created = createRoom.create(template, "호스트");

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
@@ -45,10 +45,11 @@ class RoomRepositoryIntegrationTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 CREATED_AT
@@ -67,9 +68,11 @@ class RoomRepositoryIntegrationTest {
         assertThat(reloaded.getId()).isEqualTo(saved.getId());
         assertThat(reloaded.getCode()).isEqualTo("ROOM01");
         assertThat(reloaded.getCreatedAt()).isEqualTo(CREATED_AT);
+        assertThat(reloaded.getPickBanTime()).isEqualTo(30);
         assertThat(reloaded.getPlayers()).extracting(RoomPlayer::getId)
             .containsExactly(new RoomPlayerId(0), new RoomPlayerId(1));
         assertThat(reloaded.getPlayers().stream().map(RoomPlayer::getName)).containsExactly("선수1", "선수2");
+        assertThat(reloaded.getPlayers().stream().map(RoomPlayer::getPosition)).containsExactly("TOP", "JUNGLE");
         assertThat(reloaded.getLeaders())
             .extracting(RoomTeamLeader::getId, RoomTeamLeader::getNickname, RoomTeamLeader::getActionToken, RoomTeamLeader::getDraftPosition)
             .containsExactlyInAnyOrder(
@@ -92,10 +95,11 @@ class RoomRepositoryIntegrationTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 CREATED_AT
@@ -123,10 +127,11 @@ class RoomRepositoryIntegrationTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 null

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
@@ -40,7 +40,16 @@ class RoomServiceIntegrationTest {
     @Test
     void 템플릿으로_방을_생성하면_호스트_액션_토큰을_발급하고_저장한다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         Room reloaded = rooms.findById(created.getId()).orElseThrow();
@@ -57,7 +66,16 @@ class RoomServiceIntegrationTest {
     @Test
     void 호스트가_아닌_액션_토큰으로는_방을_시작할_수_없다() {
         var template =
-            templateFixture.createAuctionTemplateId("경매전", 2, 2, 300, List.of("선수1", "선수2"));
+            templateFixture.createAuctionTemplateId(
+                "경매전",
+                2,
+                2,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -74,7 +92,16 @@ class RoomServiceIntegrationTest {
     @Test
     void 드래프트_자리가_모두_확정되면_시작_가능_상태가_된다() {
         var template =
-            templateFixture.createDraftTemplateId("드래프트전", 2, 2, DraftOrderStrategy.SNAKE, List.of("선수1", "선수2"));
+            templateFixture.createDraftTemplateId(
+                "드래프트전",
+                2,
+                2,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
@@ -96,7 +123,16 @@ class RoomServiceIntegrationTest {
     @Test
     void 드래프트_자리가_미확정이면_방을_시작할_수_없다() {
         var template =
-            templateFixture.createDraftTemplateId("드래프트전", 2, 2, DraftOrderStrategy.SNAKE, List.of("선수1", "선수2"));
+            templateFixture.createDraftTemplateId(
+                "드래프트전",
+                2,
+                2,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
         joinRoom.join(created.getCode(), "게스트");
@@ -114,7 +150,16 @@ class RoomServiceIntegrationTest {
     @Test
     void 드래프트_자리를_취소하면_다시_미선택이_된다() {
         var template =
-            templateFixture.createDraftTemplateId("드래프트전", 2, 2, DraftOrderStrategy.SNAKE, List.of("선수1", "선수2"));
+            templateFixture.createDraftTemplateId(
+                "드래프트전",
+                2,
+                2,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
 
         Room created = createRoom.create(template, "호스트");
 

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateApiIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.TestConstructor;
         "spring.datasource.username=sa",
         "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=validate",
+        "spring.jpa.open-in-view=false",
         "spring.liquibase.enabled=true",
         "sentry.enabled=false"
     }
@@ -43,11 +44,18 @@ class TemplateApiIntegrationTest {
                     """
                     {
                       "name": "경매전",
+                      "gameType": "LEAGUE_OF_LEGENDS",
                       "mode": "AUCTION",
                       "teamCount": 2,
                       "teamSize": 2,
                       "budget": 300,
-                      "playerNames": ["선수1", "선수2"]
+                      "pickBanTime": 45,
+                      "minBidUnit": 10,
+                      "positionLimit": 1,
+                      "players": [
+                        {"name": "선수1", "position": "TOP"},
+                        {"name": "선수2", "position": "JUNGLE"}
+                      ]
                     }
                     """
                 ),
@@ -56,7 +64,18 @@ class TemplateApiIntegrationTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody()).containsEntry("resultType", "SUCCESS");
-        assertThat(((Map<?, ?>) response.getBody().get("success")).get("name")).isEqualTo("경매전");
+        Map<?, ?> success = (Map<?, ?>) response.getBody().get("success");
+        assertThat(success.get("name")).isEqualTo("경매전");
+        assertThat(success.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
+        assertThat(success.get("pickBanTime")).isEqualTo(45);
+        assertThat(success.get("minBidUnit")).isEqualTo(10);
+        assertThat(success.get("positionLimit")).isEqualTo(1);
+        assertThat(success.get("players")).isEqualTo(
+            List.of(
+                Map.of("name", "선수1", "position", "TOP", "displayOrder", 0),
+                Map.of("name", "선수2", "position", "JUNGLE", "displayOrder", 1)
+            )
+        );
     }
 
     @Test
@@ -68,11 +87,18 @@ class TemplateApiIntegrationTest {
                     """
                     {
                       "name": "상세조회용 경매전",
+                      "gameType": "LEAGUE_OF_LEGENDS",
                       "mode": "AUCTION",
                       "teamCount": 2,
                       "teamSize": 2,
                       "budget": 300,
-                      "playerNames": ["선수1", "선수2"]
+                      "pickBanTime": 45,
+                      "minBidUnit": 10,
+                      "positionLimit": 1,
+                      "players": [
+                        {"name": "선수1", "position": "TOP"},
+                        {"name": "선수2", "position": "JUNGLE"}
+                      ]
                     }
                     """
                 ),
@@ -87,11 +113,15 @@ class TemplateApiIntegrationTest {
         assertThat(response.getBody()).containsEntry("resultType", "SUCCESS");
         Map<?, ?> success = (Map<?, ?>) response.getBody().get("success");
         assertThat(success.get("name")).isEqualTo("상세조회용 경매전");
+        assertThat(success.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
+        assertThat(success.get("pickBanTime")).isEqualTo(45);
+        assertThat(success.get("minBidUnit")).isEqualTo(10);
+        assertThat(success.get("positionLimit")).isEqualTo(1);
         List<Map<String, Object>> players = (List<Map<String, Object>>) success.get("players");
         assertThat(players)
             .containsExactly(
-                Map.of("name", "선수1", "displayOrder", 0),
-                Map.of("name", "선수2", "displayOrder", 1)
+                Map.of("name", "선수1", "position", "TOP", "displayOrder", 0),
+                Map.of("name", "선수2", "position", "JUNGLE", "displayOrder", 1)
             );
     }
 
@@ -104,12 +134,17 @@ class TemplateApiIntegrationTest {
                     """
                     {
                       "name": "드래프트전",
+                      "gameType": "OVERWATCH_2",
                       "mode": "DRAFT",
                       "teamCount": 2,
                       "teamSize": 2,
                       "budget": 300,
+                      "pickBanTime": 30,
                       "draftOrderStrategy": "SNAKE",
-                      "playerNames": ["선수1", "선수2"]
+                      "players": [
+                        {"name": "선수1", "position": "TANK"},
+                        {"name": "선수2", "position": "SUPPORT"}
+                      ]
                     }
                     """
                 ),
@@ -125,6 +160,108 @@ class TemplateApiIntegrationTest {
     }
 
     @Test
+    void 경매_요청에_최소_입찰_단위가_없으면_400을_반환한다() {
+        ResponseEntity<Map> response = restTemplate.exchange(
+            RequestEntity.post("/api/v1/templates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(
+                    """
+                    {
+                      "name": "경매전",
+                      "gameType": "LEAGUE_OF_LEGENDS",
+                      "mode": "AUCTION",
+                      "teamCount": 2,
+                      "teamSize": 2,
+                      "budget": 300,
+                      "pickBanTime": 45,
+                      "positionLimit": 1,
+                      "players": [
+                        {"name": "선수1", "position": "TOP"},
+                        {"name": "선수2", "position": "JUNGLE"}
+                      ]
+                    }
+                    """
+                ),
+            Map.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsEntry("resultType", "ERROR");
+        Map<?, ?> error = (Map<?, ?>) response.getBody().get("error");
+        assertThat(error.get("code")).isEqualTo("TEMPLATE_AUCTION_MIN_BID_UNIT_REQUIRED");
+        assertThat(error.get("message")).isEqualTo("경매 템플릿에는 최소 입찰 단위가 필요합니다");
+        assertThat(error.get("data")).isNull();
+    }
+
+    @Test
+    void 드래프트_요청에_최소_입찰_단위가_있으면_400을_반환한다() {
+        ResponseEntity<Map> response = restTemplate.exchange(
+            RequestEntity.post("/api/v1/templates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(
+                    """
+                    {
+                      "name": "드래프트전",
+                      "gameType": "OVERWATCH_2",
+                      "mode": "DRAFT",
+                      "teamCount": 2,
+                      "teamSize": 2,
+                      "pickBanTime": 30,
+                      "minBidUnit": 10,
+                      "draftOrderStrategy": "SNAKE",
+                      "players": [
+                        {"name": "선수1", "position": "TANK"},
+                        {"name": "선수2", "position": "SUPPORT"}
+                      ]
+                    }
+                    """
+                ),
+            Map.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsEntry("resultType", "ERROR");
+        Map<?, ?> error = (Map<?, ?>) response.getBody().get("error");
+        assertThat(error.get("code")).isEqualTo("TEMPLATE_DRAFT_MIN_BID_UNIT_NOT_ALLOWED");
+        assertThat(error.get("message")).isEqualTo("드래프트 템플릿에는 최소 입찰 단위를 지정할 수 없습니다");
+        assertThat(error.get("data")).isNull();
+    }
+
+    @Test
+    void 드래프트_요청에_포지션_제한이_있으면_400을_반환한다() {
+        ResponseEntity<Map> response = restTemplate.exchange(
+            RequestEntity.post("/api/v1/templates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(
+                    """
+                    {
+                      "name": "드래프트전",
+                      "gameType": "OVERWATCH_2",
+                      "mode": "DRAFT",
+                      "teamCount": 2,
+                      "teamSize": 2,
+                      "pickBanTime": 30,
+                      "positionLimit": 1,
+                      "draftOrderStrategy": "SNAKE",
+                      "players": [
+                        {"name": "선수1", "position": "TANK"},
+                        {"name": "선수2", "position": "SUPPORT"}
+                      ]
+                    }
+                    """
+                ),
+            Map.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsEntry("resultType", "ERROR");
+        Map<?, ?> error = (Map<?, ?>) response.getBody().get("error");
+        assertThat(error.get("code")).isEqualTo("TEMPLATE_DRAFT_POSITION_LIMIT_NOT_ALLOWED");
+        assertThat(error.get("message")).isEqualTo("드래프트 템플릿에는 포지션 제한을 지정할 수 없습니다");
+        assertThat(error.get("data")).isNull();
+    }
+
+    @Test
     void 요청_필드_검증에_실패하면_400과_필드_에러를_반환한다() {
         ResponseEntity<Map> response = restTemplate.exchange(
             RequestEntity.post("/api/v1/templates")
@@ -133,11 +270,15 @@ class TemplateApiIntegrationTest {
                     """
                     {
                       "name": "",
+                      "gameType": "LEAGUE_OF_LEGENDS",
                       "mode": "AUCTION",
                       "teamCount": 0,
                       "teamSize": 0,
                       "budget": 300,
-                      "playerNames": []
+                      "pickBanTime": 0,
+                      "minBidUnit": 10,
+                      "positionLimit": 1,
+                      "players": []
                     }
                     """
                 ),
@@ -153,7 +294,8 @@ class TemplateApiIntegrationTest {
         assertThat(data.get("name")).isEqualTo("템플릿 이름은 비어 있을 수 없습니다");
         assertThat(data.get("teamCount")).isEqualTo("팀 수는 1 이상이어야 합니다");
         assertThat(data.get("teamSize")).isEqualTo("팀 크기는 1 이상이어야 합니다");
-        assertThat(data.get("playerNames")).isEqualTo("선수 목록은 비어 있을 수 없습니다");
+        assertThat(data.get("pickBanTime")).isEqualTo("픽밴 시간은 1 이상이어야 합니다");
+        assertThat(data.get("players")).isEqualTo("선수 목록은 비어 있을 수 없습니다");
     }
 
     @Test
@@ -179,11 +321,18 @@ class TemplateApiIntegrationTest {
                     """
                     {
                       "name": "목록용 경매전",
+                      "gameType": "LEAGUE_OF_LEGENDS",
                       "mode": "AUCTION",
                       "teamCount": 2,
                       "teamSize": 2,
                       "budget": 300,
-                      "playerNames": ["선수1", "선수2"]
+                      "pickBanTime": 45,
+                      "minBidUnit": 10,
+                      "positionLimit": 1,
+                      "players": [
+                        {"name": "선수1", "position": "TOP"},
+                        {"name": "선수2", "position": "JUNGLE"}
+                      ]
                     }
                     """
                 ),
@@ -194,7 +343,19 @@ class TemplateApiIntegrationTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsEntry("resultType", "SUCCESS");
-        List<?> templates = (List<?>) response.getBody().get("success");
-        assertThat(templates).isNotEmpty();
+        List<Map<String, Object>> templates = (List<Map<String, Object>>) response.getBody().get("success");
+        assertThat(templates).anySatisfy(template -> {
+            assertThat(template.get("name")).isEqualTo("목록용 경매전");
+            assertThat(template.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
+            assertThat(template.get("pickBanTime")).isEqualTo(45);
+            assertThat(template.get("minBidUnit")).isEqualTo(10);
+            assertThat(template.get("positionLimit")).isEqualTo(1);
+            assertThat(template.get("players")).isEqualTo(
+                List.of(
+                    Map.of("name", "선수1", "position", "TOP", "displayOrder", 0),
+                    Map.of("name", "선수2", "position", "JUNGLE", "displayOrder", 1)
+                )
+            );
+        });
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateCatalogIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateCatalogIntegrationTest.java
@@ -34,26 +34,37 @@ class TemplateCatalogIntegrationTest {
             createTemplate.create(
                 new CreateTemplateCommand.Draft(
                     "사내 리그 드래프트",
+                    GameType.OVERWATCH_2,
                     2,
                     3,
+                    30,
                     DraftOrderStrategy.FIXED,
-                    List.of("선수4", "선수1", "선수3", "선수2")
+                    List.of(
+                        new CreateTemplateCommand.Player("선수4", "TANK", 0),
+                        new CreateTemplateCommand.Player("선수1", "SUPPORT", 1),
+                        new CreateTemplateCommand.Player("선수3", "DPS", 2),
+                        new CreateTemplateCommand.Player("선수2", "DPS", 3)
+                    )
                 )
             );
 
         TemplateCatalog.TemplateBlueprint blueprint = templateCatalog.getTemplate(created.getId().templateId());
 
+        assertThat(blueprint.gameType()).isEqualTo(TemplateCatalog.GameType.OVERWATCH_2);
         assertThat(blueprint.mode()).isEqualTo(TemplateCatalog.Mode.DRAFT);
         assertThat(blueprint.teamCount()).isEqualTo(2);
         assertThat(blueprint.teamSize()).isEqualTo(3);
+        assertThat(blueprint.pickBanTime()).isEqualTo(30);
+        assertThat(blueprint.minBidUnit()).isNull();
+        assertThat(blueprint.positionLimit()).isNull();
         assertThat(blueprint.draftOrderStrategy()).isEqualTo(TemplateCatalog.DraftOrderStrategy.FIXED);
         assertThat(blueprint.players())
-            .extracting("playerIndex", "name")
+            .extracting("playerIndex", "name", "position")
             .containsExactly(
-                tuple(0, "선수4"),
-                tuple(1, "선수1"),
-                tuple(2, "선수3"),
-                tuple(3, "선수2")
+                tuple(0, "선수4", "TANK"),
+                tuple(1, "선수1", "SUPPORT"),
+                tuple(2, "선수3", "DPS"),
+                tuple(3, "선수2", "DPS")
             );
     }
 

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateFixture.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateFixture.java
@@ -2,6 +2,7 @@ package com.naminhyeok.fantazzk.template;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,9 +11,22 @@ import org.springframework.stereotype.Component;
 public class TemplateFixture {
     private final CreateTemplate createTemplate;
 
-    public UUID createAuctionTemplateId(String name, int teamCount, int teamSize, int budget, List<String> playerNames) {
+    public record PlayerSpec(String name, String position) {
+    }
+
+    public UUID createAuctionTemplateId(String name, int teamCount, int teamSize, int budget, List<PlayerSpec> players) {
         return createTemplate.create(
-            new CreateTemplateCommand.Auction(name, teamCount, teamSize, budget, playerNames)
+            new CreateTemplateCommand.Auction(
+                name,
+                GameType.LEAGUE_OF_LEGENDS,
+                teamCount,
+                teamSize,
+                budget,
+                45,
+                10,
+                1,
+                toPlayers(players)
+            )
         ).getId().templateId();
     }
 
@@ -21,16 +35,24 @@ public class TemplateFixture {
         int teamCount,
         int teamSize,
         TemplateCatalog.DraftOrderStrategy strategy,
-        List<String> playerNames
+        List<PlayerSpec> players
     ) {
         return createTemplate.create(
             new CreateTemplateCommand.Draft(
                 name,
+                GameType.LEAGUE_OF_LEGENDS,
                 teamCount,
                 teamSize,
+                30,
                 DraftOrderStrategy.valueOf(strategy.name()),
-                playerNames
+                toPlayers(players)
             )
         ).getId().templateId();
+    }
+
+    private static List<CreateTemplateCommand.Player> toPlayers(List<PlayerSpec> players) {
+        return IntStream.range(0, players.size())
+            .mapToObj(index -> new CreateTemplateCommand.Player(players.get(index).name(), players.get(index).position(), index))
+            .toList();
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateRepositoryIntegrationTest.java
@@ -34,10 +34,17 @@ class TemplateRepositoryIntegrationTest {
             templates.save(
                 Template.createAuction(
                     "주말 풋살 경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     2,
                     300,
-                    List.of("선수1", "선수2")
+                    45,
+                    10,
+                    1,
+                    List.of(
+                        new TemplatePlayer("선수1", "TOP", 0),
+                        new TemplatePlayer("선수2", "JUNGLE", 1)
+                    )
                 )
             );
 
@@ -48,12 +55,16 @@ class TemplateRepositoryIntegrationTest {
 
         assertThat(reloaded.getId()).isEqualTo(saved.getId());
         assertThat(reloaded.getName()).isEqualTo("주말 풋살 경매전");
+        assertThat(reloaded.getGameType()).isEqualTo(GameType.LEAGUE_OF_LEGENDS);
         assertThat(reloaded.getMode()).isEqualTo(TemplateMode.AUCTION);
+        assertThat(reloaded.getPickBanTime()).isEqualTo(45);
+        assertThat(reloaded.getMinBidUnit()).isEqualTo(10);
+        assertThat(reloaded.getPositionLimit()).isEqualTo(1);
         assertThat(reloaded.getPlayers())
-            .extracting("playerIndex", "name")
+            .extracting(TemplatePlayer::displayOrder, TemplatePlayer::name, TemplatePlayer::position)
             .containsExactly(
-                org.assertj.core.groups.Tuple.tuple(0, "선수1"),
-                org.assertj.core.groups.Tuple.tuple(1, "선수2")
+                org.assertj.core.groups.Tuple.tuple(0, "선수1", "TOP"),
+                org.assertj.core.groups.Tuple.tuple(1, "선수2", "JUNGLE")
             );
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
@@ -72,6 +72,7 @@ class CreateRoom {
                 template.teamCount(),
                 template.teamSize(),
                 template.budget(),
+                template.pickBanTime(),
                 template.draftOrderStrategy() == null
                     ? null
                     : RoomTemplateSpec.DraftOrderStrategy.valueOf(template.draftOrderStrategy().name()),
@@ -79,6 +80,7 @@ class CreateRoom {
                     .map(player -> new RoomTemplateSpec.Player(
                         new RoomPlayerId(player.playerIndex()),
                         player.name(),
+                        player.position(),
                         player.playerIndex()
                     ))
                     .toList()

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -41,6 +41,8 @@ class Room implements AggregateRoot<Room, RoomId> {
     private final int teamCount;
     private final int teamSize;
     private final Integer budget;
+    @Column(name = "pick_ban_time")
+    private final int pickBanTime;
     @Enumerated(EnumType.STRING)
     private final RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy;
     private Integer currentTurnIndex;
@@ -68,6 +70,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         int teamCount,
         int teamSize,
         Integer budget,
+        int pickBanTime,
         RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy
     ) {
         this.id = new RoomId(UUID.randomUUID());
@@ -79,6 +82,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         this.teamCount = teamCount;
         this.teamSize = teamSize;
         this.budget = budget;
+        this.pickBanTime = pickBanTime;
         this.draftOrderStrategy = draftOrderStrategy;
         this.currentTurnIndex = null;
         this.currentAuctionRound = null;
@@ -106,12 +110,13 @@ class Room implements AggregateRoot<Room, RoomId> {
                 spec.teamCount(),
                 spec.teamSize(),
                 spec.budget(),
+                spec.pickBanTime(),
                 spec.draftOrderStrategy()
             );
 
         spec.players().stream()
             .sorted(Comparator.comparingInt(RoomTemplateSpec.Player::displayOrder))
-            .map(player -> new RoomPlayer(player.id(), player.name(), player.displayOrder()))
+            .map(player -> new RoomPlayer(player.id(), player.name(), player.position(), player.displayOrder()))
             .forEach(room.players::add);
 
         room.leaders.add(new RoomTeamLeader(hostLeaderId, hostNickname, hostActionToken, spec.budget()));
@@ -201,7 +206,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         if (mode == RoomMode.AUCTION) {
             currentAuctionRound = 1;
             currentTurnIndex = null;
-            currentAuctionRoundEndsAt = now.plusSeconds(15);
+            currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
         } else {
             currentTurnIndex = 0;
             currentAuctionRound = null;
@@ -272,7 +277,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         if (currentAuctionRoundEndsAt != null) {
             return false;
         }
-        currentAuctionRoundEndsAt = now.plusSeconds(15);
+        currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
         return true;
     }
 
@@ -313,7 +318,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             int maxOrder = players.stream().mapToInt(RoomPlayer::getDisplayOrder).max().orElse(0);
             target.moveToBack(maxOrder + 1);
             currentAuctionRound += 1;
-            currentAuctionRoundEndsAt = now.plusSeconds(15);
+            currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
             return new AuctionSettlement(target.getName(), AuctionOutcome.PASSED);
         }
 
@@ -332,7 +337,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             currentAuctionRoundEndsAt = null;
         } else {
             currentAuctionRound += 1;
-            currentAuctionRoundEndsAt = now.plusSeconds(15);
+            currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
         }
 
         return new AuctionSettlement(target.getName(), AuctionOutcome.SOLD);

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayer.java
@@ -18,6 +18,8 @@ class RoomPlayer {
     private RoomPlayerId id;
     @Column(name = "name")
     private String name;
+    @Column(name = "position")
+    private String position;
     @Column(name = "display_order")
     private int displayOrder;
     @Column(name = "status")
@@ -27,9 +29,10 @@ class RoomPlayer {
     RoomPlayer() {
     }
 
-    RoomPlayer(RoomPlayerId id, String name, int displayOrder) {
+    RoomPlayer(RoomPlayerId id, String name, String position, int displayOrder) {
         this.id = id;
         this.name = name;
+        this.position = position;
         this.displayOrder = displayOrder;
         this.status = PlayerStatus.AVAILABLE;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
@@ -2,12 +2,14 @@ package com.naminhyeok.fantazzk.room;
 
 record RoomPlayerResponse(
     String name,
+    String position,
     int displayOrder,
     String status
 ) {
     static RoomPlayerResponse from(RoomPlayer player) {
         return new RoomPlayerResponse(
             player.getName(),
+            player.getPosition(),
             player.getDisplayOrder(),
             player.getStatus().name()
         );

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomTemplateSpec.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomTemplateSpec.java
@@ -7,6 +7,7 @@ record RoomTemplateSpec(
     int teamCount,
     int teamSize,
     Integer budget,
+    int pickBanTime,
     DraftOrderStrategy draftOrderStrategy,
     List<Player> players
 ) {
@@ -20,6 +21,6 @@ record RoomTemplateSpec(
         FIXED
     }
 
-    public record Player(RoomPlayerId id, String name, int displayOrder) {
+    public record Player(RoomPlayerId id, String name, String position, int displayOrder) {
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplate.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplate.java
@@ -15,18 +15,28 @@ class CreateTemplate {
             case CreateTemplateCommand.Auction auction ->
                 Template.createAuction(
                     auction.name(),
+                    auction.gameType(),
                     auction.teamCount(),
                     auction.teamSize(),
                     auction.budget(),
-                    auction.playerNames()
+                    auction.pickBanTime(),
+                    auction.minBidUnit(),
+                    auction.positionLimit(),
+                    auction.players().stream()
+                        .map(player -> new TemplatePlayer(player.name(), player.position(), player.displayOrder()))
+                        .toList()
                 );
             case CreateTemplateCommand.Draft draft ->
                 Template.createDraft(
                     draft.name(),
+                    draft.gameType(),
                     draft.teamCount(),
                     draft.teamSize(),
+                    draft.pickBanTime(),
                     draft.strategy(),
-                    draft.playerNames()
+                    draft.players().stream()
+                        .map(player -> new TemplatePlayer(player.name(), player.position(), player.displayOrder()))
+                        .toList()
                 );
         };
 

--- a/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateCommand.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateCommand.java
@@ -5,27 +5,40 @@ import java.util.List;
 sealed interface CreateTemplateCommand permits CreateTemplateCommand.Auction, CreateTemplateCommand.Draft {
     String name();
 
+    GameType gameType();
+
     int teamCount();
 
     int teamSize();
 
-    List<String> playerNames();
+    int pickBanTime();
+
+    List<Player> players();
+
+    record Player(String name, String position, int displayOrder) {
+    }
 
     record Auction(
         String name,
+        GameType gameType,
         int teamCount,
         int teamSize,
         int budget,
-        List<String> playerNames
+        int pickBanTime,
+        int minBidUnit,
+        Integer positionLimit,
+        List<Player> players
     ) implements CreateTemplateCommand {
     }
 
     record Draft(
         String name,
+        GameType gameType,
         int teamCount,
         int teamSize,
+        int pickBanTime,
         DraftOrderStrategy strategy,
-        List<String> playerNames
+        List<Player> players
     ) implements CreateTemplateCommand {
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateRequest.java
@@ -1,21 +1,33 @@
 package com.naminhyeok.fantazzk.template;
 
 import com.naminhyeok.fantazzk.CoreException;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
+import java.util.stream.IntStream;
 
 record CreateTemplateRequest(
     @NotBlank(message = "템플릿 이름은 비어 있을 수 없습니다") String name,
+    @NotNull(message = "게임 타입은 필수입니다") GameType gameType,
     @NotNull(message = "템플릿 모드는 필수입니다") TemplateCatalog.Mode mode,
     @Positive(message = "팀 수는 1 이상이어야 합니다") int teamCount,
     @Positive(message = "팀 크기는 1 이상이어야 합니다") int teamSize,
+    @Positive(message = "픽밴 시간은 1 이상이어야 합니다") int pickBanTime,
     Integer budget,
+    Integer minBidUnit,
+    Integer positionLimit,
     TemplateCatalog.DraftOrderStrategy draftOrderStrategy,
-    @NotEmpty(message = "선수 목록은 비어 있을 수 없습니다") List<String> playerNames
+    @NotEmpty(message = "선수 목록은 비어 있을 수 없습니다") List<@Valid PlayerRequest> players
 ) {
+    record PlayerRequest(
+        @NotBlank(message = "선수 이름은 비어 있을 수 없습니다") String name,
+        @NotBlank(message = "선수 포지션은 비어 있을 수 없습니다") String position
+    ) {
+    }
+
     CreateTemplateCommand toCommand() {
         return switch (mode) {
             case AUCTION -> {
@@ -25,23 +37,50 @@ record CreateTemplateRequest(
                 if (budget == null) {
                     throw CoreException.of(TemplateErrorType.TEMPLATE_AUCTION_BUDGET_REQUIRED);
                 }
-                yield new CreateTemplateCommand.Auction(name, teamCount, teamSize, budget, playerNames);
+                if (minBidUnit == null) {
+                    throw CoreException.of(TemplateErrorType.TEMPLATE_AUCTION_MIN_BID_UNIT_REQUIRED);
+                }
+                yield new CreateTemplateCommand.Auction(
+                    name,
+                    gameType,
+                    teamCount,
+                    teamSize,
+                    budget,
+                    pickBanTime,
+                    minBidUnit,
+                    positionLimit,
+                    toPlayers()
+                );
             }
             case DRAFT -> {
                 if (budget != null) {
                     throw CoreException.of(TemplateErrorType.TEMPLATE_DRAFT_BUDGET_NOT_ALLOWED);
+                }
+                if (minBidUnit != null) {
+                    throw CoreException.of(TemplateErrorType.TEMPLATE_DRAFT_MIN_BID_UNIT_NOT_ALLOWED);
+                }
+                if (positionLimit != null) {
+                    throw CoreException.of(TemplateErrorType.TEMPLATE_DRAFT_POSITION_LIMIT_NOT_ALLOWED);
                 }
                 if (draftOrderStrategy == null) {
                     throw CoreException.of(TemplateErrorType.TEMPLATE_DRAFT_ORDER_STRATEGY_REQUIRED);
                 }
                 yield new CreateTemplateCommand.Draft(
                     name,
+                    gameType,
                     teamCount,
                     teamSize,
+                    pickBanTime,
                     DraftOrderStrategy.valueOf(draftOrderStrategy.name()),
-                    playerNames
+                    toPlayers()
                 );
             }
         };
+    }
+
+    private List<CreateTemplateCommand.Player> toPlayers() {
+        return IntStream.range(0, players.size())
+            .mapToObj(index -> new CreateTemplateCommand.Player(players.get(index).name(), players.get(index).position(), index))
+            .toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
@@ -18,7 +18,9 @@ class FindTemplates {
     }
 
     @Transactional(readOnly = true)
-    public List<Template> list() {
-        return templates.findAll();
+    public List<TemplateDetail> list() {
+        return templates.findAll().stream()
+            .map(template -> new TemplateDetail(template, template.getPlayers()))
+            .toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/GameType.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/GameType.java
@@ -1,0 +1,34 @@
+package com.naminhyeok.fantazzk.template;
+
+import java.util.Set;
+
+enum GameType {
+    LEAGUE_OF_LEGENDS(Set.of("TOP", "JUNGLE", "MID", "ADC", "SUPPORT")),
+    OVERWATCH_2(Set.of("TANK", "DPS", "SUPPORT"));
+
+    private final Set<String> supportedPositions;
+
+    GameType(Set<String> supportedPositions) {
+        this.supportedPositions = supportedPositions;
+    }
+
+    boolean supportsPosition(String position) {
+        return supportedPositions.contains(normalize(position));
+    }
+
+    void validatePosition(String position) {
+        String normalizedPosition = normalize(position);
+
+        if (!supportsPosition(normalizedPosition)) {
+            throw new IllegalArgumentException(name() + " 게임은 " + normalizedPosition + " 포지션을 지원하지 않습니다");
+        }
+    }
+
+    private static String normalize(String position) {
+        if (position == null || position.isBlank()) {
+            throw new IllegalArgumentException("포지션은 비어 있을 수 없습니다");
+        }
+
+        return position.trim().toUpperCase();
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/template/ProvideTemplateCatalog.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/ProvideTemplateCatalog.java
@@ -16,17 +16,21 @@ class ProvideTemplateCatalog implements TemplateCatalog {
             TemplateDetail detail = findTemplates.getDetail(new TemplateId(templateId));
             return new TemplateBlueprint(
                 templateId,
+                GameType.valueOf(detail.template().getGameType().name()),
                 detail.template().getMode() == TemplateMode.AUCTION
                     ? Mode.AUCTION
                     : Mode.DRAFT,
                 detail.template().getTeamCount(),
                 detail.template().getTeamSize(),
                 detail.template().getBudget(),
+                detail.template().getPickBanTime(),
+                detail.template().getMinBidUnit(),
+                detail.template().getPositionLimit(),
                 detail.template().getDraftOrderStrategy() == null
                     ? null
                     : DraftOrderStrategy.valueOf(detail.template().getDraftOrderStrategy().name()),
                 detail.players().stream()
-                    .map(player -> new PlayerBlueprint(player.name(), player.playerIndex()))
+                    .map(player -> new PlayerBlueprint(player.name(), player.position(), player.displayOrder()))
                     .toList()
             );
         } catch (CoreException ex) {

--- a/src/main/java/com/naminhyeok/fantazzk/template/Template.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/Template.java
@@ -32,28 +32,38 @@ class Template implements AggregateRoot<Template, TemplateId> {
 
     public static Template createAuction(
         String name,
+        GameType gameType,
         int teamCount,
         int teamSize,
         int budget,
-        List<String> playerNames
+        int pickBanTime,
+        int minBidUnit,
+        Integer positionLimit,
+        List<TemplatePlayer> players
     ) {
-        return new Template(name, TemplateConfiguration.auction(teamCount, teamSize, budget))
-            .registerPlayers(playerNames);
+        return new Template(name, TemplateConfiguration.auction(gameType, teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit))
+            .registerPlayers(players);
     }
 
     public static Template createDraft(
         String name,
+        GameType gameType,
         int teamCount,
         int teamSize,
+        int pickBanTime,
         DraftOrderStrategy strategy,
-        List<String> playerNames
+        List<TemplatePlayer> players
     ) {
-        return new Template(name, TemplateConfiguration.draft(teamCount, teamSize, strategy))
-            .registerPlayers(playerNames);
+        return new Template(name, TemplateConfiguration.draft(gameType, teamCount, teamSize, pickBanTime, strategy))
+            .registerPlayers(players);
     }
 
     public TemplateMode getMode() {
         return configuration.getMode();
+    }
+
+    public GameType getGameType() {
+        return configuration.getGameType();
     }
 
     public int getTeamCount() {
@@ -68,13 +78,25 @@ class Template implements AggregateRoot<Template, TemplateId> {
         return configuration.getBudget();
     }
 
+    public Integer getPickBanTime() {
+        return configuration.getPickBanTime();
+    }
+
+    public Integer getMinBidUnit() {
+        return configuration.getMinBidUnit();
+    }
+
+    public Integer getPositionLimit() {
+        return configuration.getPositionLimit();
+    }
+
     public DraftOrderStrategy getDraftOrderStrategy() {
         return configuration.getDraftOrderStrategy();
     }
 
     public List<TemplatePlayer> getPlayers() {
         return players.stream()
-            .sorted(Comparator.comparingInt(TemplatePlayer::playerIndex))
+            .sorted(Comparator.comparingInt(TemplatePlayer::displayOrder))
             .toList();
     }
 
@@ -82,14 +104,15 @@ class Template implements AggregateRoot<Template, TemplateId> {
         return configuration.getTeamSize() - 1;
     }
 
-    private Template registerPlayers(List<String> playerNames) {
-        if (playerNames.size() != configuration.requiredPlayerCount()) {
+    private Template registerPlayers(List<TemplatePlayer> templatePlayers) {
+        if (templatePlayers.size() != configuration.requiredPlayerCount()) {
             throw new IllegalArgumentException("선수 수는 정확히 " + configuration.requiredPlayerCount() + "명이어야 합니다");
         }
 
         players.clear();
-        for (int index = 0; index < playerNames.size(); index++) {
-            players.add(new TemplatePlayer(playerNames.get(index), index));
+        for (TemplatePlayer player : templatePlayers) {
+            configuration.getGameType().validatePosition(player.position());
+            players.add(player);
         }
 
         return this;

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateCatalog.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateCatalog.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 public interface TemplateCatalog {
     TemplateBlueprint getTemplate(UUID templateId);
 
+    enum GameType {
+        LEAGUE_OF_LEGENDS,
+        OVERWATCH_2
+    }
+
     enum Mode {
         AUCTION,
         DRAFT
@@ -18,10 +23,14 @@ public interface TemplateCatalog {
 
     record TemplateBlueprint(
         UUID templateId,
+        GameType gameType,
         Mode mode,
         int teamCount,
         int teamSize,
         Integer budget,
+        Integer pickBanTime,
+        Integer minBidUnit,
+        Integer positionLimit,
         DraftOrderStrategy draftOrderStrategy,
         List<PlayerBlueprint> players
     ) {
@@ -29,6 +38,7 @@ public interface TemplateCatalog {
 
     record PlayerBlueprint(
         String name,
+        String position,
         int playerIndex
     ) {
     }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateConfiguration.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateConfiguration.java
@@ -10,26 +10,40 @@ import org.jmolecules.ddd.types.ValueObject;
 @EqualsAndHashCode
 public final class TemplateConfiguration implements ValueObject {
     @Enumerated(EnumType.STRING)
+    private final GameType gameType;
+    @Enumerated(EnumType.STRING)
     private final TemplateMode mode;
     private final int teamCount;
     private final int teamSize;
     private final Integer budget;
+    private final int pickBanTime;
+    private final Integer minBidUnit;
+    private final Integer positionLimit;
     @Enumerated(EnumType.STRING)
     private final DraftOrderStrategy draftOrderStrategy;
 
     private TemplateConfiguration(
+        GameType gameType,
         TemplateMode mode,
         int teamCount,
         int teamSize,
         Integer budget,
+        int pickBanTime,
+        Integer minBidUnit,
+        Integer positionLimit,
         DraftOrderStrategy draftOrderStrategy
     ) {
+        if (gameType == null) {
+            throw new IllegalArgumentException("게임 타입은 필수입니다");
+        }
         if (teamCount <= 0) {
             throw new IllegalArgumentException("팀 수는 0보다 커야 합니다");
         }
-
         if (teamSize <= 0) {
             throw new IllegalArgumentException("팀 크기는 0보다 커야 합니다");
+        }
+        if (pickBanTime <= 0) {
+            throw new IllegalArgumentException("픽밴 시간은 0보다 커야 합니다");
         }
 
         if (mode == TemplateMode.AUCTION) {
@@ -38,6 +52,15 @@ public final class TemplateConfiguration implements ValueObject {
             }
             if (budget <= 0) {
                 throw new IllegalArgumentException("예산은 0보다 커야 합니다");
+            }
+            if (minBidUnit == null) {
+                throw new IllegalArgumentException("경매 템플릿에는 최소 입찰 단위가 필요합니다");
+            }
+            if (minBidUnit <= 0) {
+                throw new IllegalArgumentException("최소 입찰 단위는 0보다 커야 합니다");
+            }
+            if (positionLimit != null && positionLimit <= 0) {
+                throw new IllegalArgumentException("포지션 제한은 0보다 커야 합니다");
             }
             if (draftOrderStrategy != null) {
                 throw new IllegalArgumentException("경매 템플릿에는 드래프트 순서 전략을 지정할 수 없습니다");
@@ -48,31 +71,79 @@ public final class TemplateConfiguration implements ValueObject {
             if (budget != null) {
                 throw new IllegalArgumentException("드래프트 템플릿에는 예산을 지정할 수 없습니다");
             }
+            if (minBidUnit != null) {
+                throw new IllegalArgumentException("드래프트 템플릿에는 최소 입찰 단위를 지정할 수 없습니다");
+            }
+            if (positionLimit != null) {
+                throw new IllegalArgumentException("드래프트 템플릿에는 포지션 제한을 지정할 수 없습니다");
+            }
             if (draftOrderStrategy == null) {
                 throw new IllegalArgumentException("드래프트 템플릿에는 순서 전략이 필요합니다");
             }
         }
 
+        this.gameType = gameType;
         this.mode = mode;
         this.teamCount = teamCount;
         this.teamSize = teamSize;
         this.budget = budget;
+        this.pickBanTime = pickBanTime;
+        this.minBidUnit = minBidUnit;
+        this.positionLimit = positionLimit;
         this.draftOrderStrategy = draftOrderStrategy;
     }
 
-    public static TemplateConfiguration auction(int teamCount, int teamSize, int budget) {
-        return new TemplateConfiguration(TemplateMode.AUCTION, teamCount, teamSize, budget, null);
+    public static TemplateConfiguration auction(
+        GameType gameType,
+        int teamCount,
+        int teamSize,
+        int budget,
+        int pickBanTime,
+        int minBidUnit,
+        Integer positionLimit
+    ) {
+        return new TemplateConfiguration(
+            gameType,
+            TemplateMode.AUCTION,
+            teamCount,
+            teamSize,
+            budget,
+            pickBanTime,
+            minBidUnit,
+            positionLimit,
+            null
+        );
     }
 
-    public static TemplateConfiguration draft(int teamCount, int teamSize, DraftOrderStrategy strategy) {
-        return new TemplateConfiguration(TemplateMode.DRAFT, teamCount, teamSize, null, strategy);
+    public static TemplateConfiguration draft(
+        GameType gameType,
+        int teamCount,
+        int teamSize,
+        int pickBanTime,
+        DraftOrderStrategy strategy
+    ) {
+        return new TemplateConfiguration(
+            gameType,
+            TemplateMode.DRAFT,
+            teamCount,
+            teamSize,
+            null,
+            pickBanTime,
+            null,
+            null,
+            strategy
+        );
     }
 
     public static TemplateConfiguration from(
+        GameType gameType,
         TemplateMode mode,
         int teamCount,
         int teamSize,
         Integer budget,
+        int pickBanTime,
+        Integer minBidUnit,
+        Integer positionLimit,
         DraftOrderStrategy draftOrderStrategy
     ) {
         return switch (mode) {
@@ -83,16 +154,25 @@ public final class TemplateConfiguration implements ValueObject {
                 if (budget == null) {
                     throw new IllegalArgumentException("경매 템플릿에는 예산이 필요합니다");
                 }
-                yield auction(teamCount, teamSize, budget);
+                if (minBidUnit == null) {
+                    throw new IllegalArgumentException("경매 템플릿에는 최소 입찰 단위가 필요합니다");
+                }
+                yield auction(gameType, teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit);
             }
             case DRAFT -> {
                 if (budget != null) {
                     throw new IllegalArgumentException("드래프트 템플릿에는 예산을 지정할 수 없습니다");
                 }
+                if (minBidUnit != null) {
+                    throw new IllegalArgumentException("드래프트 템플릿에는 최소 입찰 단위를 지정할 수 없습니다");
+                }
+                if (positionLimit != null) {
+                    throw new IllegalArgumentException("드래프트 템플릿에는 포지션 제한을 지정할 수 없습니다");
+                }
                 if (draftOrderStrategy == null) {
                     throw new IllegalArgumentException("드래프트 템플릿에는 순서 전략이 필요합니다");
                 }
-                yield draft(teamCount, teamSize, draftOrderStrategy);
+                yield draft(gameType, teamCount, teamSize, pickBanTime, draftOrderStrategy);
             }
         };
     }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateErrorType.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateErrorType.java
@@ -20,10 +20,28 @@ enum TemplateErrorType implements ErrorDescriptor {
         "경매 템플릿에는 예산이 필요합니다",
         Level.INFO
     ),
+    TEMPLATE_AUCTION_MIN_BID_UNIT_REQUIRED(
+        HttpStatus.BAD_REQUEST,
+        "TEMPLATE_AUCTION_MIN_BID_UNIT_REQUIRED",
+        "경매 템플릿에는 최소 입찰 단위가 필요합니다",
+        Level.INFO
+    ),
     TEMPLATE_DRAFT_BUDGET_NOT_ALLOWED(
         HttpStatus.BAD_REQUEST,
         "TEMPLATE_DRAFT_BUDGET_NOT_ALLOWED",
         "드래프트 템플릿에는 예산을 지정할 수 없습니다",
+        Level.INFO
+    ),
+    TEMPLATE_DRAFT_MIN_BID_UNIT_NOT_ALLOWED(
+        HttpStatus.BAD_REQUEST,
+        "TEMPLATE_DRAFT_MIN_BID_UNIT_NOT_ALLOWED",
+        "드래프트 템플릿에는 최소 입찰 단위를 지정할 수 없습니다",
+        Level.INFO
+    ),
+    TEMPLATE_DRAFT_POSITION_LIMIT_NOT_ALLOWED(
+        HttpStatus.BAD_REQUEST,
+        "TEMPLATE_DRAFT_POSITION_LIMIT_NOT_ALLOWED",
+        "드래프트 템플릿에는 포지션 제한을 지정할 수 없습니다",
         Level.INFO
     ),
     TEMPLATE_DRAFT_ORDER_STRATEGY_REQUIRED(

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayer.java
@@ -9,23 +9,43 @@ import org.jmolecules.ddd.types.ValueObject;
 @EqualsAndHashCode
 final class TemplatePlayer implements ValueObject {
     private final String name;
+    private final String position;
     @Column(name = "display_order")
-    private final int playerIndex;
+    private final int displayOrder;
 
-    TemplatePlayer(String name, int playerIndex) {
+    TemplatePlayer(String name, String position, int displayOrder) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("선수 이름은 비어 있을 수 없습니다");
         }
+        if (position == null || position.isBlank()) {
+            throw new IllegalArgumentException("선수 포지션은 비어 있을 수 없습니다");
+        }
 
-        this.name = name;
-        this.playerIndex = playerIndex;
+        this.name = name.trim();
+        this.position = position.trim().toUpperCase();
+        this.displayOrder = displayOrder;
+    }
+
+    @SuppressWarnings("unused")
+    private TemplatePlayer() {
+        this.name = null;
+        this.position = null;
+        this.displayOrder = 0;
     }
 
     String name() {
         return name;
     }
 
-    int playerIndex() {
-        return playerIndex;
+    String position() {
+        return position;
+    }
+
+    int displayOrder() {
+        return displayOrder;
+    }
+
+    public String getName() {
+        return name();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayerResponse.java
@@ -2,9 +2,10 @@ package com.naminhyeok.fantazzk.template;
 
 record TemplatePlayerResponse(
     String name,
+    String position,
     int displayOrder
 ) {
     static TemplatePlayerResponse from(TemplatePlayer player) {
-        return new TemplatePlayerResponse(player.name(), player.playerIndex());
+        return new TemplatePlayerResponse(player.name(), player.position(), player.displayOrder());
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateResponse.java
@@ -1,37 +1,37 @@
 package com.naminhyeok.fantazzk.template;
+
 import java.util.List;
 
 record TemplateResponse(
     String id,
     String name,
+    TemplateCatalog.GameType gameType,
     TemplateCatalog.Mode mode,
     int teamCount,
     int teamSize,
     Integer budget,
+    Integer pickBanTime,
+    Integer minBidUnit,
+    Integer positionLimit,
     TemplateCatalog.DraftOrderStrategy draftOrderStrategy,
     List<TemplatePlayerResponse> players
 ) {
     static TemplateResponse from(Template template) {
-        return new TemplateResponse(
-            template.getId().templateId().toString(),
-            template.getName(),
-            template.getMode() == TemplateMode.AUCTION ? TemplateCatalog.Mode.AUCTION : TemplateCatalog.Mode.DRAFT,
-            template.getTeamCount(),
-            template.getTeamSize(),
-            template.getBudget(),
-            template.getDraftOrderStrategy() == null ? null : TemplateCatalog.DraftOrderStrategy.valueOf(template.getDraftOrderStrategy().name()),
-            null
-        );
+        return from(new TemplateDetail(template, template.getPlayers()));
     }
 
     static TemplateResponse from(TemplateDetail detail) {
         return new TemplateResponse(
             detail.template().getId().templateId().toString(),
             detail.template().getName(),
+            TemplateCatalog.GameType.valueOf(detail.template().getGameType().name()),
             detail.template().getMode() == TemplateMode.AUCTION ? TemplateCatalog.Mode.AUCTION : TemplateCatalog.Mode.DRAFT,
             detail.template().getTeamCount(),
             detail.template().getTeamSize(),
             detail.template().getBudget(),
+            detail.template().getPickBanTime(),
+            detail.template().getMinBidUnit(),
+            detail.template().getPositionLimit(),
             detail.template().getDraftOrderStrategy() == null
                 ? null
                 : TemplateCatalog.DraftOrderStrategy.valueOf(detail.template().getDraftOrderStrategy().name()),

--- a/src/main/java/com/naminhyeok/fantazzk/template/Templates.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/Templates.java
@@ -2,6 +2,7 @@ package com.naminhyeok.fantazzk.template;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.jmolecules.ddd.types.Repository;
 
 interface Templates extends Repository<Template, TemplateId> {
@@ -9,5 +10,6 @@ interface Templates extends Repository<Template, TemplateId> {
 
     Optional<Template> findById(TemplateId id);
 
+    @EntityGraph(attributePaths = "players")
     List<Template> findAll();
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,3 +21,45 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-auction-deadline.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 3-template-game-type-position
+      author: codex
+      preConditions:
+        - sqlCheck:
+            onFail: HALT
+            onError: HALT
+            expectedResult: "0"
+            sql: SELECT COUNT(*) FROM template
+        - sqlCheck:
+            expectedResult: "0"
+            sql: SELECT COUNT(*) FROM template_player
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-template-game-type-position.sql
+            splitStatements: true
+            stripComments: false
+  - changeSet:
+      id: 4-room-pick-ban-time
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-pick-ban-time.sql
+            splitStatements: true
+            stripComments: false
+  - changeSet:
+      id: 5-room-player-position
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-player-position.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-room-pick-ban-time.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-pick-ban-time.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rooms ADD COLUMN pick_ban_time INT NOT NULL DEFAULT 15;

--- a/src/main/resources/db/changelog/db.changelog-room-player-position.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-player-position.sql
@@ -1,0 +1,1 @@
+ALTER TABLE room_player ADD COLUMN position VARCHAR(255);

--- a/src/main/resources/db/changelog/db.changelog-template-game-type-position.sql
+++ b/src/main/resources/db/changelog/db.changelog-template-game-type-position.sql
@@ -1,0 +1,6 @@
+ALTER TABLE template ADD COLUMN game_type VARCHAR(255) NOT NULL;
+ALTER TABLE template ADD COLUMN pick_ban_time INT NOT NULL;
+ALTER TABLE template ADD COLUMN min_bid_unit INT;
+ALTER TABLE template ADD COLUMN position_limit INT;
+
+ALTER TABLE template_player ADD COLUMN position VARCHAR(255) NOT NULL;

--- a/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
@@ -41,8 +41,9 @@ class CreateRoomTest {
         assertThat(created).isSameAs(rooms.savedRoom());
         assertThat(rooms.flushAttemptCount()).isEqualTo(3);
         assertThat(rooms.attemptedRoomIds()).doesNotHaveDuplicates();
+        assertThat(created.getPickBanTime()).isEqualTo(45);
         assertThat(created.getPlayers().stream().map(RoomPlayer::getId))
-            .containsExactly(new RoomPlayerId(1), new RoomPlayerId(2));
+            .containsExactly(new RoomPlayerId(0), new RoomPlayerId(1));
     }
 
     @Test
@@ -175,12 +176,19 @@ class CreateRoomTest {
         public TemplateBlueprint getTemplate(UUID templateId) {
             return new TemplateBlueprint(
                 templateId,
+                GameType.LEAGUE_OF_LEGENDS,
                 Mode.AUCTION,
                 2,
                 2,
                 300,
+                45,
+                10,
+                1,
                 null,
-                List.of(new PlayerBlueprint("선수1", 1), new PlayerBlueprint("선수2", 2))
+                List.of(
+                    new PlayerBlueprint("선수1", "TOP", 0),
+                    new PlayerBlueprint("선수2", "JUNGLE", 1)
+                )
             );
         }
     }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAggregateTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAggregateTest.java
@@ -30,10 +30,11 @@ class RoomAggregateTest {
                     2,
                     3,
                     300,
+                    45,
                     null,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수B", 1),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수A", 0)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수B", "JUNGLE", 1),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수A", "TOP", 0)
                     )
                 ),
                 CREATED_AT
@@ -43,7 +44,9 @@ class RoomAggregateTest {
         assertThat(room.getCreatedAt()).isEqualTo(CREATED_AT);
         assertThat(room.getStatus()).isEqualTo(RoomStatus.WAITING);
         assertThat(room.getMode()).isEqualTo(RoomMode.AUCTION);
+        assertThat(room.getPickBanTime()).isEqualTo(45);
         assertThat(room.getPlayers().stream().map(RoomPlayer::getName)).containsExactly("선수A", "선수B");
+        assertThat(room.getPlayers().stream().map(RoomPlayer::getPosition)).containsExactly("TOP", "JUNGLE");
         assertThat(room.getPlayers().stream().map(RoomPlayer::getId))
             .containsExactly(new RoomPlayerId(0), new RoomPlayerId(1));
 
@@ -155,10 +158,11 @@ class RoomAggregateTest {
                     1,
                     2,
                     300,
+                    45,
                     null,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 CREATED_AT
@@ -260,10 +264,11 @@ class RoomAggregateTest {
                 2,
                 2,
                 300,
+                15,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt
@@ -292,10 +297,11 @@ class RoomAggregateTest {
                 2,
                 2,
                 null,
+                30,
                 RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -154,6 +154,7 @@ class RoomApiWebMvcTest {
         assertThat(body.at("/success/teamLeaders/0/draftPosition").asInt()).isEqualTo(1);
         assertThat(body.at("/success/teamLeaders/1/draftPosition").isNull()).isTrue();
         assertThat(body.at("/success/players/0/name").asText()).isEqualTo("선수1");
+        assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
         assertThat(body.at("/success/players/0/displayOrder").asInt()).isEqualTo(0);
         assertThat(body.at("/success/players/0/status").asText()).isEqualTo("AVAILABLE");
         assertThat(body.at("/success/players/1/name").asText()).isEqualTo("선수2");
@@ -223,6 +224,7 @@ class RoomApiWebMvcTest {
         assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
         assertThat(body.at("/success/budget").asInt()).isEqualTo(300);
         assertThat(body.at("/success/draftOrderStrategy").isNull()).isTrue();
+        assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
         assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
         assertThat(body.at("/success/players/1/status").asText()).isEqualTo("AVAILABLE");
         assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
@@ -683,10 +685,11 @@ class RoomApiWebMvcTest {
                 2,
                 2,
                 300,
+                15,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             createdAt
@@ -715,10 +718,11 @@ class RoomApiWebMvcTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 createdAt
@@ -746,12 +750,13 @@ class RoomApiWebMvcTest {
                     2,
                     3,
                     300,
+                    15,
                     null,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(2), "선수3", 2),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(3), "선수4", 3)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(2), "선수3", "MID", 2),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(3), "선수4", "ADC", 3)
                     )
                 ),
                 CREATED_AT
@@ -775,12 +780,13 @@ class RoomApiWebMvcTest {
                     2,
                     3,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(2), "선수3", 2),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(3), "선수4", 3)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(2), "선수3", "MID", 2),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(3), "선수4", "ADC", 3)
                     )
                 ),
                 CREATED_AT

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
@@ -177,10 +177,11 @@ class RoomAuctionDeadlineSchedulerTest {
                     2,
                     2,
                     300,
+                    15,
                     null,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 Instant.parse("2026-04-09T00:00:00Z")

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 
 class RoomAuctionTest {
     private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
+    private static final int PICK_BAN_TIME = 45;
     private static final String HOST_ID = "host-1";
     private static final String HOST_ACTION_TOKEN = "host-action-token";
     private static final String GUEST_ID = "guest-1";
@@ -34,7 +35,7 @@ class RoomAuctionTest {
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
 
         assertThat(room.getCurrentAuctionRound()).isEqualTo(1);
-        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(15));
+        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME));
     }
 
     @Test
@@ -50,7 +51,7 @@ class RoomAuctionTest {
     void deadline_가_지나면_입찰할_수_없다() {
         Room room = startedAuctionRoom();
 
-        assertThatThrownBy(() -> room.placeBid(new TeamLeaderId(HOST_ID), 100, CREATED_AT.plusSeconds(15)))
+        assertThatThrownBy(() -> room.placeBid(new TeamLeaderId(HOST_ID), 100, CREATED_AT.plusSeconds(PICK_BAN_TIME)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_BID_REQUIRES_OPEN_ROUND));
     }
@@ -65,11 +66,11 @@ class RoomAuctionTest {
         room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
         room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
 
-        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(16));
+        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
 
         assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
         assertThat(room.getCurrentAuctionRound()).isEqualTo(2);
-        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(31));
+        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds((PICK_BAN_TIME * 2L) + 1));
     }
 
     @Test
@@ -95,8 +96,8 @@ class RoomAuctionTest {
 
         Room repaired = settleAuction.settleIfDue(room.getCode());
 
-        assertThat(repaired.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(15));
-        assertThat(taskScheduler.activeScheduledInstants()).containsExactly(CREATED_AT.plusSeconds(15));
+        assertThat(repaired.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+        assertThat(taskScheduler.activeScheduledInstants()).containsExactly(CREATED_AT.plusSeconds(PICK_BAN_TIME));
     }
 
     @Test
@@ -168,7 +169,7 @@ class RoomAuctionTest {
         RoomBid firstBid = room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
         RoomBid secondBid = room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
 
-        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(15));
+        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
 
         assertThat(firstBid.sequence()).isEqualTo(new BidSequence(1));
         assertThat(secondBid.sequence()).isEqualTo(new BidSequence(2));
@@ -181,7 +182,7 @@ class RoomAuctionTest {
             .isEqualTo(150);
         assertThat(room.getPlayers().getFirst().getStatus()).isEqualTo(PlayerStatus.ASSIGNED);
         assertThat(room.getCurrentAuctionRound()).isEqualTo(2);
-        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(30));
+        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L));
     }
 
     @Test
@@ -190,9 +191,9 @@ class RoomAuctionTest {
         TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
 
         room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
-        room.settleAuction(CREATED_AT.plusSeconds(15));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
 
-        RoomBid nextRoundBid = room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(16));
+        RoomBid nextRoundBid = room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
 
         assertThat(nextRoundBid.sequence()).isEqualTo(new BidSequence(1));
         assertThat(nextRoundBid.round()).isEqualTo(2);
@@ -209,11 +210,11 @@ class RoomAuctionTest {
 
         room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
         room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
-        room.settleAuction(CREATED_AT.plusSeconds(15));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
 
-        room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(16));
-        room.placeBid(guestLeaderId, 130, CREATED_AT.plusSeconds(17));
-        room.settleAuction(CREATED_AT.plusSeconds(30));
+        room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
+        room.placeBid(guestLeaderId, 130, CREATED_AT.plusSeconds(PICK_BAN_TIME + 2L));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L));
 
         assertThat(room.getStatus()).isEqualTo(RoomStatus.COMPLETED);
         assertThat(room.getCurrentAuctionRoundEndsAt()).isNull();
@@ -315,10 +316,11 @@ class RoomAuctionTest {
                 2,
                 2,
                 300,
+                PICK_BAN_TIME,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             CREATED_AT
@@ -337,10 +339,11 @@ class RoomAuctionTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 CREATED_AT
@@ -371,10 +374,11 @@ class RoomAuctionTest {
                     2,
                     2,
                     null,
+                    30,
                     RoomTemplateSpec.DraftOrderStrategy.SNAKE,
                     List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                     )
                 ),
                 CREATED_AT

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class RoomDraftTest {
     private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
+    private static final List<String> POSITIONS = List.of("TOP", "JUNGLE", "MID", "ADC", "SUPPORT");
     private static final String HOST_ID = "host-1";
     private static final String HOST_ACTION_TOKEN = "host-action-token";
     private static final String GUEST_ID = "guest-1";
@@ -188,9 +189,15 @@ class RoomDraftTest {
                 2,
                 teamSize,
                 null,
+                30,
                 draftOrderStrategy,
                 IntStream.range(0, playerNames.size())
-                    .mapToObj(index -> new RoomTemplateSpec.Player(new RoomPlayerId(index), playerNames.get(index), index))
+                    .mapToObj(index -> new RoomTemplateSpec.Player(
+                        new RoomPlayerId(index),
+                        playerNames.get(index),
+                        POSITIONS.get(index % POSITIONS.size()),
+                        index
+                    ))
                     .toList()
             ),
             CREATED_AT
@@ -208,10 +215,11 @@ class RoomDraftTest {
                 2,
                 2,
                 300,
+                15,
                 null,
                 List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", 1)
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
                 )
             ),
             CREATED_AT

--- a/src/test/java/com/naminhyeok/fantazzk/template/CreateTemplateTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/CreateTemplateTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class CreateTemplateTest {
     @Test
-    void 경매_생성_command로_템플릿과_선수_컬렉션을_저장한다() {
+    void 경매_생성_command로_확장된_설정과_타입드_선수_컬렉션을_저장한다() {
         InMemoryTemplates templates = new InMemoryTemplates();
 
         CreateTemplate cut = new CreateTemplate(templates);
@@ -22,25 +22,33 @@ class CreateTemplateTest {
             cut.create(
                 new CreateTemplateCommand.Auction(
                     "경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     2,
                     500,
-                    List.of("선수A", "선수B")
+                    45,
+                    10,
+                    1,
+                    List.of(
+                        new CreateTemplateCommand.Player("선수A", "TOP", 0),
+                        new CreateTemplateCommand.Player("선수B", "JUNGLE", 1)
+                    )
                 )
             );
 
         assertThat(template.getName()).isEqualTo("경매전");
-        assertThat(template.getConfiguration()).isEqualTo(TemplateConfiguration.auction(2, 2, 500));
+        assertThat(template.getConfiguration())
+            .isEqualTo(TemplateConfiguration.auction(GameType.LEAGUE_OF_LEGENDS, 2, 2, 500, 45, 10, 1));
         assertThat(template.getPlayers())
-            .extracting("playerIndex", "name")
+            .extracting(TemplatePlayer::displayOrder, TemplatePlayer::name, TemplatePlayer::position)
             .containsExactly(
-                tuple(0, "선수A"),
-                tuple(1, "선수B")
+                tuple(0, "선수A", "TOP"),
+                tuple(1, "선수B", "JUNGLE")
             );
     }
 
     @Test
-    void 드래프트_생성_command로_드래프트_설정을_저장한다() {
+    void 드래프트_생성_command로_게임타입과_픽밴시간을_포함한_설정을_저장한다() {
         InMemoryTemplates templates = new InMemoryTemplates();
 
         CreateTemplate cut = new CreateTemplate(templates);
@@ -49,14 +57,20 @@ class CreateTemplateTest {
             cut.create(
                 new CreateTemplateCommand.Draft(
                     "드래프트전",
+                    GameType.OVERWATCH_2,
                     2,
                     2,
+                    30,
                     DraftOrderStrategy.SNAKE,
-                    List.of("선수1", "선수2")
+                    List.of(
+                        new CreateTemplateCommand.Player("선수1", "TANK", 0),
+                        new CreateTemplateCommand.Player("선수2", "SUPPORT", 1)
+                    )
                 )
             );
 
-        assertThat(template.getConfiguration()).isEqualTo(TemplateConfiguration.draft(2, 2, DraftOrderStrategy.SNAKE));
+        assertThat(template.getConfiguration())
+            .isEqualTo(TemplateConfiguration.draft(GameType.OVERWATCH_2, 2, 2, 30, DraftOrderStrategy.SNAKE));
         assertThat(template.getBudget()).isNull();
     }
 
@@ -68,10 +82,14 @@ class CreateTemplateTest {
             cut.create(
                 new CreateTemplateCommand.Auction(
                     "실패",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     2,
                     300,
-                    List.of("선수1")
+                    45,
+                    10,
+                    1,
+                    List.of(new CreateTemplateCommand.Player("선수1", "TOP", 0))
                 )
             )
         )

--- a/src/test/java/com/naminhyeok/fantazzk/template/FindTemplatesTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/FindTemplatesTest.java
@@ -32,8 +32,36 @@ class FindTemplatesTest {
     @Test
     void 목록_조회는_저장된_템플릿을_반환한다() {
         InMemoryTemplates templates = new InMemoryTemplates();
-        templates.save(Template.createAuction("첫째", 2, 2, 300, List.of("선수1", "선수2")));
-        templates.save(Template.createDraft("둘째", 2, 2, DraftOrderStrategy.SNAKE, List.of("선수1", "선수2")));
+        templates.save(
+            Template.createAuction(
+                "첫째",
+                GameType.LEAGUE_OF_LEGENDS,
+                2,
+                2,
+                300,
+                45,
+                10,
+                1,
+                List.of(
+                    new TemplatePlayer("선수1", "TOP", 0),
+                    new TemplatePlayer("선수2", "JUNGLE", 1)
+                )
+            )
+        );
+        templates.save(
+            Template.createDraft(
+                "둘째",
+                GameType.OVERWATCH_2,
+                2,
+                2,
+                30,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplatePlayer("선수1", "TANK", 0),
+                    new TemplatePlayer("선수2", "SUPPORT", 1)
+                )
+            )
+        );
 
         FindTemplates cut = new FindTemplates(templates);
 
@@ -43,36 +71,72 @@ class FindTemplatesTest {
     @Test
     void 상세_조회는_템플릿과_선수_목록을_함께_반환한다() {
         InMemoryTemplates templates = new InMemoryTemplates();
-        Template template = Template.createAuction("첫째", 2, 2, 300, List.of("선수1", "선수2"));
+        Template template =
+            Template.createAuction(
+                "첫째",
+                GameType.LEAGUE_OF_LEGENDS,
+                2,
+                2,
+                300,
+                45,
+                10,
+                1,
+                List.of(
+                    new TemplatePlayer("선수1", "TOP", 0),
+                    new TemplatePlayer("선수2", "JUNGLE", 1)
+                )
+            );
         templates.save(template);
 
         FindTemplates cut = new FindTemplates(templates);
         TemplateDetail detail = cut.getDetail(template.getId());
 
         assertThat(detail.template().getId()).isEqualTo(template.getId());
+        assertThat(detail.template().getGameType()).isEqualTo(GameType.LEAGUE_OF_LEGENDS);
+        assertThat(detail.template().getPickBanTime()).isEqualTo(45);
+        assertThat(detail.template().getMinBidUnit()).isEqualTo(10);
+        assertThat(detail.template().getPositionLimit()).isEqualTo(1);
         assertThat(detail.players())
-            .extracting("playerIndex", "name")
+            .extracting(TemplatePlayer::displayOrder, TemplatePlayer::name, TemplatePlayer::position)
             .containsExactly(
-                tuple(0, "선수1"),
-                tuple(1, "선수2")
+                tuple(0, "선수1", "TOP"),
+                tuple(1, "선수2", "JUNGLE")
             );
     }
 
     @Test
-    void 템플릿_카탈로그는_플레이어_blueprint에_aggregate_local_player_index를_노출한다() {
+    void 템플릿_카탈로그는_게임과_플레이어_blueprint를_확장된_형태로_노출한다() {
         InMemoryTemplates templates = new InMemoryTemplates();
-        Template template = Template.createAuction("첫째", 2, 2, 300, List.of("선수1", "선수2"));
+        Template template =
+            Template.createAuction(
+                "첫째",
+                GameType.LEAGUE_OF_LEGENDS,
+                2,
+                2,
+                300,
+                45,
+                10,
+                1,
+                List.of(
+                    new TemplatePlayer("선수1", "TOP", 0),
+                    new TemplatePlayer("선수2", "JUNGLE", 1)
+                )
+            );
         templates.save(template);
 
         ProvideTemplateCatalog catalog = new ProvideTemplateCatalog(new FindTemplates(templates));
 
         TemplateCatalog.TemplateBlueprint blueprint = catalog.getTemplate(template.getId().templateId());
 
+        assertThat(blueprint.gameType()).isEqualTo(TemplateCatalog.GameType.LEAGUE_OF_LEGENDS);
+        assertThat(blueprint.pickBanTime()).isEqualTo(45);
+        assertThat(blueprint.minBidUnit()).isEqualTo(10);
+        assertThat(blueprint.positionLimit()).isEqualTo(1);
         assertThat(blueprint.players())
-            .extracting("playerIndex", "name")
+            .extracting("playerIndex", "name", "position")
             .containsExactly(
-                tuple(0, "선수1"),
-                tuple(1, "선수2")
+                tuple(0, "선수1", "TOP"),
+                tuple(1, "선수2", "JUNGLE")
             );
     }
     private static final class InMemoryTemplates implements Templates {

--- a/src/test/java/com/naminhyeok/fantazzk/template/TemplateAggregateTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/TemplateAggregateTest.java
@@ -12,32 +12,44 @@ class TemplateAggregateTest {
     @Nested
     class 경매_템플릿_생성 {
         @Test
-        void 입력한_선수_순서를_aggregate_local_player_index와_이름으로_보관한다() {
+        void 입력한_선수의_이름_포지션_표시순서를_보관한다() {
             Template template =
                 Template.createAuction(
                     "주말 경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     2,
                     300,
-                    List.of("선수2", "선수1")
+                    45,
+                    10,
+                    1,
+                    List.of(
+                        new TemplatePlayer("선수2", "JUNGLE", 0),
+                        new TemplatePlayer("선수1", "TOP", 1)
+                    )
                 );
 
             assertThat(template.getPlayers())
-                .extracting("playerIndex", "name")
+                .extracting(TemplatePlayer::displayOrder, TemplatePlayer::name, TemplatePlayer::position)
                 .containsExactly(
-                    tuple(0, "선수2"),
-                    tuple(1, "선수1")
+                    tuple(0, "선수2", "JUNGLE"),
+                    tuple(1, "선수1", "TOP")
                 );
         }
+
         @Test
         void 필요한_선수_수를_정확히_강제한다() {
             assertThatThrownBy(() ->
                 Template.createAuction(
                     "주말 경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     2,
                     300,
-                    List.of("선수1")
+                    45,
+                    10,
+                    1,
+                    List.of(new TemplatePlayer("선수1", "TOP", 0))
                 )
             )
                 .isInstanceOf(IllegalArgumentException.class)
@@ -45,21 +57,56 @@ class TemplateAggregateTest {
         }
 
         @Test
+        void 선택한_게임_타입에서_지원하지_않는_포지션이면_거부한다() {
+            assertThatThrownBy(() ->
+                Template.createAuction(
+                    "주말 경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
+                    2,
+                    2,
+                    300,
+                    45,
+                    10,
+                    1,
+                    List.of(
+                        new TemplatePlayer("선수1", "TANK", 0),
+                        new TemplatePlayer("선수2", "SUPPORT", 1)
+                    )
+                )
+            )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("LEAGUE_OF_LEGENDS 게임은 TANK 포지션을 지원하지 않습니다");
+        }
+
+        @Test
         void 경매_설정을_flat_필드로_노출한다() {
             Template template =
                 Template.createAuction(
                     "경매전",
+                    GameType.LEAGUE_OF_LEGENDS,
                     2,
                     3,
                     300,
-                    List.of("선수1", "선수2", "선수3", "선수4")
+                    45,
+                    10,
+                    2,
+                    List.of(
+                        new TemplatePlayer("선수1", "TOP", 0),
+                        new TemplatePlayer("선수2", "JUNGLE", 1),
+                        new TemplatePlayer("선수3", "MID", 2),
+                        new TemplatePlayer("선수4", "ADC", 3)
+                    )
                 );
 
             assertThat(template.getName()).isEqualTo("경매전");
+            assertThat(template.getGameType()).isEqualTo(GameType.LEAGUE_OF_LEGENDS);
             assertThat(template.getMode()).isEqualTo(TemplateMode.AUCTION);
             assertThat(template.getTeamCount()).isEqualTo(2);
             assertThat(template.getTeamSize()).isEqualTo(3);
             assertThat(template.getBudget()).isEqualTo(300);
+            assertThat(template.getPickBanTime()).isEqualTo(45);
+            assertThat(template.getMinBidUnit()).isEqualTo(10);
+            assertThat(template.getPositionLimit()).isEqualTo(2);
             assertThat(template.getDraftOrderStrategy()).isNull();
             assertThat(template.getPicksPerTeam()).isEqualTo(2);
         }
@@ -72,14 +119,23 @@ class TemplateAggregateTest {
             Template template =
                 Template.createDraft(
                     "사내 리그 드래프트",
+                    GameType.OVERWATCH_2,
                     2,
                     2,
+                    30,
                     DraftOrderStrategy.FIXED,
-                    List.of("선수1", "선수2")
+                    List.of(
+                        new TemplatePlayer("선수1", "TANK", 0),
+                        new TemplatePlayer("선수2", "SUPPORT", 1)
+                    )
                 );
 
+            assertThat(template.getGameType()).isEqualTo(GameType.OVERWATCH_2);
             assertThat(template.getMode()).isEqualTo(TemplateMode.DRAFT);
             assertThat(template.getBudget()).isNull();
+            assertThat(template.getPickBanTime()).isEqualTo(30);
+            assertThat(template.getMinBidUnit()).isNull();
+            assertThat(template.getPositionLimit()).isNull();
             assertThat(template.getDraftOrderStrategy()).isEqualTo(DraftOrderStrategy.FIXED);
         }
     }

--- a/src/test/java/com/naminhyeok/fantazzk/template/TemplateConfigurationTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/TemplateConfigurationTest.java
@@ -7,28 +7,84 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class TemplateConfigurationTest {
+    @Test
+    void 지원_게임_타입은_리그오브레전드와_오버워치2다() {
+        assertThat(GameType.values()).containsExactly(
+            GameType.LEAGUE_OF_LEGENDS,
+            GameType.OVERWATCH_2
+        );
+    }
+
     @Nested
     class 경매_설정 {
         @Test
-        void 예산과_필요한_선수_수를_노출한다() {
-            TemplateConfiguration configuration = TemplateConfiguration.auction(2, 3, 300);
+        void 게임타입과_픽밴시간_최소입찰단위_포지션제한을_노출한다() {
+            TemplateConfiguration configuration =
+                TemplateConfiguration.auction(GameType.LEAGUE_OF_LEGENDS, 2, 3, 300, 45, 10, 2);
 
+            assertThat(configuration.getGameType()).isEqualTo(GameType.LEAGUE_OF_LEGENDS);
             assertThat(configuration.getMode()).isEqualTo(TemplateMode.AUCTION);
             assertThat(configuration.getBudget()).isEqualTo(300);
+            assertThat(configuration.getPickBanTime()).isEqualTo(45);
+            assertThat(configuration.getMinBidUnit()).isEqualTo(10);
+            assertThat(configuration.getPositionLimit()).isEqualTo(2);
             assertThat(configuration.requiredPlayerCount()).isEqualTo(4);
             assertThat(configuration.getDraftOrderStrategy()).isNull();
         }
 
         @Test
         void 예산이_필요하다() {
-            assertThatThrownBy(() -> TemplateConfiguration.from(TemplateMode.AUCTION, 2, 3, null, null))
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.LEAGUE_OF_LEGENDS,
+                    TemplateMode.AUCTION,
+                    2,
+                    3,
+                    null,
+                    45,
+                    10,
+                    2,
+                    null
+                )
+            )
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("경매 템플릿에는 예산이 필요합니다");
         }
 
         @Test
+        void 최소_입찰_단위가_필요하다() {
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.LEAGUE_OF_LEGENDS,
+                    TemplateMode.AUCTION,
+                    2,
+                    3,
+                    300,
+                    45,
+                    null,
+                    2,
+                    null
+                )
+            )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("경매 템플릿에는 최소 입찰 단위가 필요합니다");
+        }
+
+        @Test
         void 드래프트_순서_전략을_가질_수_없다() {
-            assertThatThrownBy(() -> TemplateConfiguration.from(TemplateMode.AUCTION, 2, 3, 300, DraftOrderStrategy.SNAKE))
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.LEAGUE_OF_LEGENDS,
+                    TemplateMode.AUCTION,
+                    2,
+                    3,
+                    300,
+                    45,
+                    10,
+                    2,
+                    DraftOrderStrategy.SNAKE
+                )
+            )
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("경매 템플릿에는 드래프트 순서 전략을 지정할 수 없습니다");
         }
@@ -37,28 +93,94 @@ class TemplateConfigurationTest {
     @Nested
     class 드래프트_설정 {
         @Test
-        void 순서_전략과_필요한_선수_수를_노출한다() {
+        void 게임타입과_픽밴시간_순서전략과_필요한_선수_수를_노출한다() {
             TemplateConfiguration configuration =
-                TemplateConfiguration.draft(2, 3, DraftOrderStrategy.SNAKE);
+                TemplateConfiguration.draft(GameType.OVERWATCH_2, 2, 3, 30, DraftOrderStrategy.SNAKE);
 
+            assertThat(configuration.getGameType()).isEqualTo(GameType.OVERWATCH_2);
             assertThat(configuration.getMode()).isEqualTo(TemplateMode.DRAFT);
             assertThat(configuration.getBudget()).isNull();
+            assertThat(configuration.getPickBanTime()).isEqualTo(30);
+            assertThat(configuration.getMinBidUnit()).isNull();
+            assertThat(configuration.getPositionLimit()).isNull();
             assertThat(configuration.getDraftOrderStrategy()).isEqualTo(DraftOrderStrategy.SNAKE);
             assertThat(configuration.requiredPlayerCount()).isEqualTo(4);
         }
 
         @Test
         void 순서_전략이_필요하다() {
-            assertThatThrownBy(() -> TemplateConfiguration.from(TemplateMode.DRAFT, 2, 3, null, null))
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.OVERWATCH_2,
+                    TemplateMode.DRAFT,
+                    2,
+                    3,
+                    null,
+                    30,
+                    null,
+                    null,
+                    null
+                )
+            )
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("드래프트 템플릿에는 순서 전략이 필요합니다");
         }
 
         @Test
         void 예산을_가질_수_없다() {
-            assertThatThrownBy(() -> TemplateConfiguration.from(TemplateMode.DRAFT, 2, 3, 300, DraftOrderStrategy.SNAKE))
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.OVERWATCH_2,
+                    TemplateMode.DRAFT,
+                    2,
+                    3,
+                    300,
+                    30,
+                    null,
+                    null,
+                    DraftOrderStrategy.SNAKE
+                )
+            )
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("드래프트 템플릿에는 예산을 지정할 수 없습니다");
+        }
+
+        @Test
+        void 최소_입찰_단위를_가질_수_없다() {
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.OVERWATCH_2,
+                    TemplateMode.DRAFT,
+                    2,
+                    3,
+                    null,
+                    30,
+                    10,
+                    null,
+                    DraftOrderStrategy.SNAKE
+                )
+            )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("드래프트 템플릿에는 최소 입찰 단위를 지정할 수 없습니다");
+        }
+
+        @Test
+        void 포지션_제한을_가질_수_없다() {
+            assertThatThrownBy(() ->
+                TemplateConfiguration.from(
+                    GameType.OVERWATCH_2,
+                    TemplateMode.DRAFT,
+                    2,
+                    3,
+                    null,
+                    30,
+                    null,
+                    2,
+                    DraftOrderStrategy.SNAKE
+                )
+            )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("드래프트 템플릿에는 포지션 제한을 지정할 수 없습니다");
         }
     }
 
@@ -66,23 +188,30 @@ class TemplateConfigurationTest {
     class 공통_검증 {
         @Test
         void 팀_수는_0보다_커야_한다() {
-            assertThatThrownBy(() -> TemplateConfiguration.auction(0, 2, 300))
+            assertThatThrownBy(() -> TemplateConfiguration.auction(GameType.LEAGUE_OF_LEGENDS, 0, 2, 300, 45, 10, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("팀 수는 0보다 커야 합니다");
         }
 
         @Test
         void 팀_크기는_0보다_커야_한다() {
-            assertThatThrownBy(() -> TemplateConfiguration.draft(2, 0, DraftOrderStrategy.FIXED))
+            assertThatThrownBy(() -> TemplateConfiguration.draft(GameType.OVERWATCH_2, 2, 0, 30, DraftOrderStrategy.FIXED))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("팀 크기는 0보다 커야 합니다");
         }
 
         @Test
         void 예산은_0보다_커야_한다() {
-            assertThatThrownBy(() -> TemplateConfiguration.auction(2, 2, 0))
+            assertThatThrownBy(() -> TemplateConfiguration.auction(GameType.LEAGUE_OF_LEGENDS, 2, 2, 0, 45, 10, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("예산은 0보다 커야 합니다");
+        }
+
+        @Test
+        void 픽밴_시간은_0보다_커야_한다() {
+            assertThatThrownBy(() -> TemplateConfiguration.draft(GameType.OVERWATCH_2, 2, 2, 0, DraftOrderStrategy.FIXED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("픽밴 시간은 0보다 커야 합니다");
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
- 템플릿 도메인/API를 확장해 `gameType`, `pickBanTime`, `minBidUnit`, `positionLimit`, 그리고 `players[{ name, position }]` 형태의 선수 정보를 지원하도록 변경했습니다.
- 지원 게임 타입을 `LEAGUE_OF_LEGENDS`, `OVERWATCH_2`로 제한했습니다.
- 선수 `position` 정보를 템플릿 카탈로그, 방 생성, 방 영속성, 방 API 응답까지 전파하도록 반영했습니다.
- 방 경매 진행 시 사용하던 고정 `15초` 제한 시간을 제거하고, 템플릿의 `pickBanTime`을 방에 저장해 실제 경매 deadline 계산에 사용하도록 바꿨습니다.
- 템플릿 필드, 방 `pick_ban_time`, 방 선수 `position`에 대한 Liquibase 변경셋을 추가했습니다.
- 새 요청 분기 검증 실패가 generic `BAD_REQUEST`가 아니라 구체적인 `TEMPLATE_*` 에러 코드로 내려가도록 정리했습니다.

## 변경 이유
프론트엔드에서 템플릿 기반 드래프트/경매 플로우를 구현하려면, 서버가 누락된 템플릿 필드와 타입이 있는 선수 정보를 제공해야 했습니다. 또한 경매 진행 시간도 더 이상 서버 상수에 의존하지 않고, 템플릿 설정값인 `pickBanTime`을 실제 런타임 규칙으로 사용해야 했습니다.

## 영향 범위
- 템플릿 생성/목록/상세 API가 프론트엔드가 기대하는 확장된 응답 형태를 반환합니다.
- 방 API가 템플릿에서 온 선수 `position` 정보를 유지하고 응답합니다.
- 새로 생성되는 방의 경매 deadline이 템플릿 설정 기반으로 동작합니다.
- 템플릿 관련 마이그레이션은 기존 템플릿 데이터가 있는 환경에서는 안전하지 않은 자동 backfill 대신 명시적으로 중단되도록 구성했습니다.

## 마이그레이션 참고
이 변경은 대상 환경에 기존 `template` / `template_player` 데이터가 없다는 전제를 둡니다. 해당 데이터가 이미 존재하는 환경에서는 unsafe한 자동 변환을 시도하지 않고 changelog가 명시적으로 중단되도록 했습니다.

## 검증
- `./gradlew check`
- `./gradlew integrationTest`

- closed #66 