### PR TITLE
드래프트 시작 순서 미리보기와 자리 변경 충돌 처리를 추가합니다

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
@@ -172,4 +172,49 @@ class RoomServiceIntegrationTest {
             .extracting(RoomTeamLeader::getDraftPosition)
             .isNull();
     }
+
+    @Test
+    void 드래프트_자리_선택과_취소는_응답_preview와_시작가능_상태를_함께_갱신한다() {
+        var template =
+            templateFixture.createDraftTemplateId(
+                "드래프트전",
+                2,
+                2,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
+                )
+            );
+
+        Room created = createRoom.create(template, "호스트");
+        RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
+
+        selectDraftPosition.select(created.getCode(), created.getLeaders().getFirst().getActionToken(), 2);
+        selectDraftPosition.select(created.getCode(), guest.getActionToken(), 1);
+
+        Room afterSelect = rooms.findByCode(created.getCode()).orElseThrow();
+        RoomResponse selectableResponse = RoomResponse.from(afterSelect);
+
+        assertThat(selectableResponse.startReadiness()).isEqualTo("STARTABLE");
+        assertThat(selectableResponse.draftOrderPreview().slots())
+            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+            .containsExactly(
+                tuple(1, guest.getId().value(), "게스트"),
+                tuple(2, created.getLeaders().getFirst().getId().value(), "호스트")
+            );
+
+        clearDraftPosition.clear(created.getCode(), guest.getActionToken());
+
+        Room afterClear = rooms.findByCode(created.getCode()).orElseThrow();
+        RoomResponse clearedResponse = RoomResponse.from(afterClear);
+
+        assertThat(clearedResponse.startReadiness()).isEqualTo(RoomStartReadiness.WAITING_FOR_DRAFT_POSITIONS.name());
+        assertThat(clearedResponse.draftOrderPreview().slots())
+            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+            .containsExactly(
+                tuple(1, null, null),
+                tuple(2, created.getLeaders().getFirst().getId().value(), "호스트")
+            );
+    }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
@@ -1,21 +1,41 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
 class ClearDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional
     public void clear(String code, String actionToken) {
-        Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-        RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-        room.clearDraftPosition(caller.getId());
-        rooms.save(room);
+        inTransaction(() -> {
+            Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
+            RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
+            room.clearDraftPosition(caller.getId());
+            rooms.save(room);
+            return room;
+        });
+    }
+
+    private <T> T inTransaction(TransactionCallback<T> callback) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        try {
+            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
+        } catch (OptimisticLockingFailureException ex) {
+            throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
+        }
+    }
+
+    @FunctionalInterface
+    private interface TransactionCallback<T> {
+        T execute();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderPreviewResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderPreviewResponse.java
@@ -1,0 +1,32 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+record DraftOrderPreviewResponse(List<DraftOrderSlotResponse> slots) {
+    static DraftOrderPreviewResponse from(Room room) {
+        if (room.getMode() != RoomMode.DRAFT) {
+            return null;
+        }
+
+        Map<Integer, RoomTeamLeader> leadersByDraftPosition = new HashMap<>();
+        room.getLeaders().stream()
+            .filter(leader -> leader.getDraftPosition() != null)
+            .forEach(leader -> leadersByDraftPosition.put(leader.getDraftPosition(), leader));
+
+        List<DraftOrderSlotResponse> slots =
+            IntStream.rangeClosed(1, room.getTeamCount())
+                .mapToObj(draftPosition -> {
+                    RoomTeamLeader leader = leadersByDraftPosition.get(draftPosition);
+                    if (leader == null) {
+                        return DraftOrderSlotResponse.empty(draftPosition);
+                    }
+                    return DraftOrderSlotResponse.from(draftPosition, leader);
+                })
+                .toList();
+
+        return new DraftOrderPreviewResponse(slots);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderSlotResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderSlotResponse.java
@@ -1,0 +1,19 @@
+package com.naminhyeok.fantazzk.room;
+
+record DraftOrderSlotResponse(
+    int draftPosition,
+    String leaderId,
+    String nickname
+) {
+    static DraftOrderSlotResponse empty(int draftPosition) {
+        return new DraftOrderSlotResponse(draftPosition, null, null);
+    }
+
+    static DraftOrderSlotResponse from(int draftPosition, RoomTeamLeader leader) {
+        return new DraftOrderSlotResponse(
+            draftPosition,
+            leader.getId().value(),
+            leader.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
@@ -1,4 +1,5 @@
 package com.naminhyeok.fantazzk.room;
+
 import java.util.List;
 
 record RoomResponse(
@@ -10,6 +11,7 @@ record RoomResponse(
     Integer budget,
     String draftOrderStrategy,
     String startReadiness,
+    DraftOrderPreviewResponse draftOrderPreview,
     List<TeamLeaderResponse> teamLeaders,
     List<RoomPlayerResponse> players,
     List<RoomMemberResponse> members,
@@ -25,6 +27,7 @@ record RoomResponse(
             room.getBudget(),
             room.getDraftOrderStrategy() == null ? null : room.getDraftOrderStrategy().name(),
             room.getStartReadiness().name(),
+            DraftOrderPreviewResponse.from(room),
             room.getLeaders().stream().map(TeamLeaderResponse::from).toList(),
             room.getPlayers().stream().map(RoomPlayerResponse::from).toList(),
             room.getMembers().stream().map(RoomMemberResponse::from).toList(),

--- a/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
@@ -1,21 +1,41 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
 class SelectDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional
     public void select(String code, String actionToken, int draftPosition) {
-        Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-        RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-        room.selectDraftPosition(caller.getId(), draftPosition);
-        rooms.save(room);
+        inTransaction(() -> {
+            Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
+            RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
+            room.selectDraftPosition(caller.getId(), draftPosition);
+            rooms.save(room);
+            return room;
+        });
+    }
+
+    private <T> T inTransaction(TransactionCallback<T> callback) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        try {
+            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
+        } catch (OptimisticLockingFailureException ex) {
+            throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
+        }
+    }
+
+    @FunctionalInterface
+    private interface TransactionCallback<T> {
+        T execute();
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -153,6 +153,12 @@ class RoomApiWebMvcTest {
         assertThat(body.at("/success/startReadiness").asText()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
         assertThat(body.at("/success/teamLeaders/0/draftPosition").asInt()).isEqualTo(1);
         assertThat(body.at("/success/teamLeaders/1/draftPosition").isNull()).isTrue();
+        assertThat(body.at("/success/draftOrderPreview/slots/0/draftPosition").asInt()).isEqualTo(1);
+        assertThat(body.at("/success/draftOrderPreview/slots/0/leaderId").asText()).isEqualTo(HOST_ID);
+        assertThat(body.at("/success/draftOrderPreview/slots/0/nickname").asText()).isEqualTo("호스트");
+        assertThat(body.at("/success/draftOrderPreview/slots/1/draftPosition").asInt()).isEqualTo(2);
+        assertThat(body.at("/success/draftOrderPreview/slots/1/leaderId").isNull()).isTrue();
+        assertThat(body.at("/success/draftOrderPreview/slots/1/nickname").isNull()).isTrue();
         assertThat(body.at("/success/players/0/name").asText()).isEqualTo("선수1");
         assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
         assertThat(body.at("/success/players/0/displayOrder").asInt()).isEqualTo(0);
@@ -224,6 +230,7 @@ class RoomApiWebMvcTest {
         assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
         assertThat(body.at("/success/budget").asInt()).isEqualTo(300);
         assertThat(body.at("/success/draftOrderStrategy").isNull()).isTrue();
+        assertThat(body.at("/success/draftOrderPreview").isNull()).isTrue();
         assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
         assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
         assertThat(body.at("/success/players/1/status").asText()).isEqualTo("AVAILABLE");
@@ -609,12 +616,19 @@ class RoomApiWebMvcTest {
                 assertThat(response.success().startReadiness()).isEqualTo("STARTABLE");
                 assertThat(response.success().teamLeaders()).extracting(TeamLeaderResponse::draftPosition)
                     .containsExactly(1, 2);
+                assertThat(response.success().draftOrderPreview().slots())
+                    .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+                    .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(1, HOST_ID, "호스트"),
+                        org.assertj.core.groups.Tuple.tuple(2, GUEST_ID, "게스트")
+                    );
             });
     }
 
     @Test
     void clearDraftPosition은_header가_있으면_성공한다() throws Exception {
         Room room = waitingDraftRoom();
+        room.clearDraftPosition(new TeamLeaderId(HOST_ID));
         doNothing().when(clearDraftPosition).clear(ROOM_CODE, HOST_TOKEN);
         given(getRoom.get(ROOM_CODE)).willReturn(room);
 
@@ -628,7 +642,13 @@ class RoomApiWebMvcTest {
             .satisfies(response -> {
                 assertThat(response.success().startReadiness()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
                 assertThat(response.success().teamLeaders()).extracting(TeamLeaderResponse::draftPosition)
-                    .containsExactly(1, null);
+                    .containsExactly(null, null);
+                assertThat(response.success().draftOrderPreview().slots())
+                    .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+                    .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(1, null, null),
+                        org.assertj.core.groups.Tuple.tuple(2, null, null)
+                    );
             });
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -295,6 +295,37 @@ class RoomAuctionTest {
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
     }
 
+    @Test
+    void selectDraftPosition은_optimistic_lock을_room_conflict로_번역한다() {
+        Room room = waitingDraftRoomForPositionChange();
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
+        SelectDraftPosition selectDraftPosition = new SelectDraftPosition(
+            rooms,
+            new RoomActionAuthorizer(),
+            new StubTransactionManager()
+        );
+
+        assertThatThrownBy(() -> selectDraftPosition.select(room.getCode(), HOST_ACTION_TOKEN, 1))
+            .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
+    }
+
+    @Test
+    void clearDraftPosition은_optimistic_lock을_room_conflict로_번역한다() {
+        Room room = waitingDraftRoomForPositionChange();
+        room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
+        ClearDraftPosition clearDraftPosition = new ClearDraftPosition(
+            rooms,
+            new RoomActionAuthorizer(),
+            new StubTransactionManager()
+        );
+
+        assertThatThrownBy(() -> clearDraftPosition.clear(room.getCode(), HOST_ACTION_TOKEN))
+            .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
+    }
+
     private static void assertRoomError(CoreException ex, RoomErrorType expected) {
         assertThat(ex.getError()).isEqualTo(expected);
     }
@@ -387,6 +418,31 @@ class RoomAuctionTest {
         room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
         room.selectDraftPosition(new TeamLeaderId(GUEST_ID), 2);
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
+        return room;
+    }
+
+    private static Room waitingDraftRoomForPositionChange() {
+        Room room =
+            Room.createFromTemplate(
+                "DRF001",
+                new TeamLeaderId(HOST_ID),
+                "호스트",
+                HOST_ACTION_TOKEN,
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.DRAFT,
+                    2,
+                    2,
+                    null,
+                    PICK_BAN_TIME,
+                    RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                    List.of(
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+                    )
+                ),
+                CREATED_AT
+            );
+        room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
         return room;
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
@@ -1,0 +1,108 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RoomResponseTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
+    private static final String HOST_ID = "host-1";
+    private static final String HOST_ACTION_TOKEN = "host-action-token";
+    private static final String GUEST_ONE_ID = "guest-1";
+    private static final String GUEST_ONE_ACTION_TOKEN = "guest-1-action-token";
+    private static final String GUEST_TWO_ID = "guest-2";
+    private static final String GUEST_TWO_ACTION_TOKEN = "guest-2-action-token";
+
+    @Test
+    void 드래프트_방_응답은_자리_기준_예상_시작_순서를_슬롯으로_반환한다() {
+        Room room = threeTeamDraftRoom();
+        room.join(new TeamLeaderId(GUEST_ONE_ID), "게스트1", GUEST_ONE_ACTION_TOKEN);
+        room.join(new TeamLeaderId(GUEST_TWO_ID), "게스트2", GUEST_TWO_ACTION_TOKEN);
+        room.selectDraftPosition(new TeamLeaderId(HOST_ID), 2);
+        room.selectDraftPosition(new TeamLeaderId(GUEST_ONE_ID), 1);
+        room.selectDraftPosition(new TeamLeaderId(GUEST_TWO_ID), 3);
+
+        RoomResponse response = RoomResponse.from(room);
+
+        assertThat(response.draftOrderPreview()).isNotNull();
+        assertThat(response.draftOrderPreview().slots())
+            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+            .containsExactly(
+                tuple(1, GUEST_ONE_ID, "게스트1"),
+                tuple(2, HOST_ID, "호스트"),
+                tuple(3, GUEST_TWO_ID, "게스트2")
+            );
+    }
+
+    @Test
+    void 드래프트_방_응답은_비어있는_자리를_null_슬롯으로_반환한다() {
+        Room room = threeTeamDraftRoom();
+        room.join(new TeamLeaderId(GUEST_ONE_ID), "게스트1", GUEST_ONE_ACTION_TOKEN);
+        room.selectDraftPosition(new TeamLeaderId(HOST_ID), 2);
+
+        RoomResponse response = RoomResponse.from(room);
+
+        assertThat(response.draftOrderPreview()).isNotNull();
+        assertThat(response.draftOrderPreview().slots())
+            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
+            .containsExactly(
+                tuple(1, null, null),
+                tuple(2, HOST_ID, "호스트"),
+                tuple(3, null, null)
+            );
+    }
+
+    @Test
+    void 경매_방_응답은_드래프트_preview를_포함하지_않는다() {
+        Room room =
+            Room.createFromTemplate(
+                "AUC001",
+                new TeamLeaderId(HOST_ID),
+                "호스트",
+                HOST_ACTION_TOKEN,
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.AUCTION,
+                    2,
+                    2,
+                    300,
+                    15,
+                    null,
+                    List.of(
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+                    )
+                ),
+                CREATED_AT
+            );
+
+        RoomResponse response = RoomResponse.from(room);
+
+        assertThat(response.draftOrderPreview()).isNull();
+    }
+
+    private Room threeTeamDraftRoom() {
+        return Room.createFromTemplate(
+            "DRF001",
+            new TeamLeaderId(HOST_ID),
+            "호스트",
+            HOST_ACTION_TOKEN,
+            new RoomTemplateSpec(
+                RoomTemplateSpec.Mode.DRAFT,
+                3,
+                2,
+                null,
+                30,
+                RoomTemplateSpec.DraftOrderStrategy.SNAKE,
+                List.of(
+                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1),
+                    new RoomTemplateSpec.Player(new RoomPlayerId(2), "선수3", "MID", 2)
+                )
+            ),
+            CREATED_AT
+        );
+    }
+}


### PR DESCRIPTION
## 요약
- 드래프트 방 조회 응답에 `draftOrderPreview.slots`를 추가해 현재 기준 1라운드 시작 순서를 슬롯 단위로 노출했습니다
- 자리 선택/취소 서비스도 optimistic lock 충돌을 `ROOM_CONCURRENT_MODIFICATION`로 번역하도록 맞췄습니다
- 단위 테스트, WebMvc 테스트, 통합 테스트에 시작 순서 미리보기와 충돌 처리 회귀를 추가했습니다

## 왜 변경했는지
이슈 #51은 호스트와 게스트가 대기 상태에서 각자 드래프트 자리를 선택하고, 그 결과를 기준으로 시작 가능 상태와 실제 1라운드 시작 순서를 명확히 표현할 수 있어야 합니다.

기존 구현은 `draftPosition` 자체는 가지고 있었지만, 조회 응답에서 FE가 그대로 렌더링할 수 있는 시작 순서 preview가 없었습니다. 또한 자리 선택/취소는 시작/입찰/픽과 달리 optimistic lock 충돌을 일관된 도메인 오류로 번역하지 않아 동시 수정 시 API 계약이 흔들릴 수 있었습니다.

## 변경 사항
### 응답 계약
- `RoomResponse`에 `draftOrderPreview`를 추가했습니다
- 드래프트 방은 항상 `1..teamCount` 슬롯을 반환합니다
- 비어 있는 자리는 `leaderId`, `nickname`이 `null`인 슬롯으로 표현합니다
- 경매 방은 `draftOrderPreview`를 `null`로 유지합니다

### 동시성 처리
- `SelectDraftPosition`
- `ClearDraftPosition`

위 두 서비스가 optimistic lock 충돌을 `ROOM_CONCURRENT_MODIFICATION`로 번역하도록 `TransactionTemplate` 기반 패턴으로 맞췄습니다.

### 테스트
- `RoomResponseTest`에서 preview 계산 규칙을 고정했습니다
- `RoomApiWebMvcTest`에서 `GET room`, 자리 선택, 자리 취소 응답 계약을 검증했습니다
- `RoomServiceIntegrationTest`에서 선택/취소 후 preview와 시작 가능 상태가 함께 갱신되는지 검증했습니다
- `RoomAuctionTest`에 자리 선택/취소 서비스의 optimistic lock 번역 회귀를 추가했습니다

## 사용자 영향
- 클라이언트는 각 팀장의 `draftPosition`만 직접 정렬하지 않아도 현재 기준 예상 시작 순서를 바로 렌더링할 수 있습니다
- 빈 자리와 이미 선점된 자리를 같은 구조에서 표현할 수 있습니다
- 자리 선택/변경/취소 경쟁 상황에서도 일관된 `409 ROOM_CONCURRENT_MODIFICATION` 응답을 기대할 수 있습니다

## 검증
- `./gradlew check`
- `./gradlew integrationTest`

## 관련 이슈
- closes #51