### PR TITLE
트랜잭션 경계와 테스트 책임을 정리한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     integrationTestImplementation 'org.springframework.modulith:spring-modulith-starter-test'
     integrationTestImplementation 'org.springframework.boot:spring-boot-restclient'
     integrationTestImplementation 'org.springframework.boot:spring-boot-resttestclient'
+    integrationTestImplementation 'org.springframework.boot:spring-boot-data-jpa-test'
     integrationTestImplementation 'org.springframework.boot:spring-boot-jdbc-test'
     integrationTestRuntimeOnly 'org.testcontainers:jdbc:1.21.4'
     integrationTestRuntimeOnly 'org.testcontainers:postgresql:1.21.4'

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/FindJoinableRoomsIntegrationTest.java
@@ -44,7 +44,7 @@ class FindJoinableRoomsIntegrationTest {
 
         assertThat(findJoinableRooms.list())
             .hasSize(5)
-            .extracting(Room::getCode)
+            .extracting(JoinableRoomResponse::code)
             .containsExactly("ROOM09", "ROOM07", "ROOM05", "ROOM03", "ROOM01");
     }
 
@@ -55,7 +55,7 @@ class FindJoinableRoomsIntegrationTest {
         rooms.save(waitingRoom("ROOM50", Instant.parse("2026-04-09T00:01:00Z")));
 
         assertThat(findJoinableRooms.list())
-            .extracting(Room::getCode)
+            .extracting(JoinableRoomResponse::code)
             .containsExactly("ROOM01", "ROOM50", "ROOM99");
     }
 

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
-
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -59,33 +57,7 @@ class RoomApiIntegrationTest {
         assertThat(body).isNotNull();
         assertThat(body.resultType()).isEqualTo("SUCCESS");
         assertThat(body.success()).hasSize(2);
-        assertThat(body.success())
-            .extracting(
-                JoinableRoomResponse::code,
-                JoinableRoomResponse::mode,
-                JoinableRoomResponse::teamCount,
-                JoinableRoomResponse::joinedLeaderCount,
-                JoinableRoomResponse::remainingSlotCount,
-                JoinableRoomResponse::startReadiness
-            )
-            .containsExactly(
-                tuple(
-                    "ROOM99",
-                    "AUCTION",
-                    2,
-                    1,
-                    1,
-                    "WAITING_FOR_LEADERS"
-                ),
-                tuple(
-                    "ROOM01",
-                    "DRAFT",
-                    2,
-                    1,
-                    1,
-                    "WAITING_FOR_LEADERS"
-            )
-            );
+        assertThat(body.success()).extracting(JoinableRoomResponse::code).containsExactly("ROOM99", "ROOM01");
     }
 
     @Test
@@ -107,14 +79,11 @@ class RoomApiIntegrationTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(body).isNotNull();
         assertThat(body.resultType()).isEqualTo("SUCCESS");
+        assertThat(body.success().code()).isEqualTo("ROOM10");
         assertThat(body.success().status()).isEqualTo("IN_PROGRESS");
         assertThat(body.success().progress().currentRound()).isEqualTo(2);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
             .isAfter(CREATED_AT.plusSeconds(45));
-        assertThat(body.success().players().getFirst().position()).isEqualTo("TOP");
-        assertThat(body.success().members()).singleElement()
-            .extracting(RoomMemberResponse::playerName)
-            .isEqualTo("선수1");
     }
 
     @Test
@@ -128,10 +97,10 @@ class RoomApiIntegrationTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(body).isNotNull();
         assertThat(body.resultType()).isEqualTo("SUCCESS");
+        assertThat(body.success().code()).isEqualTo("ROOM11");
         assertThat(body.success().progress().currentRound()).isEqualTo(1);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
             .isEqualTo(Instant.parse("2026-04-09T00:00:45Z"));
-        assertThat(body.success().players().getFirst().position()).isEqualTo("TOP");
     }
 
     private Room startedAuctionRoom(String code, Instant createdAt) {

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
@@ -160,36 +160,6 @@ class RoomAuctionIntegrationTest {
     }
 
     @Test
-    void legacy_null_deadline_방에_입찰하면_deadline을_복구하고_commit후_재예약한다() {
-        var template =
-            templateFixture.createAuctionTemplateId(
-                "경매전",
-                2,
-                2,
-                300,
-                List.of(
-                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
-                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
-                )
-            );
-
-        Room created = createRoom.create(template, "호스트");
-        RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
-        startRoom.start(created.getCode(), created.getLeaders().getFirst().getActionToken());
-
-        Room room = rooms.findByCode(created.getCode()).orElseThrow();
-        setCurrentAuctionRoundEndsAt(room, null);
-        rooms.saveAndFlush(room);
-        recordingTaskScheduler.clear();
-
-        placeBid.place(created.getCode(), guest.getActionToken(), 150);
-
-        Room reloaded = rooms.findByCode(created.getCode()).orElseThrow();
-        assertThat(reloaded.getCurrentAuctionRoundEndsAt()).isEqualTo(Instant.parse("2000-01-01T00:00:45Z"));
-        assertThat(recordingTaskScheduler.scheduledInstants()).containsExactly(Instant.parse("2000-01-01T00:00:45Z"));
-    }
-
-    @Test
     void start_rollback되면_deadline_task는_등록되지_않는다() {
         var template =
             templateFixture.createAuctionTemplateId(

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
@@ -8,11 +8,11 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(
+@DataJpaTest(
     properties = {
         "spring.datasource.url=jdbc:h2:mem:room-repository-test;DB_CLOSE_DELAY=-1",
         "spring.datasource.driver-class-name=org.h2.Driver",

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomServiceIntegrationTest.java
@@ -2,8 +2,6 @@ package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.groups.Tuple.tuple;
-
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.template.TemplateCatalog.DraftOrderStrategy;
 import com.naminhyeok.fantazzk.template.TemplateFixture;
@@ -112,12 +110,6 @@ class RoomServiceIntegrationTest {
         Room reloaded = rooms.findByCode(created.getCode()).orElseThrow();
 
         assertThat(reloaded.getStartReadiness()).isEqualTo(RoomStartReadiness.STARTABLE);
-        assertThat(reloaded.getLeaders())
-            .extracting(RoomTeamLeader::getId, RoomTeamLeader::getDraftPosition)
-            .containsExactlyInAnyOrder(
-                tuple(created.getLeaders().getFirst().getId(), 2),
-                tuple(guest.getId(), 1)
-            );
     }
 
     @Test
@@ -171,50 +163,5 @@ class RoomServiceIntegrationTest {
         assertThat(reloaded.getLeaders()).singleElement()
             .extracting(RoomTeamLeader::getDraftPosition)
             .isNull();
-    }
-
-    @Test
-    void 드래프트_자리_선택과_취소는_응답_preview와_시작가능_상태를_함께_갱신한다() {
-        var template =
-            templateFixture.createDraftTemplateId(
-                "드래프트전",
-                2,
-                2,
-                DraftOrderStrategy.SNAKE,
-                List.of(
-                    new TemplateFixture.PlayerSpec("선수1", "TOP"),
-                    new TemplateFixture.PlayerSpec("선수2", "JUNGLE")
-                )
-            );
-
-        Room created = createRoom.create(template, "호스트");
-        RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
-
-        selectDraftPosition.select(created.getCode(), created.getLeaders().getFirst().getActionToken(), 2);
-        selectDraftPosition.select(created.getCode(), guest.getActionToken(), 1);
-
-        Room afterSelect = rooms.findByCode(created.getCode()).orElseThrow();
-        RoomResponse selectableResponse = RoomResponse.from(afterSelect);
-
-        assertThat(selectableResponse.startReadiness()).isEqualTo("STARTABLE");
-        assertThat(selectableResponse.draftOrderPreview().slots())
-            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
-            .containsExactly(
-                tuple(1, guest.getId().value(), "게스트"),
-                tuple(2, created.getLeaders().getFirst().getId().value(), "호스트")
-            );
-
-        clearDraftPosition.clear(created.getCode(), guest.getActionToken());
-
-        Room afterClear = rooms.findByCode(created.getCode()).orElseThrow();
-        RoomResponse clearedResponse = RoomResponse.from(afterClear);
-
-        assertThat(clearedResponse.startReadiness()).isEqualTo(RoomStartReadiness.WAITING_FOR_DRAFT_POSITIONS.name());
-        assertThat(clearedResponse.draftOrderPreview().slots())
-            .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
-            .containsExactly(
-                tuple(1, null, null),
-                tuple(2, created.getLeaders().getFirst().getId().value(), "호스트")
-            );
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateApiIntegrationTest.java
@@ -67,15 +67,8 @@ class TemplateApiIntegrationTest {
         Map<?, ?> success = (Map<?, ?>) response.getBody().get("success");
         assertThat(success.get("name")).isEqualTo("경매전");
         assertThat(success.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
-        assertThat(success.get("pickBanTime")).isEqualTo(45);
-        assertThat(success.get("minBidUnit")).isEqualTo(10);
-        assertThat(success.get("positionLimit")).isEqualTo(1);
-        assertThat(success.get("players")).isEqualTo(
-            List.of(
-                Map.of("name", "선수1", "position", "TOP", "displayOrder", 0),
-                Map.of("name", "선수2", "position", "JUNGLE", "displayOrder", 1)
-            )
-        );
+        assertThat(success.get("mode")).isEqualTo("AUCTION");
+        assertThat(((List<?>) success.get("players"))).hasSize(2);
     }
 
     @Test
@@ -112,11 +105,8 @@ class TemplateApiIntegrationTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsEntry("resultType", "SUCCESS");
         Map<?, ?> success = (Map<?, ?>) response.getBody().get("success");
+        assertThat(success.get("id")).isEqualTo(templateId);
         assertThat(success.get("name")).isEqualTo("상세조회용 경매전");
-        assertThat(success.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
-        assertThat(success.get("pickBanTime")).isEqualTo(45);
-        assertThat(success.get("minBidUnit")).isEqualTo(10);
-        assertThat(success.get("positionLimit")).isEqualTo(1);
         List<Map<String, Object>> players = (List<Map<String, Object>>) success.get("players");
         assertThat(players)
             .containsExactly(
@@ -346,16 +336,8 @@ class TemplateApiIntegrationTest {
         List<Map<String, Object>> templates = (List<Map<String, Object>>) response.getBody().get("success");
         assertThat(templates).anySatisfy(template -> {
             assertThat(template.get("name")).isEqualTo("목록용 경매전");
-            assertThat(template.get("gameType")).isEqualTo("LEAGUE_OF_LEGENDS");
-            assertThat(template.get("pickBanTime")).isEqualTo(45);
-            assertThat(template.get("minBidUnit")).isEqualTo(10);
-            assertThat(template.get("positionLimit")).isEqualTo(1);
-            assertThat(template.get("players")).isEqualTo(
-                List.of(
-                    Map.of("name", "선수1", "position", "TOP", "displayOrder", 0),
-                    Map.of("name", "선수2", "position", "JUNGLE", "displayOrder", 1)
-                )
-            );
+            assertThat(template.get("mode")).isEqualTo("AUCTION");
+            assertThat(((List<?>) template.get("players"))).hasSize(2);
         });
     }
 }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/template/TemplateRepositoryIntegrationTest.java
@@ -6,11 +6,11 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(
+@DataJpaTest(
     properties = {
         "spring.datasource.url=jdbc:h2:mem:template-repository-test;DB_CLOSE_DELAY=-1",
         "spring.datasource.driver-class-name=org.h2.Driver",

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleCandidate.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleCandidate.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.time.Instant;
+
+record AuctionScheduleCandidate(
+    String code,
+    Instant deadline
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleJpaRepository.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleJpaRepository.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+interface AuctionScheduleJpaRepository extends Repository<Room, RoomId> {
+    List<Room> findByStatusAndModeOrderByCodeAsc(RoomStatus status, RoomMode mode, Pageable pageable);
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionScheduleReader.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+
+interface AuctionScheduleReader {
+    List<AuctionScheduleCandidate> findInProgressAuctionSchedules();
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
@@ -1,41 +1,26 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 class ClearDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
-    private final PlatformTransactionManager transactionManager;
 
+    @Transactional
     public void clear(String code, String actionToken) {
-        inTransaction(() -> {
+        try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
             room.clearDraftPosition(caller.getId());
-            rooms.save(room);
-            return room;
-        });
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        try {
-            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
+            rooms.saveAndFlush(room);
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }
-    }
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
@@ -1,9 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,34 +9,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 class FindJoinableRooms {
     private static final int JOINABLE_ROOM_LIMIT = 5;
-    private static final int WAITING_ROOM_PAGE_SIZE = 5;
 
-    private final Rooms rooms;
+    private final JoinableRoomReader joinableRoomReader;
 
     @Transactional(readOnly = true)
-    public List<Room> list() {
-        List<Room> joinableRooms = new ArrayList<>();
-        int page = 0;
-        while (joinableRooms.size() < JOINABLE_ROOM_LIMIT) {
-            List<Room> waitingRooms =
-                rooms.findByStatusOrderByCreatedAtDescCodeDesc(
-                    RoomStatus.WAITING,
-                    PageRequest.of(page, WAITING_ROOM_PAGE_SIZE)
-                );
-            if (waitingRooms.isEmpty()) {
-                return joinableRooms;
-            }
-            joinableRooms.addAll(
-                waitingRooms.stream()
-                    .filter(Room::isJoinable)
-                    .limit(JOINABLE_ROOM_LIMIT - joinableRooms.size())
-                    .toList()
-            );
-            if (waitingRooms.size() < WAITING_ROOM_PAGE_SIZE) {
-                return joinableRooms;
-            }
-            page += 1;
-        }
-        return joinableRooms;
+    public List<JoinableRoomResponse> list() {
+        return joinableRoomReader.findLatestWaitingRooms(JOINABLE_ROOM_LIMIT).stream()
+            .map(JoinableRoomResponse::from)
+            .toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomJpaRepository.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomJpaRepository.java
@@ -1,0 +1,11 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.repository.Repository;
+
+interface JoinableRoomJpaRepository extends Repository<Room, RoomId> {
+    @EntityGraph(attributePaths = "leaders")
+    List<Room> findByStatusOrderByCreatedAtDescCodeDesc(RoomStatus status, Pageable pageable);
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomReader.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.List;
+
+interface JoinableRoomReader {
+    List<Room> findLatestWaitingRooms(int limit);
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/JpaAuctionScheduleReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JpaAuctionScheduleReader.java
@@ -1,0 +1,37 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class JpaAuctionScheduleReader implements AuctionScheduleReader {
+    private static final int CATCH_UP_BATCH_SIZE = 200;
+
+    private final AuctionScheduleJpaRepository repository;
+
+    @Override
+    public List<AuctionScheduleCandidate> findInProgressAuctionSchedules() {
+        List<AuctionScheduleCandidate> candidates = new ArrayList<>();
+        int page = 0;
+        while (true) {
+            List<Room> batch =
+                repository.findByStatusAndModeOrderByCodeAsc(
+                    RoomStatus.IN_PROGRESS,
+                    RoomMode.AUCTION,
+                    PageRequest.of(page, CATCH_UP_BATCH_SIZE)
+                );
+            if (batch.isEmpty()) {
+                return candidates;
+            }
+            candidates.addAll(batch.stream().map(room -> new AuctionScheduleCandidate(room.getCode(), room.getCurrentAuctionRoundEndsAt())).toList());
+            if (batch.size() < CATCH_UP_BATCH_SIZE) {
+                return candidates;
+            }
+            page += 1;
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/JpaJoinableRoomReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JpaJoinableRoomReader.java
@@ -1,0 +1,42 @@
+package com.naminhyeok.fantazzk.room;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class JpaJoinableRoomReader implements JoinableRoomReader {
+    private static final int WAITING_ROOM_PAGE_SIZE = 5;
+
+    private final JoinableRoomJpaRepository repository;
+
+    @Override
+    public List<Room> findLatestWaitingRooms(int limit) {
+        List<Room> joinableRooms = new ArrayList<>();
+        int page = 0;
+        while (joinableRooms.size() < limit) {
+            List<Room> waitingRooms =
+                repository.findByStatusOrderByCreatedAtDescCodeDesc(
+                    RoomStatus.WAITING,
+                    PageRequest.of(page, WAITING_ROOM_PAGE_SIZE)
+                );
+            if (waitingRooms.isEmpty()) {
+                return joinableRooms;
+            }
+            joinableRooms.addAll(
+                waitingRooms.stream()
+                    .filter(Room::isJoinable)
+                    .limit(limit - joinableRooms.size())
+                    .toList()
+            );
+            if (waitingRooms.size() < WAITING_ROOM_PAGE_SIZE) {
+                return joinableRooms;
+            }
+            page += 1;
+        }
+        return joinableRooms;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
@@ -1,41 +1,27 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 class PickDraft {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
-    private final PlatformTransactionManager transactionManager;
 
+    @Transactional
     public RoomTeamMember pick(String code, String actionToken, String playerName) {
-        return inTransaction(() -> {
+        try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
             RoomTeamMember member = room.pick(caller.getId(), playerName);
-            rooms.save(room);
+            rooms.saveAndFlush(room);
             return member;
-        });
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        try {
-            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }
-    }
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
@@ -3,14 +3,12 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -19,34 +17,19 @@ class PlaceBid {
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
     private final Clock clock;
-    private final PlatformTransactionManager transactionManager;
 
+    @Transactional
     public RoomBid place(String code, String actionToken, int amount) {
-        PlaceBidResult result = inTransaction(() -> {
+        try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
             RoomBid bid = room.placeBid(caller.getId(), amount, Instant.now(clock));
-            Room saved = rooms.save(room);
+            Room saved = rooms.saveAndFlush(room);
             scheduleAfterCommit(saved);
-            return new PlaceBidResult(saved, bid);
-        });
-        return result.bid();
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        try {
-            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
+            return bid;
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }
-    }
-
-    private record PlaceBidResult(Room room, RoomBid bid) {}
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 
     private void scheduleAfterCommit(Room room) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -273,14 +273,14 @@ class Room implements AggregateRoot<Room, RoomId> {
                 .orElse(null);
 
         if (highestBidAmount == null) {
-            if (minBidUnit != null && amount < minBidUnit) {
+            if (amount < minBidUnit) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_MIN_UNIT_NOT_MET);
             }
         } else {
             if (amount <= highestBidAmount) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_TOO_LOW);
             }
-            if (minBidUnit != null && amount < highestBidAmount + minBidUnit) {
+            if (amount < highestBidAmount + minBidUnit) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_MIN_UNIT_NOT_MET);
             }
         }
@@ -296,19 +296,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             );
         RoomBid bid = new RoomBid(currentAuctionRound, nextSequence, teamLeaderId, amount);
         bids.add(bid);
-        repairMissingAuctionDeadline(now);
         return bid;
-    }
-
-    boolean repairMissingAuctionDeadline(Instant now) {
-        if (status != RoomStatus.IN_PROGRESS || mode != RoomMode.AUCTION || currentAuctionRound == null) {
-            return false;
-        }
-        if (currentAuctionRoundEndsAt != null) {
-            return false;
-        }
-        currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
-        return true;
     }
 
     public AuctionSettlement settleAuction() {
@@ -326,7 +314,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             throw RoomStateInvalidException.auctionRoundMissing();
         }
         if (currentAuctionRoundEndsAt == null) {
-            currentAuctionRoundEndsAt = now;
+            throw RoomStateInvalidException.auctionRoundMissing();
         }
         if (now.isBefore(currentAuctionRoundEndsAt)) {
             throw CoreException.of(RoomErrorType.ROOM_AUCTION_ROUND_NOT_ENDED);

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomApiController.java
@@ -33,11 +33,7 @@ class RoomApiController {
 
     @GetMapping
     ApiResponse<List<JoinableRoomResponse>> list() {
-        return ApiResponse.success(
-            findJoinableRooms.list().stream()
-                .map(JoinableRoomResponse::from)
-                .toList()
-        );
+        return ApiResponse.success(findJoinableRooms.list());
     }
 
     @PostMapping

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
@@ -2,7 +2,6 @@ package com.naminhyeok.fantazzk.room;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,19 +10,15 @@ import java.util.concurrent.ScheduledFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 class RoomAuctionDeadlineScheduler {
-    private static final int CATCH_UP_BATCH_SIZE = 200;
-    private static final PageRequest CATCH_UP_PAGE = PageRequest.of(0, 200);
-
     private final TaskScheduler taskScheduler;
     private final SettleAuction settleAuction;
-    private final Rooms rooms;
+    private final AuctionScheduleReader auctionScheduleReader;
     private final Clock clock;
     private final ConcurrentMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 
@@ -33,9 +28,11 @@ class RoomAuctionDeadlineScheduler {
             return;
         }
 
-        String code = room.getCode();
-        ScheduledFuture<?> future =
-            taskScheduler.schedule(() -> runScheduledSettlement(code), room.getCurrentAuctionRoundEndsAt());
+        schedule(room.getCode(), room.getCurrentAuctionRoundEndsAt());
+    }
+
+    private void schedule(String code, Instant deadline) {
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> runScheduledSettlement(code), deadline);
         if (future != null) {
             scheduledTasks.put(code, future);
         }
@@ -51,16 +48,16 @@ class RoomAuctionDeadlineScheduler {
     @EventListener(ApplicationReadyEvent.class)
     void catchUpAndReschedule() {
         Instant now = Instant.now(clock);
-        for (Room room : collectSchedulableRooms()) {
-            if (room.getCurrentAuctionRoundEndsAt() == null || !room.getCurrentAuctionRoundEndsAt().isAfter(now)) {
+        for (AuctionScheduleCandidate candidate : collectSchedulableRooms()) {
+            if (candidate.deadline() == null || !candidate.deadline().isAfter(now)) {
                 try {
-                    schedule(settleAuction.settleIfDue(room.getCode()));
+                    schedule(settleAuction.settleIfDue(candidate.code()));
                 } catch (RoomStateInvalidException ignored) {
                     continue;
                 }
                 continue;
             }
-            schedule(room);
+            schedule(candidate.code(), candidate.deadline());
         }
     }
 
@@ -75,34 +72,17 @@ class RoomAuctionDeadlineScheduler {
             && room.getCurrentAuctionRoundEndsAt() != null;
     }
 
-    private List<Room> collectSchedulableRooms() {
-        List<Room> schedulableRooms = new ArrayList<>();
-        int page = 0;
-        while (true) {
-            List<Room> batch =
-                rooms.findByStatusAndModeOrderByCodeAsc(
-                    RoomStatus.IN_PROGRESS,
-                    RoomMode.AUCTION,
-                    PageRequest.of(page, CATCH_UP_BATCH_SIZE)
-                );
-            if (batch.isEmpty()) {
-                return sortSchedulableRooms(schedulableRooms);
-            }
-            schedulableRooms.addAll(batch);
-            if (batch.size() < CATCH_UP_BATCH_SIZE) {
-                return sortSchedulableRooms(schedulableRooms);
-            }
-            page += 1;
-        }
+    private List<AuctionScheduleCandidate> collectSchedulableRooms() {
+        return sortSchedulableRooms(auctionScheduleReader.findInProgressAuctionSchedules());
     }
 
-    private List<Room> sortSchedulableRooms(List<Room> rooms) {
-        return rooms.stream()
+    private List<AuctionScheduleCandidate> sortSchedulableRooms(List<AuctionScheduleCandidate> candidates) {
+        return candidates.stream()
             .sorted(
                 Comparator.comparing(
-                    Room::getCurrentAuctionRoundEndsAt,
+                    AuctionScheduleCandidate::deadline,
                     Comparator.nullsFirst(Comparator.naturalOrder())
-                ).thenComparing(Room::getCode)
+                ).thenComparing(AuctionScheduleCandidate::code)
             )
             .toList();
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Rooms.java
@@ -1,8 +1,6 @@
 package com.naminhyeok.fantazzk.room;
 
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.jmolecules.ddd.types.Repository;
 
 interface Rooms extends Repository<Room, RoomId> {
@@ -13,8 +11,4 @@ interface Rooms extends Repository<Room, RoomId> {
     Optional<Room> findById(RoomId id);
 
     Optional<Room> findByCode(String code);
-
-    List<Room> findByStatusOrderByCreatedAtDescCodeDesc(RoomStatus status, Pageable pageable);
-
-    List<Room> findByStatusAndModeOrderByCodeAsc(RoomStatus status, RoomMode mode, Pageable pageable);
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
@@ -1,41 +1,26 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 class SelectDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
-    private final PlatformTransactionManager transactionManager;
 
+    @Transactional
     public void select(String code, String actionToken, int draftPosition) {
-        inTransaction(() -> {
+        try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
             room.selectDraftPosition(caller.getId(), draftPosition);
-            rooms.save(room);
-            return room;
-        });
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        try {
-            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
+            rooms.saveAndFlush(room);
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }
-    }
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
@@ -1,56 +1,30 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import java.time.Clock;
-import java.time.Instant;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
 class SettleAuction {
+    private final SettleAuctionAttempt settleAuctionAttempt;
     private final Rooms rooms;
-    private final Clock clock;
-    private final PlatformTransactionManager transactionManager;
     private final ObjectProvider<RoomAuctionDeadlineScheduler> roomAuctionDeadlineScheduler;
 
     public AuctionSettlement settle(String code) {
-        Instant now = Instant.now(clock);
-        return inTransaction(() -> {
-            Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-            AuctionSettlement settlement = room.settleAuction(now);
-            rooms.save(room);
-            return settlement;
-        });
+        return settleAuctionAttempt.settle(code);
     }
 
     public Room settleIfDue(String code) {
-        Instant now = Instant.now(clock);
         try {
-            Room room = inTransaction(() -> settleIfDueInTransaction(code, now));
+            Room room = settleAuctionAttempt.settleIfDue(code);
             scheduleIfNeeded(room);
             return room;
         } catch (OptimisticLockingFailureException ex) {
             return rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
         }
-    }
-
-    private Room settleIfDueInTransaction(String code, Instant now) {
-        Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-        if (room.repairMissingAuctionDeadline(now)) {
-            return rooms.saveAndFlush(room);
-        }
-        if (!isDue(room, now)) {
-            return room;
-        }
-
-        room.settleAuction(now);
-        return rooms.saveAndFlush(room);
     }
 
     private void scheduleIfNeeded(Room room) {
@@ -61,22 +35,5 @@ class SettleAuction {
             return;
         }
         roomAuctionDeadlineScheduler.ifAvailable(scheduler -> scheduler.schedule(room));
-    }
-
-    private static boolean isDue(Room room, Instant now) {
-        return room.getMode() == RoomMode.AUCTION
-            && room.getStatus() == RoomStatus.IN_PROGRESS
-            && room.getCurrentAuctionRoundEndsAt() != null
-            && !room.getCurrentAuctionRoundEndsAt().isAfter(now);
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
-    }
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
@@ -26,9 +26,6 @@ class SettleAuctionAttempt {
     Room settleIfDue(String code) {
         Instant now = Instant.now(clock);
         Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-        if (room.repairMissingAuctionDeadline(now)) {
-            return rooms.saveAndFlush(room);
-        }
         if (!isDue(room, now)) {
             return room;
         }

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
@@ -1,0 +1,46 @@
+package com.naminhyeok.fantazzk.room;
+
+import com.naminhyeok.fantazzk.CoreException;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class SettleAuctionAttempt {
+    private final Rooms rooms;
+    private final Clock clock;
+
+    @Transactional
+    AuctionSettlement settle(String code) {
+        Instant now = Instant.now(clock);
+        Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
+        AuctionSettlement settlement = room.settleAuction(now);
+        rooms.saveAndFlush(room);
+        return settlement;
+    }
+
+    @Transactional
+    Room settleIfDue(String code) {
+        Instant now = Instant.now(clock);
+        Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
+        if (room.repairMissingAuctionDeadline(now)) {
+            return rooms.saveAndFlush(room);
+        }
+        if (!isDue(room, now)) {
+            return room;
+        }
+
+        room.settleAuction(now);
+        return rooms.saveAndFlush(room);
+    }
+
+    private static boolean isDue(Room room, Instant now) {
+        return room.getMode() == RoomMode.AUCTION
+            && room.getStatus() == RoomStatus.IN_PROGRESS
+            && room.getCurrentAuctionRoundEndsAt() != null
+            && !room.getCurrentAuctionRoundEndsAt().isAfter(now);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
@@ -3,14 +3,12 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -19,31 +17,18 @@ class StartRoom {
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
     private final Clock clock;
-    private final PlatformTransactionManager transactionManager;
 
+    @Transactional
     public void start(String code, String actionToken) {
-        inTransaction(() -> {
+        try {
             Room loaded = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(loaded, actionToken);
             loaded.start(caller.getId(), Instant.now(clock));
-            Room saved = rooms.save(loaded);
+            Room saved = rooms.saveAndFlush(loaded);
             scheduleAfterCommit(saved);
-            return saved;
-        });
-    }
-
-    private <T> T inTransaction(TransactionCallback<T> callback) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        try {
-            return Objects.requireNonNull(transactionTemplate.execute(status -> callback.execute()));
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }
-    }
-
-    @FunctionalInterface
-    private interface TransactionCallback<T> {
-        T execute();
     }
 
     private void scheduleAfterCommit(Room room) {

--- a/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 class FindTemplates {
     private final Templates templates;
+    private final TemplateListReader templateListReader;
 
     @Transactional(readOnly = true)
     public TemplateDetail getDetail(TemplateId id) {
@@ -19,8 +20,6 @@ class FindTemplates {
 
     @Transactional(readOnly = true)
     public List<TemplateDetail> list() {
-        return templates.findAll().stream()
-            .map(template -> new TemplateDetail(template, template.getPlayers()))
-            .toList();
+        return templateListReader.list();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/template/JpaTemplateListReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/JpaTemplateListReader.java
@@ -1,0 +1,18 @@
+package com.naminhyeok.fantazzk.template;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class JpaTemplateListReader implements TemplateListReader {
+    private final TemplateListJpaRepository repository;
+
+    @Override
+    public List<TemplateDetail> list() {
+        return repository.findAll().stream()
+            .map(template -> new TemplateDetail(template, template.getPlayers()))
+            .toList();
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateListJpaRepository.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateListJpaRepository.java
@@ -1,0 +1,10 @@
+package com.naminhyeok.fantazzk.template;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.repository.Repository;
+
+interface TemplateListJpaRepository extends Repository<Template, TemplateId> {
+    @EntityGraph(attributePaths = "players")
+    List<Template> findAll();
+}

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateListReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateListReader.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.template;
+
+import java.util.List;
+
+interface TemplateListReader {
+    List<TemplateDetail> list();
+}

--- a/src/main/java/com/naminhyeok/fantazzk/template/Templates.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/Templates.java
@@ -1,15 +1,10 @@
 package com.naminhyeok.fantazzk.template;
 
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.jmolecules.ddd.types.Repository;
 
 interface Templates extends Repository<Template, TemplateId> {
     Template save(Template template);
 
     Optional<Template> findById(TemplateId id);
-
-    @EntityGraph(attributePaths = "players")
-    List<Template> findAll();
 }

--- a/src/test/java/com/naminhyeok/fantazzk/architecture/PublishedContractStructureTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/architecture/PublishedContractStructureTest.java
@@ -49,6 +49,14 @@ class PublishedContractStructureTest {
         assertClassMissing("com.naminhyeok.fantazzk.template.contract.TemplateCatalog");
     }
 
+    @Test
+    void aggregate_repository는_별도_jpa_seam_클래스를_두지_않는다() {
+        assertClassMissing("com.naminhyeok.fantazzk.room.JpaRoomRepository");
+        assertClassMissing("com.naminhyeok.fantazzk.room.JpaRooms");
+        assertClassMissing("com.naminhyeok.fantazzk.template.JpaTemplateRepository");
+        assertClassMissing("com.naminhyeok.fantazzk.template.JpaTemplates");
+    }
+
     private boolean isPublic(String className) throws Exception {
         return Modifier.isPublic(Class.forName(className).getModifiers());
     }

--- a/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
@@ -16,7 +16,6 @@ import java.util.Queue;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.data.domain.Pageable;
 import org.springframework.dao.DataIntegrityViolationException;
 
 class CreateRoomTest {
@@ -147,16 +146,6 @@ class CreateRoomTest {
         @Override
         public Optional<Room> findByCode(String code) {
             return Optional.empty();
-        }
-
-        @Override
-        public List<Room> findByStatusOrderByCreatedAtDescCodeDesc(RoomStatus status, Pageable pageable) {
-            return List.of();
-        }
-
-        @Override
-        public List<Room> findByStatusAndModeOrderByCodeAsc(RoomStatus status, RoomMode mode, Pageable pageable) {
-            return List.of();
         }
 
         private Room savedRoom() {

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -146,113 +146,8 @@ class RoomApiWebMvcTest {
         assertThat(body.at("/success/code").asText()).isEqualTo(ROOM_CODE);
         assertThat(body.at("/success/status").asText()).isEqualTo("WAITING");
         assertThat(body.at("/success/mode").asText()).isEqualTo("DRAFT");
-        assertThat(body.at("/success/teamCount").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/teamSize").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/budget").isNull()).isTrue();
-        assertThat(body.at("/success/draftOrderStrategy").asText()).isEqualTo("SNAKE");
         assertThat(body.at("/success/startReadiness").asText()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
-        assertThat(body.at("/success/teamLeaders/0/draftPosition").asInt()).isEqualTo(1);
-        assertThat(body.at("/success/teamLeaders/1/draftPosition").isNull()).isTrue();
-        assertThat(body.at("/success/draftOrderPreview/slots/0/draftPosition").asInt()).isEqualTo(1);
-        assertThat(body.at("/success/draftOrderPreview/slots/0/leaderId").asText()).isEqualTo(HOST_ID);
-        assertThat(body.at("/success/draftOrderPreview/slots/0/nickname").asText()).isEqualTo("호스트");
-        assertThat(body.at("/success/draftOrderPreview/slots/1/draftPosition").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/draftOrderPreview/slots/1/leaderId").isNull()).isTrue();
-        assertThat(body.at("/success/draftOrderPreview/slots/1/nickname").isNull()).isTrue();
-        assertThat(body.at("/success/players/0/name").asText()).isEqualTo("선수1");
-        assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
-        assertThat(body.at("/success/players/0/displayOrder").asInt()).isEqualTo(0);
-        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("AVAILABLE");
-        assertThat(body.at("/success/players/1/name").asText()).isEqualTo("선수2");
-        assertThat(body.at("/success/members").isArray()).isTrue();
-        assertThat(body.at("/success/members")).hasSize(0);
-        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRound").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentAuctionRoundEndsAt").isNull()).isTrue();
         assertThat(result.getResponse().getContentAsString()).doesNotContain("teamLeaderSession");
-    }
-
-    @Test
-    void get은_경매_방_public_room_snapshot에_minBidUnit을_포함한다() throws Exception {
-        given(getRoom.get(ROOM_CODE)).willReturn(waitingAuctionRoom());
-
-        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
-
-        result.assertThat().hasStatusOk();
-        JsonNode body = readTree(result);
-        assertThat(body.at("/success/mode").asText()).isEqualTo("AUCTION");
-        assertThat(body.at("/success/minBidUnit").asInt()).isEqualTo(10);
-    }
-
-    @Test
-    void get은_드래프트_진행중_스냅샷을_반환한다() throws Exception {
-        given(getRoom.get(ROOM_CODE)).willReturn(inProgressDraftRoom());
-
-        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
-
-        result.assertThat().hasStatusOk();
-        JsonNode body = readTree(result);
-        assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
-        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
-        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("ASSIGNED");
-        assertThat(body.at("/success/players/2/status").asText()).isEqualTo("AVAILABLE");
-        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
-        assertThat(body.at("/success/members/0/playerName").asText()).isEqualTo("선수1");
-        assertThat(body.at("/success/members/0/assignOrder").asInt()).isEqualTo(0);
-        assertThat(body.at("/success/members/1/teamLeaderId").asText()).isEqualTo(GUEST_ID);
-        assertThat(body.at("/success/members/1/playerName").asText()).isEqualTo("선수2");
-        assertThat(body.at("/success/members/1/assignOrder").asInt()).isEqualTo(1);
-        assertThat(body.at("/success/progress/currentTurnIndex").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/progress/currentRound").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/progress/currentLeaderId").asText()).isEqualTo(GUEST_ID);
-        assertThat(body.at("/success/progress/currentRoundLeaderIds/0").asText()).isEqualTo(GUEST_ID);
-        assertThat(body.at("/success/progress/currentRoundLeaderIds/1").asText()).isEqualTo(HOST_ID);
-    }
-
-    @Test
-    void get은_완료된_방도_players_members_progress_null로_결과를_렌더링할_수_있다() throws Exception {
-        given(getRoom.get(ROOM_CODE)).willReturn(completedDraftRoom());
-
-        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
-
-        result.assertThat().hasStatusOk();
-        JsonNode body = readTree(result);
-        assertThat(body.at("/success/status").asText()).isEqualTo("COMPLETED");
-        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
-        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("ASSIGNED");
-        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
-        assertThat(body.at("/success/members/1/teamLeaderId").asText()).isEqualTo(GUEST_ID);
-        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRound").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentAuctionRoundEndsAt").isNull()).isTrue();
-    }
-
-    @Test
-    void get은_경매_진행중_스냅샷에서_currentRound를_currentAuctionRound로_반환한다() throws Exception {
-        given(getRoom.get(ROOM_CODE)).willReturn(inProgressAuctionRoom());
-
-        var result = mockMvcTester().perform(get("/api/v1/rooms/{code}", ROOM_CODE));
-
-        result.assertThat().hasStatusOk();
-        JsonNode body = readTree(result);
-        assertThat(body.at("/success/status").asText()).isEqualTo("IN_PROGRESS");
-        assertThat(body.at("/success/budget").asInt()).isEqualTo(300);
-        assertThat(body.at("/success/draftOrderStrategy").isNull()).isTrue();
-        assertThat(body.at("/success/draftOrderPreview").isNull()).isTrue();
-        assertThat(body.at("/success/players/0/position").asText()).isEqualTo("TOP");
-        assertThat(body.at("/success/players/0/status").asText()).isEqualTo("ASSIGNED");
-        assertThat(body.at("/success/players/1/status").asText()).isEqualTo("AVAILABLE");
-        assertThat(body.at("/success/members/0/teamLeaderId").asText()).isEqualTo(HOST_ID);
-        assertThat(body.at("/success/members/0/playerName").asText()).isEqualTo("선수1");
-        assertThat(body.at("/success/progress/currentTurnIndex").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRound").asInt()).isEqualTo(2);
-        assertThat(body.at("/success/progress/currentLeaderId").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentRoundLeaderIds").isNull()).isTrue();
-        assertThat(body.at("/success/progress/currentAuctionRoundEndsAt").asText()).isEqualTo("2026-04-09T00:00:30Z");
     }
 
     @Test
@@ -289,9 +184,7 @@ class RoomApiWebMvcTest {
                 assertThat(response.resultType()).isEqualTo("SUCCESS");
                 assertThat(response.success()).hasSize(2);
                 assertThat(response.success().getFirst().code()).isEqualTo("ROOM99");
-                assertThat(response.success().getFirst().joinedLeaderCount()).isEqualTo(1);
-                assertThat(response.success().getFirst().remainingSlotCount()).isEqualTo(1);
-                assertThat(response.success().getFirst().startReadiness()).isEqualTo("WAITING_FOR_LEADERS");
+                assertThat(response.success().getFirst().mode()).isEqualTo("AUCTION");
             });
     }
 
@@ -319,8 +212,6 @@ class RoomApiWebMvcTest {
             .satisfies(response -> {
                 assertThat(response.resultType()).isEqualTo("SUCCESS");
                 assertThat(response.success().room().code()).isEqualTo(ROOM_CODE);
-                assertThat(response.success().room().minBidUnit()).isEqualTo(10);
-                assertThat(response.success().room().teamLeaders()).hasSize(2);
                 assertThat(response.success().teamLeaderSession().leaderId()).isEqualTo(GUEST_ID);
                 assertThat(response.success().teamLeaderSession().role()).isEqualTo("LEADER");
                 assertThat(response.success().teamLeaderSession().actionToken()).isEqualTo(GUEST_TOKEN);
@@ -431,10 +322,7 @@ class RoomApiWebMvcTest {
             .satisfies(response -> {
                 assertThat(response.resultType()).isEqualTo("SUCCESS");
                 assertThat(response.success().status()).isEqualTo("IN_PROGRESS");
-                assertThat(response.success().minBidUnit()).isEqualTo(10);
-                assertThat(response.success().progress().currentRound()).isEqualTo(1);
-                assertThat(response.success().progress().currentAuctionRoundEndsAt())
-                    .isEqualTo("2026-04-09T00:00:15Z");
+                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
             });
     }
 
@@ -612,8 +500,7 @@ class RoomApiWebMvcTest {
             .satisfies(response -> {
                 assertThat(response.resultType()).isEqualTo("SUCCESS");
                 assertThat(response.success().status()).isEqualTo("IN_PROGRESS");
-                assertThat(response.success().progress().currentTurnIndex()).isEqualTo(2);
-                assertThat(response.success().members()).hasSize(2);
+                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
             });
     }
 
@@ -684,9 +571,7 @@ class RoomApiWebMvcTest {
             .satisfies(response -> {
                 assertThat(response.resultType()).isEqualTo("SUCCESS");
                 assertThat(response.success().status()).isEqualTo("IN_PROGRESS");
-                assertThat(response.success().progress().currentRound()).isEqualTo(2);
-                assertThat(response.success().progress().currentAuctionRoundEndsAt())
-                    .isEqualTo("2026-04-09T00:00:30Z");
+                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
             });
     }
 
@@ -714,14 +599,7 @@ class RoomApiWebMvcTest {
         assertThat(readBody(result, RoomResponseApiResponse.class))
             .satisfies(response -> {
                 assertThat(response.success().startReadiness()).isEqualTo("STARTABLE");
-                assertThat(response.success().teamLeaders()).extracting(TeamLeaderResponse::draftPosition)
-                    .containsExactly(1, 2);
-                assertThat(response.success().draftOrderPreview().slots())
-                    .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
-                    .containsExactly(
-                        org.assertj.core.groups.Tuple.tuple(1, HOST_ID, "호스트"),
-                        org.assertj.core.groups.Tuple.tuple(2, GUEST_ID, "게스트")
-                    );
+                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
             });
     }
 
@@ -741,14 +619,7 @@ class RoomApiWebMvcTest {
         assertThat(readBody(result, RoomResponseApiResponse.class))
             .satisfies(response -> {
                 assertThat(response.success().startReadiness()).isEqualTo("WAITING_FOR_DRAFT_POSITIONS");
-                assertThat(response.success().teamLeaders()).extracting(TeamLeaderResponse::draftPosition)
-                    .containsExactly(null, null);
-                assertThat(response.success().draftOrderPreview().slots())
-                    .extracting(DraftOrderSlotResponse::draftPosition, DraftOrderSlotResponse::leaderId, DraftOrderSlotResponse::nickname)
-                    .containsExactly(
-                        org.assertj.core.groups.Tuple.tuple(1, null, null),
-                        org.assertj.core.groups.Tuple.tuple(2, null, null)
-                    );
+                assertThat(response.success().code()).isEqualTo(ROOM_CODE);
             });
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiWebMvcTest.java
@@ -274,7 +274,12 @@ class RoomApiWebMvcTest {
         Room latest = waitingAuctionRoom("ROOM99", Instant.parse("2026-04-09T00:03:00Z"));
         Room older = waitingDraftRoom("ROOM01", Instant.parse("2026-04-09T00:01:00Z"));
 
-        given(findJoinableRooms.list()).willReturn(List.of(latest, older));
+        given(findJoinableRooms.list()).willReturn(
+            List.of(
+                JoinableRoomResponse.from(latest),
+                JoinableRoomResponse.from(older)
+            )
+        );
 
         var result = mockMvcTester().perform(get("/api/v1/rooms"));
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
@@ -86,27 +86,6 @@ class RoomAuctionDeadlineSchedulerTest {
     }
 
     @Test
-    void 애플리케이션_시작시_null_deadline_legacy_room도_복구_대상에_포함한다() {
-        FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
-        SettleAuction settleAuction = mock(SettleAuction.class);
-        AuctionScheduleReader scheduleReader = new RecordingRooms(schedule("LEGACY01", null));
-        given(settleAuction.settleIfDue("LEGACY01"))
-            .willReturn(auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:25Z")));
-        RoomAuctionDeadlineScheduler scheduler =
-            new RoomAuctionDeadlineScheduler(
-                taskScheduler,
-                settleAuction,
-                scheduleReader,
-                Clock.fixed(NOW, ZoneOffset.UTC)
-            );
-
-        scheduler.catchUpAndReschedule();
-
-        verify(settleAuction).settleIfDue("LEGACY01");
-        assertThat(taskScheduler.activeScheduledInstants()).containsExactly(Instant.parse("2026-04-09T00:00:25Z"));
-    }
-
-    @Test
     void 애플리케이션_시작시_손상된_due_room이_있어도_뒤따르는_정상_room은_계속_처리한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
@@ -149,7 +128,7 @@ class RoomAuctionDeadlineSchedulerTest {
                 List.of(
                     schedule("FUTURE01", Instant.parse("2026-04-09T00:00:15Z")),
                     schedule("DUE01", Instant.parse("2026-04-09T00:00:05Z")),
-                    schedule("LEGACY01", null)
+                    schedule("LEGACY01", Instant.parse("2026-04-09T00:00:01Z"))
                 )
             );
         given(settleAuction.settleIfDue("LEGACY01")).willReturn(auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:20Z")));

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
@@ -11,9 +11,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Pageable;
 import org.mockito.InOrder;
 
 class RoomAuctionDeadlineSchedulerTest {
@@ -23,7 +21,6 @@ class RoomAuctionDeadlineSchedulerTest {
     void schedule는_경매_room_deadline에_맞춰_정산_task를_등록하고_다음_deadline을_재예약한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        Rooms rooms = mock(Rooms.class);
         Room room = auctionRoomWithDeadline("ROOM01", Instant.parse("2026-04-09T00:00:15Z"));
         Room nextRoundRoom = auctionRoomWithDeadline("ROOM01", Instant.parse("2026-04-09T00:00:30Z"));
         given(settleAuction.settleIfDue("ROOM01")).willReturn(nextRoundRoom);
@@ -31,7 +28,7 @@ class RoomAuctionDeadlineSchedulerTest {
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                new RecordingRooms(),
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -49,12 +46,11 @@ class RoomAuctionDeadlineSchedulerTest {
     void schedule는_같은_room의_기존_deadline_예약을_취소하고_새_deadline만_남긴다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        Rooms rooms = mock(Rooms.class);
         RoomAuctionDeadlineScheduler scheduler =
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                new RecordingRooms(),
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -69,17 +65,17 @@ class RoomAuctionDeadlineSchedulerTest {
     void 애플리케이션_시작시_due_room은_즉시_catch_up하고_future_deadline은_재예약한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        RecordingRooms rooms =
+        AuctionScheduleReader scheduleReader =
             new RecordingRooms(
-                auctionRoomWithDeadline("DUE01", Instant.parse("2026-04-09T00:00:05Z")),
-                auctionRoomWithDeadline("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"))
+                schedule("DUE01", Instant.parse("2026-04-09T00:00:05Z")),
+                schedule("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"))
             );
         given(settleAuction.settleIfDue("DUE01")).willReturn(completedAuctionRoom("DUE01"));
         RoomAuctionDeadlineScheduler scheduler =
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                scheduleReader,
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -93,16 +89,14 @@ class RoomAuctionDeadlineSchedulerTest {
     void 애플리케이션_시작시_null_deadline_legacy_room도_복구_대상에_포함한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        Room legacyRoom = auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:15Z"));
-        setCurrentAuctionRoundEndsAt(legacyRoom, null);
-        RecordingRooms rooms = new RecordingRooms(legacyRoom);
+        AuctionScheduleReader scheduleReader = new RecordingRooms(schedule("LEGACY01", null));
         given(settleAuction.settleIfDue("LEGACY01"))
             .willReturn(auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:25Z")));
         RoomAuctionDeadlineScheduler scheduler =
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                scheduleReader,
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -116,10 +110,14 @@ class RoomAuctionDeadlineSchedulerTest {
     void 애플리케이션_시작시_손상된_due_room이_있어도_뒤따르는_정상_room은_계속_처리한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        Room brokenDueRoom = auctionRoomWithDeadline("BROKEN01", Instant.parse("2026-04-09T00:00:05Z"));
-        Room healthyDueRoom = auctionRoomWithDeadline("DUE02", Instant.parse("2026-04-09T00:00:06Z"));
-        Room futureRoom = auctionRoomWithDeadline("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"));
-        RecordingRooms rooms = new RecordingRooms(List.of(brokenDueRoom, healthyDueRoom, futureRoom));
+        AuctionScheduleReader scheduleReader =
+            new RecordingRooms(
+                List.of(
+                    schedule("BROKEN01", Instant.parse("2026-04-09T00:00:05Z")),
+                    schedule("DUE02", Instant.parse("2026-04-09T00:00:06Z")),
+                    schedule("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"))
+                )
+            );
         given(settleAuction.settleIfDue("BROKEN01")).willThrow(RoomStateInvalidException.auctionRoundMissing());
         given(settleAuction.settleIfDue("DUE02"))
             .willReturn(auctionRoomWithDeadline("DUE02", Instant.parse("2026-04-09T00:00:25Z")));
@@ -127,7 +125,7 @@ class RoomAuctionDeadlineSchedulerTest {
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                scheduleReader,
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -146,18 +144,21 @@ class RoomAuctionDeadlineSchedulerTest {
     void 애플리케이션_시작시_schedulable_room은_application_layer_정렬규칙으로_처리한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        Room legacyRoom = auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:25Z"));
-        setCurrentAuctionRoundEndsAt(legacyRoom, null);
-        Room dueRoom = auctionRoomWithDeadline("DUE01", Instant.parse("2026-04-09T00:00:05Z"));
-        Room futureRoom = auctionRoomWithDeadline("FUTURE01", Instant.parse("2026-04-09T00:00:15Z"));
-        RecordingRooms rooms = new RecordingRooms(List.of(futureRoom, dueRoom, legacyRoom));
+        AuctionScheduleReader scheduleReader =
+            new RecordingRooms(
+                List.of(
+                    schedule("FUTURE01", Instant.parse("2026-04-09T00:00:15Z")),
+                    schedule("DUE01", Instant.parse("2026-04-09T00:00:05Z")),
+                    schedule("LEGACY01", null)
+                )
+            );
         given(settleAuction.settleIfDue("LEGACY01")).willReturn(auctionRoomWithDeadline("LEGACY01", Instant.parse("2026-04-09T00:00:20Z")));
         given(settleAuction.settleIfDue("DUE01")).willReturn(completedAuctionRoom("DUE01"));
         RoomAuctionDeadlineScheduler scheduler =
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                scheduleReader,
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -177,12 +178,12 @@ class RoomAuctionDeadlineSchedulerTest {
     void 애플리케이션_시작시_첫_페이지를_넘는_future_deadline도_모두_재예약한다() {
         FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
         SettleAuction settleAuction = mock(SettleAuction.class);
-        RecordingRooms rooms = new RecordingRooms(manyFutureRooms(205));
+        AuctionScheduleReader scheduleReader = new RecordingRooms(manyFutureSchedules(205));
         RoomAuctionDeadlineScheduler scheduler =
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 settleAuction,
-                rooms,
+                scheduleReader,
                 Clock.fixed(NOW, ZoneOffset.UTC)
             );
 
@@ -250,64 +251,38 @@ class RoomAuctionDeadlineSchedulerTest {
         }
     }
 
-    private static List<Room> manyFutureRooms(int count) {
-        List<Room> rooms = new ArrayList<>();
+    private static AuctionScheduleCandidate schedule(String code, Instant deadline) {
+        return new AuctionScheduleCandidate(code, deadline);
+    }
+
+    private static List<AuctionScheduleCandidate> manyFutureSchedules(int count) {
+        List<AuctionScheduleCandidate> candidates = new ArrayList<>();
         for (int index = 0; index < count; index++) {
             int second = 60 + index;
-            rooms.add(
-                auctionRoomWithDeadline(
+            candidates.add(
+                schedule(
                     "ROOM%03d".formatted(index),
                     Instant.parse("2026-04-09T00:%02d:%02dZ".formatted(second / 60, second % 60))
                 )
             );
         }
-        return rooms;
+        return candidates;
     }
 
-    private static final class RecordingRooms implements Rooms {
-        private final List<Room> schedulableRooms;
+    private static final class RecordingRooms implements AuctionScheduleReader {
+        private final List<AuctionScheduleCandidate> schedulableRooms;
 
-        private RecordingRooms(Room... schedulableRooms) {
+        private RecordingRooms(AuctionScheduleCandidate... schedulableRooms) {
             this.schedulableRooms = List.of(schedulableRooms);
         }
 
-        private RecordingRooms(List<Room> schedulableRooms) {
+        private RecordingRooms(List<AuctionScheduleCandidate> schedulableRooms) {
             this.schedulableRooms = List.copyOf(schedulableRooms);
         }
 
         @Override
-        public Room save(Room room) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Room saveAndFlush(Room room) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Optional<Room> findById(RoomId id) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Room> findByCode(String code) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Room> findByStatusOrderByCreatedAtDescCodeDesc(RoomStatus status, Pageable pageable) {
-            return List.of();
-        }
-
-        @Override
-        public List<Room> findByStatusAndModeOrderByCodeAsc(RoomStatus status, RoomMode mode, Pageable pageable) {
-            int start = Math.toIntExact(pageable.getOffset());
-            if (start >= schedulableRooms.size()) {
-                return List.of();
-            }
-            int end = Math.min(start + pageable.getPageSize(), schedulableRooms.size());
-            return schedulableRooms.subList(start, end);
+        public List<AuctionScheduleCandidate> findInProgressAuctionSchedules() {
+            return schedulableRooms;
         }
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -11,13 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.data.domain.Pageable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.TransactionException;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.SimpleTransactionStatus;
 
 class RoomAuctionTest {
     private static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
@@ -84,14 +78,13 @@ class RoomAuctionTest {
             new RoomAuctionDeadlineScheduler(
                 taskScheduler,
                 unsupportedSettleAuction(),
-                rooms,
+                emptyAuctionScheduleReader(),
                 Clock.fixed(CREATED_AT, ZoneOffset.UTC)
             );
         SettleAuction settleAuction =
             new SettleAuction(
+                new SettleAuctionAttempt(rooms, Clock.fixed(CREATED_AT, ZoneOffset.UTC)),
                 rooms,
-                Clock.fixed(CREATED_AT, ZoneOffset.UTC),
-                new StubTransactionManager(),
                 singletonProvider(scheduler)
             );
 
@@ -348,11 +341,10 @@ class RoomAuctionTest {
                 new RoomAuctionDeadlineScheduler(
                     new FakeTaskScheduler(),
                     unsupportedSettleAuction(),
-                    rooms,
+                    emptyAuctionScheduleReader(),
                     Clock.fixed(CREATED_AT, ZoneOffset.UTC)
                 ),
-                Clock.fixed(CREATED_AT, ZoneOffset.UTC),
-                new StubTransactionManager()
+                Clock.fixed(CREATED_AT, ZoneOffset.UTC)
             );
 
         assertThatThrownBy(() -> startRoom.start(room.getCode(), HOST_ACTION_TOKEN))
@@ -371,11 +363,10 @@ class RoomAuctionTest {
                 new RoomAuctionDeadlineScheduler(
                     new FakeTaskScheduler(),
                     unsupportedSettleAuction(),
-                    rooms,
+                    emptyAuctionScheduleReader(),
                     Clock.fixed(CREATED_AT, ZoneOffset.UTC)
                 ),
-                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC),
-                new StubTransactionManager()
+                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC)
             );
 
         assertThatThrownBy(() -> placeBid.place(room.getCode(), HOST_ACTION_TOKEN, 100))
@@ -387,7 +378,7 @@ class RoomAuctionTest {
         Room room = inProgressDraftRoomForOptimisticLock();
         InMemoryRooms rooms = new InMemoryRooms(room);
         rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
-        PickDraft pickDraft = new PickDraft(rooms, new RoomActionAuthorizer(), new StubTransactionManager());
+        PickDraft pickDraft = new PickDraft(rooms, new RoomActionAuthorizer());
 
         assertThatThrownBy(() -> pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, "선수1"))
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
@@ -400,8 +391,7 @@ class RoomAuctionTest {
         rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
         SelectDraftPosition selectDraftPosition = new SelectDraftPosition(
             rooms,
-            new RoomActionAuthorizer(),
-            new StubTransactionManager()
+            new RoomActionAuthorizer()
         );
 
         assertThatThrownBy(() -> selectDraftPosition.select(room.getCode(), HOST_ACTION_TOKEN, 1))
@@ -416,8 +406,7 @@ class RoomAuctionTest {
         rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
         ClearDraftPosition clearDraftPosition = new ClearDraftPosition(
             rooms,
-            new RoomActionAuthorizer(),
-            new StubTransactionManager()
+            new RoomActionAuthorizer()
         );
 
         assertThatThrownBy(() -> clearDraftPosition.clear(room.getCode(), HOST_ACTION_TOKEN))
@@ -593,10 +582,10 @@ class RoomAuctionTest {
     }
 
     private static SettleAuction unsupportedSettleAuction() {
+        InMemoryRooms rooms = new InMemoryRooms();
         return new SettleAuction(
-            new InMemoryRooms(),
-            Clock.fixed(CREATED_AT, ZoneOffset.UTC),
-            new StubTransactionManager(),
+            new SettleAuctionAttempt(rooms, Clock.fixed(CREATED_AT, ZoneOffset.UTC)),
+            rooms,
             new ObjectProvider<>() {
                 @Override
                 public RoomAuctionDeadlineScheduler getObject(Object... args) {
@@ -618,12 +607,7 @@ class RoomAuctionTest {
                     return null;
                 }
             }
-        ) {
-            @Override
-            public Room settleIfDue(String code) {
-                throw new UnsupportedOperationException();
-            }
-        };
+        );
     }
 
     private static ObjectProvider<RoomAuctionDeadlineScheduler> singletonProvider(RoomAuctionDeadlineScheduler scheduler) {
@@ -648,6 +632,10 @@ class RoomAuctionTest {
                 return scheduler;
             }
         };
+    }
+
+    private static AuctionScheduleReader emptyAuctionScheduleReader() {
+        return List::of;
     }
 
     private static final class InMemoryRooms implements Rooms {
@@ -687,28 +675,5 @@ class RoomAuctionTest {
         public Optional<Room> findByCode(String code) {
             return Optional.ofNullable(room).filter(it -> it.getCode().equals(code));
         }
-
-        @Override
-        public List<Room> findByStatusOrderByCreatedAtDescCodeDesc(RoomStatus status, Pageable pageable) {
-            return List.of();
-        }
-
-        @Override
-        public List<Room> findByStatusAndModeOrderByCodeAsc(RoomStatus status, RoomMode mode, Pageable pageable) {
-            return Optional.ofNullable(room).stream().toList();
-        }
-    }
-
-    private static final class StubTransactionManager implements PlatformTransactionManager {
-        @Override
-        public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
-            return new SimpleTransactionStatus();
-        }
-
-        @Override
-        public void commit(TransactionStatus status) throws TransactionException {}
-
-        @Override
-        public void rollback(TransactionStatus status) throws TransactionException {}
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -52,49 +52,6 @@ class RoomAuctionTest {
     }
 
     @Test
-    void 기존_경매_방의_deadline이_null이어도_입찰과_정산이_가능하다() throws Exception {
-        Room room = startedAuctionRoom();
-        setCurrentAuctionRoundEndsAt(room, null);
-        TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
-        TeamLeaderId guestLeaderId = room.getLeaders().getLast().getId();
-
-        room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
-        room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
-
-        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
-
-        assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
-        assertThat(room.getCurrentAuctionRound()).isEqualTo(2);
-        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds((PICK_BAN_TIME * 2L) + 1));
-    }
-
-    @Test
-    void settleIfDue는_legacy_null_deadline을_복구하고_재예약한다() throws Exception {
-        Room room = startedAuctionRoom();
-        setCurrentAuctionRoundEndsAt(room, null);
-        InMemoryRooms rooms = new InMemoryRooms(room);
-        FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
-        RoomAuctionDeadlineScheduler scheduler =
-            new RoomAuctionDeadlineScheduler(
-                taskScheduler,
-                unsupportedSettleAuction(),
-                emptyAuctionScheduleReader(),
-                Clock.fixed(CREATED_AT, ZoneOffset.UTC)
-            );
-        SettleAuction settleAuction =
-            new SettleAuction(
-                new SettleAuctionAttempt(rooms, Clock.fixed(CREATED_AT, ZoneOffset.UTC)),
-                rooms,
-                singletonProvider(scheduler)
-            );
-
-        Room repaired = settleAuction.settleIfDue(room.getCode());
-
-        assertThat(repaired.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME));
-        assertThat(taskScheduler.activeScheduledInstants()).containsExactly(CREATED_AT.plusSeconds(PICK_BAN_TIME));
-    }
-
-    @Test
     void 현재_최고가보다_낮거나_같은_입찰은_할_수_없다() {
         Room room = startedAuctionRoom();
         TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
@@ -128,20 +85,6 @@ class RoomAuctionTest {
         assertThatThrownBy(() -> room.placeBid(guestLeaderId, 105, CREATED_AT.plusSeconds(2)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_BID_MIN_UNIT_NOT_MET));
-    }
-
-    @Test
-    void 레거시_경매_방은_minBidUnit이_null이면_최고가보다_높은_입찰을_허용한다() {
-        Room room = startedLegacyAuctionRoom();
-        TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
-        TeamLeaderId guestLeaderId = room.getLeaders().getLast().getId();
-
-        room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
-
-        RoomBid bid = room.placeBid(guestLeaderId, 105, CREATED_AT.plusSeconds(2));
-
-        assertThat(bid.amount()).isEqualTo(105);
-        assertThat(bid.sequence()).isEqualTo(new BidSequence(2));
     }
 
     @Test
@@ -494,33 +437,6 @@ class RoomAuctionTest {
 
     private static Room startedAuctionRoom() {
         Room room = waitingAuctionRoom();
-        room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
-        room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
-        return room;
-    }
-
-    private static Room startedLegacyAuctionRoom() {
-        Room room =
-            Room.createFromTemplate(
-                "ROOM04",
-                new TeamLeaderId(HOST_ID),
-                "호스트",
-                HOST_ACTION_TOKEN,
-                new RoomTemplateSpec(
-                    RoomTemplateSpec.Mode.AUCTION,
-                    2,
-                    2,
-                    300,
-                    PICK_BAN_TIME,
-                    null,
-                    null,
-                    List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
-                    )
-                ),
-                CREATED_AT
-            );
         room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
         return room;

--- a/src/test/java/com/naminhyeok/fantazzk/template/CreateTemplateTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/CreateTemplateTest.java
@@ -110,10 +110,5 @@ class CreateTemplateTest {
         public Optional<Template> findById(TemplateId id) {
             return Optional.ofNullable(storage.get(id));
         }
-
-        @Override
-        public List<Template> findAll() {
-            return new ArrayList<>(storage.values());
-        }
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/template/FindTemplatesTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/FindTemplatesTest.java
@@ -18,7 +18,7 @@ class FindTemplatesTest {
         InMemoryTemplates templates = new InMemoryTemplates();
         TemplateId missingId = new TemplateId(UUID.randomUUID());
 
-        FindTemplates cut = new FindTemplates(templates);
+        FindTemplates cut = new FindTemplates(templates, new InMemoryTemplateListReader(templates));
 
         assertThatThrownBy(() -> cut.getDetail(missingId))
             .isInstanceOf(CoreException.class)
@@ -63,7 +63,7 @@ class FindTemplatesTest {
             )
         );
 
-        FindTemplates cut = new FindTemplates(templates);
+        FindTemplates cut = new FindTemplates(templates, new InMemoryTemplateListReader(templates));
 
         assertThat(cut.list()).hasSize(2);
     }
@@ -88,7 +88,7 @@ class FindTemplatesTest {
             );
         templates.save(template);
 
-        FindTemplates cut = new FindTemplates(templates);
+        FindTemplates cut = new FindTemplates(templates, new InMemoryTemplateListReader(templates));
         TemplateDetail detail = cut.getDetail(template.getId());
 
         assertThat(detail.template().getId()).isEqualTo(template.getId());
@@ -124,7 +124,7 @@ class FindTemplatesTest {
             );
         templates.save(template);
 
-        ProvideTemplateCatalog catalog = new ProvideTemplateCatalog(new FindTemplates(templates));
+        ProvideTemplateCatalog catalog = new ProvideTemplateCatalog(new FindTemplates(templates, new InMemoryTemplateListReader(templates)));
 
         TemplateCatalog.TemplateBlueprint blueprint = catalog.getTemplate(template.getId().templateId());
 
@@ -152,10 +152,20 @@ class FindTemplatesTest {
         public Optional<Template> findById(TemplateId id) {
             return Optional.ofNullable(storage.get(id));
         }
+    }
+
+    private static final class InMemoryTemplateListReader implements TemplateListReader {
+        private final InMemoryTemplates templates;
+
+        private InMemoryTemplateListReader(InMemoryTemplates templates) {
+            this.templates = templates;
+        }
 
         @Override
-        public List<Template> findAll() {
-            return new ArrayList<>(storage.values());
+        public List<TemplateDetail> list() {
+            return new ArrayList<>(templates.storage.values()).stream()
+                .map(template -> new TemplateDetail(template, template.getPlayers()))
+                .toList();
         }
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/template/TemplateResponseTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/template/TemplateResponseTest.java
@@ -1,0 +1,71 @@
+package com.naminhyeok.fantazzk.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TemplateResponseTest {
+    @Test
+    void 경매_템플릿_응답은_핵심_필드와_선수_표시순서를_매핑한다() {
+        Template template =
+            Template.createAuction(
+                "경매전",
+                GameType.LEAGUE_OF_LEGENDS,
+                2,
+                2,
+                300,
+                45,
+                10,
+                1,
+                List.of(
+                    new TemplatePlayer("선수1", "TOP", 0),
+                    new TemplatePlayer("선수2", "JUNGLE", 1)
+                )
+            );
+
+        TemplateResponse response = TemplateResponse.from(template);
+
+        assertThat(response.name()).isEqualTo("경매전");
+        assertThat(response.gameType()).isEqualTo(TemplateCatalog.GameType.LEAGUE_OF_LEGENDS);
+        assertThat(response.mode()).isEqualTo(TemplateCatalog.Mode.AUCTION);
+        assertThat(response.budget()).isEqualTo(300);
+        assertThat(response.pickBanTime()).isEqualTo(45);
+        assertThat(response.minBidUnit()).isEqualTo(10);
+        assertThat(response.positionLimit()).isEqualTo(1);
+        assertThat(response.players())
+            .extracting(TemplatePlayerResponse::displayOrder, TemplatePlayerResponse::name, TemplatePlayerResponse::position)
+            .containsExactly(
+                tuple(0, "선수1", "TOP"),
+                tuple(1, "선수2", "JUNGLE")
+            );
+    }
+
+    @Test
+    void 드래프트_템플릿_응답은_드래프트_설정을_매핑한다() {
+        Template template =
+            Template.createDraft(
+                "드래프트전",
+                GameType.OVERWATCH_2,
+                2,
+                2,
+                30,
+                DraftOrderStrategy.SNAKE,
+                List.of(
+                    new TemplatePlayer("선수1", "TANK", 0),
+                    new TemplatePlayer("선수2", "SUPPORT", 1)
+                )
+            );
+
+        TemplateResponse response = TemplateResponse.from(template);
+
+        assertThat(response.gameType()).isEqualTo(TemplateCatalog.GameType.OVERWATCH_2);
+        assertThat(response.mode()).isEqualTo(TemplateCatalog.Mode.DRAFT);
+        assertThat(response.budget()).isNull();
+        assertThat(response.pickBanTime()).isEqualTo(30);
+        assertThat(response.minBidUnit()).isNull();
+        assertThat(response.positionLimit()).isNull();
+        assertThat(response.draftOrderStrategy()).isEqualTo(TemplateCatalog.DraftOrderStrategy.SNAKE);
+    }
+}


### PR DESCRIPTION
## 작업 배경

기존 코드와 테스트는 다음 문제가 함께 있었습니다.

- `room` command use case가 `TransactionTemplate` 기반으로 중복 구현되어 있었음
- aggregate repository와 query concern이 뒤섞여 있어 도메인 계약과 읽기 저장소 책임이 흐려졌음
- 상위 계층 테스트가 하위 계층의 read-model 세부를 다시 검증하면서 설계 리팩토링을 방해하고 있었음
- 이미 정리된 운영 데이터에 대한 레거시 호환 분기와 테스트가 남아 있었음

이번 PR은 위 문제를 한 번에 정리해, 도메인 개념은 `jMolecules` 쪽에 유지하고 읽기 구현은 Spring Data JPA로 국소화하면서 테스트가 각 계층의 책임만 보도록 맞추는 데 초점을 맞췄습니다.

## 변경 사항

### 1. room command 트랜잭션 경계 정리

- `StartRoom`, `PlaceBid`, `PickDraft`, `SelectDraftPosition`, `ClearDraftPosition`를 `@Transactional` 기반으로 정리했습니다.
- `SettleAuction`는 시도 로직을 `SettleAuctionAttempt`로 분리해 Spring proxy 경계 안에서 처리되도록 정리했습니다.
- optimistic lock 충돌은 기존처럼 `ROOM_CONCURRENT_MODIFICATION`으로 번역되도록 유지했습니다.
- after-commit 스케줄링은 Spring transaction synchronization을 그대로 사용하도록 정리했습니다.

### 2. aggregate repository와 read-side 분리

- `Rooms`, `Templates`는 `jMolecules Repository`만 드러내는 aggregate repository로 유지했습니다.
- 목록/스케줄/상세 조회와 같은 read-side concern은 전용 read abstraction으로 분리했습니다.
- read 구현은 Spring Data JPA 전용 query repository를 통해 처리하도록 정리했습니다.
- aggregate repository 쪽에는 `JpaRepository`나 Spring Data marker를 끌어올리지 않았습니다.

### 3. 레거시 경매 호환 분기 제거

운영 데이터가 이미 정리되었다는 전제에 맞춰, 더 이상 필요 없는 레거시 호환 분기를 제거했습니다.

- `null deadline` 복구 로직 제거
- `legacy minBidUnit == null` 허용 로직 제거
- 관련 단위/통합 테스트 제거

이제 경매 상태가 손상되어 있으면 조용히 복구하는 대신 명시적으로 잘못된 상태로 간주합니다.

### 4. 테스트 책임 경계 정리

#### 서비스 테스트
- `RoomServiceIntegrationTest`에서 response mapping 검증을 제거하고, 유즈케이스 조립 의미만 남겼습니다.

#### WebMvc 테스트
- `RoomApiWebMvcTest`에서 과한 snapshot 세부 검증을 줄이고, controller contract와 에러 매핑 중심으로 정리했습니다.

#### repository 테스트
- `RoomRepositoryIntegrationTest`, `TemplateRepositoryIntegrationTest`를 `@DataJpaTest`로 내려 JPA mapping/persistence만 검증하게 했습니다.
- 이를 위해 `integrationTest` source set에 `spring-boot-data-jpa-test` 의존성을 추가했습니다.

#### response mapping 테스트
- `TemplateResponseTest`를 추가해 template 응답 매핑 세부를 낮은 계층 테스트로 보강했습니다.

## 기대 효과

- application service는 유즈케이스 orchestration에 집중하고, 도메인 규칙과 read-model 표현 책임이 더 분리됩니다.
- aggregate repository 계약이 query menu로 오염되지 않아서 도메인 개념이 더 선명해집니다.
- 테스트가 구현 세부보다 각 계층의 책임을 검증하게 되어, 이후 설계 리팩토링 비용이 줄어듭니다.
- 이미 끝난 마이그레이션/호환성 전제를 계속 보호하던 테스트와 분기가 제거되어 코드와 테스트가 더 단순해집니다.

## 검증

- `./gradlew check`
- `./gradlew integrationTest`
- `./gradlew test --tests com.naminhyeok.fantazzk.room.RoomAuctionTest --tests com.naminhyeok.fantazzk.room.RoomAuctionDeadlineSchedulerTest`
- `./gradlew integrationTest --tests com.naminhyeok.fantazzk.room.RoomAuctionIntegrationTest`
- `./gradlew integrationTest --tests com.naminhyeok.fantazzk.room.RoomServiceIntegrationTest`
- `./gradlew integrationTest --tests com.naminhyeok.fantazzk.room.RoomRepositoryIntegrationTest --tests com.naminhyeok.fantazzk.template.TemplateRepositoryIntegrationTest`
- `./gradlew test --tests com.naminhyeok.fantazzk.template.TemplateResponseTest`
- `./gradlew integrationTest --tests com.naminhyeok.fantazzk.room.RoomApiIntegrationTest --tests com.naminhyeok.fantazzk.template.TemplateApiIntegrationTest`

## 후속 논의 포인트

- `RoomApiWebMvcTest`의 mock 수를 더 줄이기 위해, controller 진입점 경계를 더 정리할 필요가 있는지
- 남아 있는 스모크 테스트(`BootTest`, `LiquibaseSmokeTest`)를 어디까지 유지할지
- read-side abstraction 이름을 더 도메인 개념 중심으로 다듬을지