### PR TITLE
Room 도메인 예외를 CoreException/RoomErrorType 체계로 정리한다

### DIFF
--- a/src/main/java/com/naminhyeok/fantazzk/GlobalExceptionHandler.java
+++ b/src/main/java/com/naminhyeok/fantazzk/GlobalExceptionHandler.java
@@ -16,6 +16,13 @@ public class GlobalExceptionHandler {
         return respond(ex, ex.getError(), ex.getData());
     }
 
+    @ExceptionHandler(InvalidDomainStateException.class)
+    ResponseEntity<ApiResponse<Void>> handleInvalidDomainStateException(InvalidDomainStateException ex) {
+        log.error("Invalid domain state: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(ex.getError().getStatus())
+            .body(ApiResponse.error(ex.getError()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
         LinkedHashMap<String, String> errors = new LinkedHashMap<>();

--- a/src/main/java/com/naminhyeok/fantazzk/InvalidDomainStateException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/InvalidDomainStateException.java
@@ -1,0 +1,14 @@
+package com.naminhyeok.fantazzk;
+
+public abstract class InvalidDomainStateException extends RuntimeException {
+    private final ErrorDescriptor error;
+
+    protected InvalidDomainStateException(String message, ErrorDescriptor error) {
+        super(message);
+        this.error = error;
+    }
+
+    public ErrorDescriptor getError() {
+        return error;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -226,7 +226,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             throw CoreException.of(RoomErrorType.ROOM_BID_REQUIRES_AUCTION_MODE);
         }
         if (currentAuctionRound == null) {
-            throw new IllegalStateException("현재 경매 라운드가 없습니다");
+            throw RoomStateInvalidException.auctionRoundMissing();
         }
         if (currentAuctionRoundEndsAt != null && !now.isBefore(currentAuctionRoundEndsAt)) {
             throw CoreException.of(RoomErrorType.ROOM_BID_REQUIRES_OPEN_ROUND);
@@ -293,7 +293,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             throw CoreException.of(RoomErrorType.ROOM_BID_REQUIRES_AUCTION_MODE);
         }
         if (currentAuctionRound == null) {
-            throw new IllegalStateException("현재 경매 라운드가 없습니다");
+            throw RoomStateInvalidException.auctionRoundMissing();
         }
         if (currentAuctionRoundEndsAt == null) {
             currentAuctionRoundEndsAt = now;
@@ -306,7 +306,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             players.stream()
                 .filter(it -> it.getStatus() == PlayerStatus.AVAILABLE)
                 .min(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
-                .orElseThrow(() -> new IllegalStateException("경매할 선수를 찾을 수 없습니다"));
+                .orElseThrow(RoomStateInvalidException::auctionTargetMissing);
 
         RoomBid winningBid =
             bids.stream()
@@ -326,7 +326,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             leaders.stream()
                 .filter(it -> it.getId().equals(winningBid.teamLeaderId()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("낙찰한 팀장을 찾을 수 없습니다"));
+                .orElseThrow(() -> RoomStateInvalidException.auctionWinnerMissing(winningBid.teamLeaderId()));
 
         target.assign();
         winner.spend(winningBid.amount());
@@ -413,7 +413,7 @@ class Room implements AggregateRoot<Room, RoomId> {
     private DraftProgress requireCurrentDraftProgress() {
         DraftProgress progress = currentDraftProgress();
         if (progress == null) {
-            throw new IllegalStateException("현재 드래프트 턴이 없습니다");
+            throw RoomStateInvalidException.draftTurnMissing();
         }
         return progress;
     }
@@ -426,6 +426,6 @@ class Room implements AggregateRoot<Room, RoomId> {
         return leaders.stream()
             .filter(leader -> leader.getId().equals(teamLeaderId))
             .findFirst()
-            .orElseThrow(() -> new IllegalStateException("팀장을 찾을 수 없습니다"));
+            .orElseThrow(() -> RoomStateInvalidException.leaderMissing(teamLeaderId));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -380,7 +380,11 @@ class Room implements AggregateRoot<Room, RoomId> {
             return null;
         }
 
-        return DraftProgress.from(getLeaderIdsInDraftOrder(), draftOrderStrategy, currentTurnIndex);
+        try {
+            return DraftProgress.from(getLeaderIdsInDraftOrder(), draftOrderStrategy, currentTurnIndex);
+        } catch (IllegalArgumentException ex) {
+            throw RoomStateInvalidException.draftLeaderOrderEmpty();
+        }
     }
 
     private void validateDraftPositionChange(int draftPosition) {
@@ -405,6 +409,14 @@ class Room implements AggregateRoot<Room, RoomId> {
     }
 
     private List<RoomTeamLeader> getLeadersInDraftOrder() {
+        if (leaders.isEmpty()) {
+            throw RoomStateInvalidException.draftLeaderOrderEmpty();
+        }
+        RoomTeamLeader leaderWithoutDraftPosition =
+            leaders.stream().filter(leader -> leader.getDraftPosition() == null).findFirst().orElse(null);
+        if (leaderWithoutDraftPosition != null) {
+            throw RoomStateInvalidException.draftPositionMissing(leaderWithoutDraftPosition.getId());
+        }
         return leaders.stream()
             .sorted(Comparator.comparingInt(RoomTeamLeader::getDraftPosition))
             .toList();

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
@@ -53,7 +53,11 @@ class RoomAuctionDeadlineScheduler {
         Instant now = Instant.now(clock);
         for (Room room : collectSchedulableRooms()) {
             if (room.getCurrentAuctionRoundEndsAt() == null || !room.getCurrentAuctionRoundEndsAt().isAfter(now)) {
-                schedule(settleAuction.settleIfDue(room.getCode()));
+                try {
+                    schedule(settleAuction.settleIfDue(room.getCode()));
+                } catch (RoomStateInvalidException ignored) {
+                    continue;
+                }
                 continue;
             }
             schedule(room);

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomErrorType.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomErrorType.java
@@ -20,6 +20,12 @@ enum RoomErrorType implements ErrorDescriptor {
         "방 코드를 생성하지 못했습니다",
         Level.ERROR
     ),
+    ROOM_STATE_INVALID(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "ROOM_STATE_INVALID",
+        "방 상태가 올바르지 않습니다. 잠시 후 다시 시도해 주세요",
+        Level.ERROR
+    ),
     ROOM_JOIN_REQUIRES_WAITING(
         HttpStatus.CONFLICT,
         "ROOM_JOIN_REQUIRES_WAITING",

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
@@ -1,0 +1,33 @@
+package com.naminhyeok.fantazzk.room;
+
+import com.naminhyeok.fantazzk.InvalidDomainStateException;
+
+class RoomStateInvalidException extends InvalidDomainStateException {
+    private RoomStateInvalidException(String message) {
+        super(message, RoomErrorType.ROOM_STATE_INVALID);
+    }
+
+    static RoomStateInvalidException auctionRoundMissing() {
+        return new RoomStateInvalidException("경매 라운드를 찾을 수 없습니다");
+    }
+
+    static RoomStateInvalidException auctionTargetMissing() {
+        return new RoomStateInvalidException("경매 대상 선수를 찾을 수 없습니다");
+    }
+
+    static RoomStateInvalidException auctionWinnerMissing(TeamLeaderId winnerId) {
+        return new RoomStateInvalidException("경매 낙찰 팀장을 찾을 수 없습니다: " + leaderIdValue(winnerId));
+    }
+
+    static RoomStateInvalidException draftTurnMissing() {
+        return new RoomStateInvalidException("드래프트 턴 정보를 찾을 수 없습니다");
+    }
+
+    static RoomStateInvalidException leaderMissing(TeamLeaderId leaderId) {
+        return new RoomStateInvalidException("팀장을 찾을 수 없습니다: " + leaderIdValue(leaderId));
+    }
+
+    private static String leaderIdValue(TeamLeaderId leaderId) {
+        return leaderId == null ? "null" : leaderId.value();
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
@@ -37,6 +37,14 @@ final class RoomStateInvalidException extends InvalidDomainStateException {
         return new RoomStateInvalidException("드래프트 턴 정보를 찾을 수 없습니다");
     }
 
+    static RoomStateInvalidException draftPositionMissing(TeamLeaderId leaderId) {
+        return new RoomStateInvalidException("드래프트 순서를 계산할 수 없습니다: draftPosition missing, leaderId=" + leaderIdValue(leaderId));
+    }
+
+    static RoomStateInvalidException draftLeaderOrderEmpty() {
+        return new RoomStateInvalidException("드래프트 순서가 비어 있습니다");
+    }
+
     static RoomStateInvalidException leaderMissing(TeamLeaderId leaderId) {
         return new RoomStateInvalidException("팀장을 찾을 수 없습니다: " + leaderIdValue(leaderId));
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
@@ -2,7 +2,7 @@ package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.InvalidDomainStateException;
 
-class RoomStateInvalidException extends InvalidDomainStateException {
+final class RoomStateInvalidException extends InvalidDomainStateException {
     private RoomStateInvalidException(String message) {
         super(message, RoomErrorType.ROOM_STATE_INVALID);
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
@@ -19,6 +19,20 @@ final class RoomStateInvalidException extends InvalidDomainStateException {
         return new RoomStateInvalidException("경매 낙찰 팀장을 찾을 수 없습니다: " + leaderIdValue(winnerId));
     }
 
+    static RoomStateInvalidException auctionWinnerBudgetMissing(TeamLeaderId winnerId) {
+        return new RoomStateInvalidException("경매 낙찰 팀장의 남은 예산이 없습니다: " + leaderIdValue(winnerId));
+    }
+
+    static RoomStateInvalidException auctionWinnerBudgetExceeded(TeamLeaderId winnerId, Integer remainingBudget, int amount) {
+        return new RoomStateInvalidException(
+            "경매 정산 시 낙찰 팀장의 예산이 입찰가보다 작습니다: leaderId=%s, remainingBudget=%s, amount=%d".formatted(
+                    leaderIdValue(winnerId),
+                    remainingBudget,
+                    amount
+                )
+        );
+    }
+
     static RoomStateInvalidException draftTurnMissing() {
         return new RoomStateInvalidException("드래프트 턴 정보를 찾을 수 없습니다");
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamLeader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamLeader.java
@@ -44,10 +44,10 @@ class RoomTeamLeader {
 
     void spend(int amount) {
         if (remainingBudget == null) {
-            throw new IllegalStateException("예산이 없는 팀장은 입찰할 수 없습니다");
+            throw RoomStateInvalidException.auctionWinnerBudgetMissing(id);
         }
         if (remainingBudget < amount) {
-            throw new IllegalArgumentException("예산이 부족합니다");
+            throw RoomStateInvalidException.auctionWinnerBudgetExceeded(id, remainingBudget, amount);
         }
         remainingBudget -= amount;
     }

--- a/src/test/java/com/naminhyeok/fantazzk/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/GlobalExceptionHandlerTest.java
@@ -281,22 +281,31 @@ class GlobalExceptionHandlerTest {
         }
     }
 
-    private static final class TestInvalidDomainStateException extends InvalidDomainStateException {
-        private TestInvalidDomainStateException(String detailMessage) {
-            super(detailMessage, roomStateInvalidError());
+    private static final class TestInvalidDomainStateErrorDescriptor implements ErrorDescriptor {
+        @Override
+        public HttpStatus getStatus() {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
         }
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        private static ErrorDescriptor roomStateInvalidError() {
-            try {
-                Class<?> roomErrorTypeClass = Class.forName("com.naminhyeok.fantazzk.room.RoomErrorType");
-                return (ErrorDescriptor) Enum.valueOf(
-                    (Class<Enum>) roomErrorTypeClass.asSubclass(Enum.class),
-                    "ROOM_STATE_INVALID"
-                );
-            } catch (ReflectiveOperationException ex) {
-                throw new AssertionError(ex);
-            }
+        @Override
+        public String getCode() {
+            return "ROOM_STATE_INVALID";
+        }
+
+        @Override
+        public String getMessage() {
+            return "방 상태가 올바르지 않습니다. 잠시 후 다시 시도해 주세요";
+        }
+
+        @Override
+        public org.slf4j.event.Level getLogLevel() {
+            return org.slf4j.event.Level.ERROR;
+        }
+    }
+
+    private static final class TestInvalidDomainStateException extends InvalidDomainStateException {
+        private TestInvalidDomainStateException(String detailMessage) {
+            super(detailMessage, new TestInvalidDomainStateErrorDescriptor());
         }
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/GlobalExceptionHandlerTest.java
@@ -148,6 +148,23 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void 내부_상태_예외는_500과_room_state_invalid로_응답한다() throws Exception {
+        String response = mockMvc.perform(get("/invalid-room-state"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.resultType").value("ERROR"))
+            .andExpect(jsonPath("$.error.code").value("ROOM_STATE_INVALID"))
+            .andExpect(jsonPath("$.error.message").value("방 상태가 올바르지 않습니다. 잠시 후 다시 시도해 주세요"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(response);
+
+        assertThat(json.get("error").get("data").isNull()).isTrue();
+        assertLastLog(Level.ERROR, "broken room state");
+    }
+
+    @Test
     void validation_exception_renders_field_error_map_in_data() throws Exception {
         String response = mockMvc.perform(
                 post("/validation")
@@ -201,6 +218,11 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/generic")
         String generic() {
             throw new RuntimeException("boom");
+        }
+
+        @GetMapping("/invalid-room-state")
+        String invalidRoomState() {
+            throw new TestInvalidDomainStateException("broken room state");
         }
 
         @PostMapping("/validation")
@@ -259,8 +281,34 @@ class GlobalExceptionHandlerTest {
         }
     }
 
+    private static final class TestInvalidDomainStateException extends InvalidDomainStateException {
+        private TestInvalidDomainStateException(String detailMessage) {
+            super(detailMessage, roomStateInvalidError());
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static ErrorDescriptor roomStateInvalidError() {
+            try {
+                Class<?> roomErrorTypeClass = Class.forName("com.naminhyeok.fantazzk.room.RoomErrorType");
+                return (ErrorDescriptor) Enum.valueOf(
+                    (Class<Enum>) roomErrorTypeClass.asSubclass(Enum.class),
+                    "ROOM_STATE_INVALID"
+                );
+            } catch (ReflectiveOperationException ex) {
+                throw new AssertionError(ex);
+            }
+        }
+    }
+
     private void assertLastLog(Level expectedLevel) {
         assertThat(logAppender.list).isNotEmpty();
         assertThat(logAppender.list.get(logAppender.list.size() - 1).getLevel()).isEqualTo(expectedLevel);
+    }
+
+    private void assertLastLog(Level expectedLevel, String messageFragment) {
+        assertThat(logAppender.list).isNotEmpty();
+        ILoggingEvent lastLog = logAppender.list.get(logAppender.list.size() - 1);
+        assertThat(lastLog.getLevel()).isEqualTo(expectedLevel);
+        assertThat(lastLog.getFormattedMessage()).contains(messageFragment);
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -481,6 +481,35 @@ class RoomApiWebMvcTest {
     }
 
     @Test
+    void placeBid는_내부_상태_예외를_500으로_반환한다() throws Exception {
+        doThrow(RoomStateInvalidException.auctionRoundMissing())
+            .when(placeBid)
+            .place(ROOM_CODE, HOST_TOKEN, 150);
+
+        var result = mockMvcTester().perform(
+            post("/api/v1/rooms/{code}/bids", ROOM_CODE)
+                .header("X-Room-Action-Token", HOST_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "amount": 150
+                    }
+                    """
+                )
+        );
+
+        result.assertThat().hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(readBody(result, VoidApiResponse.class))
+            .satisfies(response -> {
+                assertThat(response.resultType()).isEqualTo("ERROR");
+                assertThat(response.error().code()).isEqualTo("ROOM_STATE_INVALID");
+                assertThat(response.error().message()).isEqualTo("방 상태가 올바르지 않습니다. 잠시 후 다시 시도해 주세요");
+                assertThat(response.error().data()).isNull();
+            });
+    }
+
+    @Test
     void pickDraft는_header가_있으면_최신_room_snapshot을_반환한다() throws Exception {
         Room room = inProgressDraftRoom();
         given(pickDraft.pick(ROOM_CODE, GUEST_TOKEN, "선수3"))

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
@@ -113,6 +113,36 @@ class RoomAuctionDeadlineSchedulerTest {
     }
 
     @Test
+    void 애플리케이션_시작시_손상된_due_room이_있어도_뒤따르는_정상_room은_계속_처리한다() {
+        FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
+        SettleAuction settleAuction = mock(SettleAuction.class);
+        Room brokenDueRoom = auctionRoomWithDeadline("BROKEN01", Instant.parse("2026-04-09T00:00:05Z"));
+        Room healthyDueRoom = auctionRoomWithDeadline("DUE02", Instant.parse("2026-04-09T00:00:06Z"));
+        Room futureRoom = auctionRoomWithDeadline("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"));
+        RecordingRooms rooms = new RecordingRooms(List.of(brokenDueRoom, healthyDueRoom, futureRoom));
+        given(settleAuction.settleIfDue("BROKEN01")).willThrow(RoomStateInvalidException.auctionRoundMissing());
+        given(settleAuction.settleIfDue("DUE02"))
+            .willReturn(auctionRoomWithDeadline("DUE02", Instant.parse("2026-04-09T00:00:25Z")));
+        RoomAuctionDeadlineScheduler scheduler =
+            new RoomAuctionDeadlineScheduler(
+                taskScheduler,
+                settleAuction,
+                rooms,
+                Clock.fixed(NOW, ZoneOffset.UTC)
+            );
+
+        scheduler.catchUpAndReschedule();
+
+        verify(settleAuction).settleIfDue("BROKEN01");
+        verify(settleAuction).settleIfDue("DUE02");
+        assertThat(taskScheduler.activeScheduledInstants())
+            .containsExactly(
+                Instant.parse("2026-04-09T00:00:25Z"),
+                Instant.parse("2026-04-09T00:00:15Z")
+            );
+    }
+
+    @Test
     void 애플리케이션_시작시_schedulable_room은_application_layer_정렬규칙으로_처리한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -131,6 +131,16 @@ class RoomAuctionTest {
     }
 
     @Test
+    void 시작한_경매_방의_현재_라운드가_null이면_room_state_invalid를_던진다() throws Exception {
+        Room room = startedAuctionRoom();
+        setCurrentAuctionRound(room, null);
+
+        assertThatThrownBy(() -> room.placeBid(new TeamLeaderId(HOST_ID), 100, CREATED_AT.plusSeconds(1)))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void 예산이_부족하면_입찰할_수_없다() {
         Room room = startedAuctionRoom();
 
@@ -301,6 +311,12 @@ class RoomAuctionTest {
 
     private static void setCurrentAuctionRoundEndsAt(Room room, Instant value) throws Exception {
         var field = Room.class.getDeclaredField("currentAuctionRoundEndsAt");
+        field.setAccessible(true);
+        field.set(room, value);
+    }
+
+    private static void setCurrentAuctionRound(Room room, Integer value) throws Exception {
+        var field = Room.class.getDeclaredField("currentAuctionRound");
         field.setAccessible(true);
         field.set(room, value);
     }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -258,6 +258,32 @@ class RoomAuctionTest {
     }
 
     @Test
+    void 낙찰_팀장의_남은_예산이_null로_손상되면_정산은_room_state_invalid를_던진다() throws Exception {
+        Room room = startedAuctionRoom();
+        TeamLeaderId guestLeaderId = room.getLeaders().getLast().getId();
+
+        room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(1));
+        setRemainingBudget(room, guestLeaderId, null);
+
+        assertThatThrownBy(() -> room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME)))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
+    void 낙찰_팀장의_남은_예산이_입찰가보다_작게_손상되면_정산은_room_state_invalid를_던진다() throws Exception {
+        Room room = startedAuctionRoom();
+        TeamLeaderId guestLeaderId = room.getLeaders().getLast().getId();
+
+        room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(1));
+        setRemainingBudget(room, guestLeaderId, 100);
+
+        assertThatThrownBy(() -> room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME)))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void start는_optimistic_lock을_room_conflict로_번역한다() {
         Room room = waitingAuctionRoom();
         room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
@@ -329,6 +355,17 @@ class RoomAuctionTest {
         var field = Room.class.getDeclaredField("currentAuctionRound");
         field.setAccessible(true);
         field.set(room, value);
+    }
+
+    private static void setRemainingBudget(Room room, TeamLeaderId leaderId, Integer value) throws Exception {
+        RoomTeamLeader leader =
+            room.getLeaders().stream()
+                .filter(it -> it.getId().equals(leaderId))
+                .findFirst()
+                .orElseThrow();
+        var field = RoomTeamLeader.class.getDeclaredField("remainingBudget");
+        field.setAccessible(true);
+        field.set(leader, value);
     }
 
     private static Room waitingAuctionRoom() {

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -248,6 +248,16 @@ class RoomAuctionTest {
     }
 
     @Test
+    void 시작한_경매_방의_현재_라운드가_null이면_낙찰_처리도_room_state_invalid를_던진다() throws Exception {
+        Room room = startedAuctionRoom();
+        setCurrentAuctionRound(room, null);
+
+        assertThatThrownBy(() -> room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME)))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void start는_optimistic_lock을_room_conflict로_번역한다() {
         Room room = waitingAuctionRoom();
         room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -69,6 +69,26 @@ class RoomDraftTest {
     }
 
     @Test
+    void 시작한_드래프트_방에서_팀장_draft_position이_null이면_현재_진행상태_조회는_room_state_invalid를_던진다() throws Exception {
+        Room room = startedDraftRoom();
+        setDraftPosition(room, new TeamLeaderId(HOST_ID), null);
+
+        assertThatThrownBy(room::currentDraftProgress)
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
+    void 시작한_드래프트_방에서_리더_순서가_비어있으면_현재_진행상태_조회는_room_state_invalid를_던진다() throws Exception {
+        Room room = startedDraftRoom();
+        clearLeaders(room);
+
+        assertThatThrownBy(room::currentDraftProgress)
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void 대기_중인_드래프트_방에서_호스트_팀장이_사라지면_draft_position_변경은_room_state_invalid를_던진다() throws Exception {
         Room room = waitingDraftRoom();
         removeLeader(room, new TeamLeaderId(HOST_ID));
@@ -168,11 +188,34 @@ class RoomDraftTest {
     }
 
     @SuppressWarnings("unchecked")
+    private static void setDraftPosition(Room room, TeamLeaderId leaderId, Integer draftPosition) throws Exception {
+        var field = Room.class.getDeclaredField("leaders");
+        field.setAccessible(true);
+        List<RoomTeamLeader> leaders = (List<RoomTeamLeader>) field.get(room);
+        RoomTeamLeader leader =
+            leaders.stream()
+                .filter(candidate -> candidate.getId().equals(leaderId))
+                .findFirst()
+                .orElseThrow();
+        var draftPositionField = RoomTeamLeader.class.getDeclaredField("draftPosition");
+        draftPositionField.setAccessible(true);
+        draftPositionField.set(leader, draftPosition);
+    }
+
+    @SuppressWarnings("unchecked")
     private static void removeLeader(Room room, TeamLeaderId leaderId) throws Exception {
         var field = Room.class.getDeclaredField("leaders");
         field.setAccessible(true);
         List<RoomTeamLeader> leaders = (List<RoomTeamLeader>) field.get(room);
         leaders.removeIf(leader -> leader.getId().equals(leaderId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearLeaders(Room room) throws Exception {
+        var field = Room.class.getDeclaredField("leaders");
+        field.setAccessible(true);
+        List<RoomTeamLeader> leaders = (List<RoomTeamLeader>) field.get(room);
+        leaders.clear();
     }
 
     private static Room startedDraftRoom() {

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -69,6 +69,16 @@ class RoomDraftTest {
     }
 
     @Test
+    void 대기_중인_드래프트_방에서_호스트_팀장이_사라지면_draft_position_변경은_room_state_invalid를_던진다() throws Exception {
+        Room room = waitingDraftRoom();
+        removeLeader(room, new TeamLeaderId(HOST_ID));
+
+        assertThatThrownBy(() -> room.clearDraftPosition(new TeamLeaderId(HOST_ID)))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void 이미_배정된_선수는_픽할_수_없다() {
         Room room = startedDraftRoom();
 
@@ -155,6 +165,14 @@ class RoomDraftTest {
         var field = Room.class.getDeclaredField("currentTurnIndex");
         field.setAccessible(true);
         field.set(room, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void removeLeader(Room room, TeamLeaderId leaderId) throws Exception {
+        var field = Room.class.getDeclaredField("leaders");
+        field.setAccessible(true);
+        List<RoomTeamLeader> leaders = (List<RoomTeamLeader>) field.get(room);
+        leaders.removeIf(leader -> leader.getId().equals(leaderId));
     }
 
     private static Room startedDraftRoom() {

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -59,6 +59,16 @@ class RoomDraftTest {
     }
 
     @Test
+    void 시작한_드래프트_방의_현재_턴이_null이면_room_state_invalid를_던진다() throws Exception {
+        Room room = startedDraftRoom();
+        setCurrentTurnIndex(room, null);
+
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), "선수1"))
+            .isInstanceOf(RoomStateInvalidException.class)
+            .isInstanceOfSatisfying(RoomStateInvalidException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_STATE_INVALID));
+    }
+
+    @Test
     void 이미_배정된_선수는_픽할_수_없다() {
         Room room = startedDraftRoom();
 
@@ -139,6 +149,12 @@ class RoomDraftTest {
 
     private static void assertRoomError(CoreException ex, RoomErrorType expected) {
         assertThat(ex.getError()).isEqualTo(expected);
+    }
+
+    private static void setCurrentTurnIndex(Room room, Integer value) throws Exception {
+        var field = Room.class.getDeclaredField("currentTurnIndex");
+        field.setAccessible(true);
+        field.set(room, value);
     }
 
     private static Room startedDraftRoom() {


### PR DESCRIPTION
## 배경
- `Room` 도메인에서는 `join`, `start`는 이미 `RoomErrorType` 기반으로 응답했지만, 일부 플레이 경로는 여전히 `IllegalStateException` 또는 `IllegalArgumentException`에 의존하고 있었습니다.
- 이 상태에서는 API에서 사용자 교정 가능 오류와 서버 내부 상태 손상이 서로 다른 방식으로 노출되어 에러 코드와 HTTP 상태가 일관되지 않았습니다.
- 특히 persisted legacy/corrupted state가 섞인 경우 `ROOM_STATE_INVALID`로 수렴하지 못하고 generic 500/400으로 새는 경로가 남아 있었습니다.

## 작업 내용
- 루트 패키지에 `InvalidDomainStateException`을 추가하고, room 모듈에는 package-private `RoomStateInvalidException`을 도입했습니다.
- `RoomErrorType`에 `ROOM_STATE_INVALID`를 추가하고, `GlobalExceptionHandler`가 내부 상태 예외를 `500 + ROOM_STATE_INVALID`로 응답하도록 정리했습니다.
- `Room` aggregate의 남아 있던 내부 상태 예외 경로를 `RoomStateInvalidException`으로 치환했습니다.
  - 경매 라운드 누락
  - 경매 대상 선수 누락
  - 낙찰 팀장 누락
  - 드래프트 턴 누락
  - 팀장 누락
- 경매 정산 시 낙찰 팀장의 예산 상태가 손상된 경우도 `ROOM_STATE_INVALID`로 정규화했습니다.
  - `remainingBudget == null`
  - `remainingBudget < winningBid.amount()`
- 애플리케이션 startup catch-up 중 손상된 due room 하나 때문에 이후 정상 room들의 재스케줄이 막히지 않도록 `RoomAuctionDeadlineScheduler`를 보강했습니다.
- in-progress draft room의 진행 상태가 손상된 경우도 `ROOM_STATE_INVALID`로 정규화했습니다.
  - `draftPosition == null`
  - leader order 비어 있음
- 전역 예외 처리, WebMvc 계약, aggregate 회귀, scheduler 회귀 테스트를 보강했습니다.

## 기대 효과
- 사용자 교정 가능 오류는 기존처럼 `CoreException` 기반 4xx 계약을 유지합니다.
- 서버 내부 상태 손상은 room 계열에서 일관되게 `ROOM_STATE_INVALID`로 수렴합니다.
- startup 시 손상된 경매방 하나가 다른 정상 경매방의 catch-up scheduling을 막는 운영 리스크를 줄였습니다.
- legacy/corrupted state에 대한 회귀 보호 범위를 넓혔습니다.

## 검증
- `./gradlew test --tests 'com.naminhyeok.fantazzk.GlobalExceptionHandlerTest' --tests 'com.naminhyeok.fantazzk.room.RoomApiWebMvcTest' --tests 'com.naminhyeok.fantazzk.room.RoomAuctionDeadlineSchedulerTest' --tests 'com.naminhyeok.fantazzk.room.RoomAuctionTest' --tests 'com.naminhyeok.fantazzk.room.RoomDraftTest'`
- `./gradlew check`
- `./gradlew integrationTest`

## 참고
- 관련 이슈: #46