### PR TITLE
경매 포지션 제한과 snapshot 상태를 room에 반영

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
@@ -35,6 +35,8 @@ class LiquibasePostgresSmokeTest {
         assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
         assertThat(countColumn("rooms", "min_bid_unit")).isEqualTo(1);
         assertThat(isNullable("rooms", "min_bid_unit")).isTrue();
+        assertThat(countColumn("rooms", "position_limit")).isEqualTo(1);
+        assertThat(isNullable("rooms", "position_limit")).isTrue();
         assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(indexColumns("rooms", "idx_rooms_status_created_at")).containsExactly("status", "created_at");
     }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -39,6 +39,8 @@ class LiquibaseSmokeTest {
         assertThat(countColumn("rooms", "created_at")).isEqualTo(1);
         assertThat(countColumn("rooms", "min_bid_unit")).isEqualTo(1);
         assertThat(isNullable("rooms", "min_bid_unit")).isTrue();
+        assertThat(countColumn("rooms", "position_limit")).isEqualTo(1);
+        assertThat(isNullable("rooms", "position_limit")).isTrue();
         assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(indexColumns("rooms", "idx_rooms_status_created_at")).containsExactly("STATUS", "CREATED_AT");
         assertThat(countTable("room_player")).isEqualTo(1);

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -82,6 +82,11 @@ class RoomApiIntegrationTest {
         assertThat(body.success().code()).isEqualTo("ROOM10");
         assertThat(body.success().status()).isEqualTo("IN_PROGRESS");
         assertThat(body.success().progress().currentRound()).isEqualTo(2);
+        assertThat(body.success().progress().currentAuctionTarget().name()).isEqualTo("선수2");
+        assertThat(body.success().progress().currentAuctionTarget().position()).isEqualTo("JUNGLE");
+        assertThat(body.success().progress().highestBidAmount()).isNull();
+        assertThat(body.success().progress().leadingLeaderId()).isNull();
+        assertThat(body.success().progress().bidCount()).isEqualTo(0);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
             .isAfter(CREATED_AT.plusSeconds(45));
     }
@@ -89,6 +94,7 @@ class RoomApiIntegrationTest {
     @Test
     void get은_경매의_deadline_projection을_반환한다() {
         Room room = startedAuctionRoom("ROOM11", CREATED_AT);
+        room.placeBid(new TeamLeaderId("host-ROOM11"), 120, CREATED_AT.plusSeconds(1));
         rooms.save(room);
 
         var response = restTemplate.getForEntity("/api/v1/rooms/ROOM11", RoomResponseApiResponse.class);
@@ -99,6 +105,11 @@ class RoomApiIntegrationTest {
         assertThat(body.resultType()).isEqualTo("SUCCESS");
         assertThat(body.success().code()).isEqualTo("ROOM11");
         assertThat(body.success().progress().currentRound()).isEqualTo(1);
+        assertThat(body.success().progress().currentAuctionTarget().name()).isEqualTo("선수1");
+        assertThat(body.success().progress().currentAuctionTarget().position()).isEqualTo("TOP");
+        assertThat(body.success().progress().highestBidAmount()).isEqualTo(120);
+        assertThat(body.success().progress().leadingLeaderId()).isEqualTo("host-ROOM11");
+        assertThat(body.success().progress().bidCount()).isEqualTo(1);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
             .isEqualTo(Instant.parse("2026-04-09T00:00:45Z"));
     }

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.naminhyeok.fantazzk.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.template.TemplateFixture;
 import java.time.Clock;
 import java.time.Duration;
@@ -127,6 +129,42 @@ class RoomAuctionIntegrationTest {
         assertThat(firstBid.sequence()).isEqualTo(new BidSequence(1));
         assertThat(secondBid.sequence()).isEqualTo(new BidSequence(2));
         assertThat(secondBid.round()).isEqualTo(1);
+    }
+
+    @Test
+    void 같은_포지션_제한에_걸리는_선수에게는_재조회_후에도_입찰할_수_없다() {
+        var template =
+            templateFixture.createAuctionTemplateId(
+                "포지션제한경매전",
+                2,
+                3,
+                300,
+                List.of(
+                    new TemplateFixture.PlayerSpec("탑선수1", "TOP"),
+                    new TemplateFixture.PlayerSpec("탑선수2", "TOP"),
+                    new TemplateFixture.PlayerSpec("정글선수1", "JUNGLE"),
+                    new TemplateFixture.PlayerSpec("미드선수1", "MID")
+                )
+            );
+
+        Room created = createRoom.create(template, "호스트");
+        RoomTeamLeader guest = joinRoom.join(created.getCode(), "게스트");
+        startRoom.start(created.getCode(), created.getLeaders().getFirst().getActionToken());
+
+        placeBid.place(created.getCode(), guest.getActionToken(), 150);
+        Room roomBeforeSettlement = rooms.findByCode(created.getCode()).orElseThrow();
+        setCurrentAuctionRoundEndsAt(roomBeforeSettlement, Instant.parse("1999-12-31T23:59:55Z"));
+        rooms.saveAndFlush(roomBeforeSettlement);
+        settleAuction.settle(created.getCode());
+
+        Room reloaded = rooms.findByCode(created.getCode()).orElseThrow();
+
+        assertThatThrownBy(() -> placeBid.place(reloaded.getCode(), guest.getActionToken(), 160))
+            .isInstanceOf(CoreException.class)
+            .isInstanceOfSatisfying(
+                CoreException.class,
+                ex -> assertThat(ex.getError().getCode()).isEqualTo("ROOM_AUCTION_POSITION_LIMIT_EXCEEDED")
+            );
     }
 
     @Test

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomRepositoryIntegrationTest.java
@@ -119,7 +119,7 @@ class RoomRepositoryIntegrationTest {
 
     @Test
     @Transactional
-    void 경매_방의_minBidUnit을_저장하고_다시_읽는다() {
+    void 경매_방의_minBidUnit과_positionLimit을_저장하고_다시_읽는다() {
         Room room =
             Room.createFromTemplate(
                 "ROOM04",
@@ -133,6 +133,7 @@ class RoomRepositoryIntegrationTest {
                     300,
                     30,
                     10,
+                    1,
                     null,
                     List.of(
                         new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
@@ -149,6 +150,7 @@ class RoomRepositoryIntegrationTest {
         Room reloaded = rooms.findById(saved.getId()).orElseThrow();
 
         assertThat(reloaded.getMinBidUnit()).isEqualTo(10);
+        assertThat(reloaded.getPositionLimit()).isEqualTo(1);
     }
 
     @Test

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
@@ -1,0 +1,13 @@
+package com.naminhyeok.fantazzk.room;
+
+record AuctionTargetResponse(
+    String name,
+    String position
+) {
+    static AuctionTargetResponse from(RoomPlayer player) {
+        if (player == null) {
+            return null;
+        }
+        return new AuctionTargetResponse(player.getName(), player.getPosition());
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
@@ -74,6 +74,7 @@ class CreateRoom {
                 template.budget(),
                 template.pickBanTime(),
                 template.minBidUnit(),
+                template.positionLimit(),
                 template.draftOrderStrategy() == null
                     ? null
                     : RoomTemplateSpec.DraftOrderStrategy.valueOf(template.draftOrderStrategy().name()),

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -45,6 +45,8 @@ class Room implements AggregateRoot<Room, RoomId> {
     @Column(name = "pick_ban_time")
     private final int pickBanTime;
     private final Integer minBidUnit;
+    @Column(name = "position_limit")
+    private final Integer positionLimit;
     @Enumerated(EnumType.STRING)
     private final RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy;
     private Integer currentTurnIndex;
@@ -74,6 +76,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         Integer budget,
         int pickBanTime,
         Integer minBidUnit,
+        Integer positionLimit,
         RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy
     ) {
         this.id = new RoomId(UUID.randomUUID());
@@ -87,6 +90,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         this.budget = budget;
         this.pickBanTime = pickBanTime;
         this.minBidUnit = minBidUnit;
+        this.positionLimit = positionLimit;
         this.draftOrderStrategy = draftOrderStrategy;
         this.currentTurnIndex = null;
         this.currentAuctionRound = null;
@@ -116,6 +120,7 @@ class Room implements AggregateRoot<Room, RoomId> {
                 spec.budget(),
                 spec.pickBanTime(),
                 spec.minBidUnit(),
+                spec.positionLimit(),
                 spec.draftOrderStrategy()
             );
 
@@ -261,6 +266,9 @@ class Room implements AggregateRoot<Room, RoomId> {
                 .findFirst()
                 .orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_BIDDER_NOT_FOUND));
 
+        RoomPlayer target = requireCurrentAuctionTarget();
+        validateAuctionPositionLimit(leader.getId(), target);
+
         if (leader.getRemainingBudget() != null && leader.getRemainingBudget() < amount) {
             throw CoreException.of(RoomErrorType.ROOM_BID_BUDGET_EXCEEDED);
         }
@@ -320,11 +328,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             throw CoreException.of(RoomErrorType.ROOM_AUCTION_ROUND_NOT_ENDED);
         }
 
-        RoomPlayer target =
-            players.stream()
-                .filter(it -> it.getStatus() == PlayerStatus.AVAILABLE)
-                .min(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
-                .orElseThrow(RoomStateInvalidException::auctionTargetMissing);
+        RoomPlayer target = requireCurrentAuctionTarget();
 
         RoomBid winningBid =
             bids.stream()
@@ -346,6 +350,7 @@ class Room implements AggregateRoot<Room, RoomId> {
                 .findFirst()
                 .orElseThrow(() -> RoomStateInvalidException.auctionWinnerMissing(winningBid.teamLeaderId()));
 
+        validateAuctionPositionLimit(winner.getId(), target);
         target.assign();
         winner.spend(winningBid.amount());
         members.add(new RoomTeamMember(winningBid.teamLeaderId(), target.getName(), members.size()));
@@ -450,6 +455,37 @@ class Room implements AggregateRoot<Room, RoomId> {
 
     private List<String> getLeaderIdsInDraftOrder() {
         return getLeadersInDraftOrder().stream().map(RoomTeamLeader::getTeamLeaderId).toList();
+    }
+
+    private RoomPlayer requireCurrentAuctionTarget() {
+        return players.stream()
+            .filter(it -> it.getStatus() == PlayerStatus.AVAILABLE)
+            .min(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
+            .orElseThrow(RoomStateInvalidException::auctionTargetMissing);
+    }
+
+    private void validateAuctionPositionLimit(TeamLeaderId leaderId, RoomPlayer target) {
+        if (positionLimit == null) {
+            return;
+        }
+
+        long assignedCount =
+            members.stream()
+                .filter(member -> member.teamLeaderId().equals(leaderId))
+                .map(this::findAssignedPlayerPosition)
+                .filter(target.getPosition()::equals)
+                .count();
+        if (assignedCount >= positionLimit) {
+            throw CoreException.of(RoomErrorType.ROOM_AUCTION_POSITION_LIMIT_EXCEEDED);
+        }
+    }
+
+    private String findAssignedPlayerPosition(RoomTeamMember member) {
+        return players.stream()
+            .filter(player -> player.getName().equals(member.playerName()))
+            .findFirst()
+            .map(RoomPlayer::getPosition)
+            .orElse(null);
     }
 
     private RoomTeamLeader getLeader(TeamLeaderId teamLeaderId) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -464,6 +464,36 @@ class Room implements AggregateRoot<Room, RoomId> {
             .orElseThrow(RoomStateInvalidException::auctionTargetMissing);
     }
 
+    RoomPlayer currentAuctionTarget() {
+        if (mode != RoomMode.AUCTION || status != RoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return null;
+        }
+
+        return players.stream()
+            .filter(it -> it.getStatus() == PlayerStatus.AVAILABLE)
+            .min(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
+            .orElse(null);
+    }
+
+    RoomBid currentWinningBid() {
+        if (mode != RoomMode.AUCTION || status != RoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return null;
+        }
+
+        return bids.stream()
+            .filter(it -> it.round() == currentAuctionRound)
+            .max(Comparator.comparingInt(RoomBid::amount))
+            .orElse(null);
+    }
+
+    int currentBidCount() {
+        if (mode != RoomMode.AUCTION || status != RoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return 0;
+        }
+
+        return (int) bids.stream().filter(it -> it.round() == currentAuctionRound).count();
+    }
+
     private void validateAuctionPositionLimit(TeamLeaderId leaderId, RoomPlayer target) {
         if (positionLimit == null) {
             return;

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomErrorType.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomErrorType.java
@@ -135,6 +135,12 @@ enum RoomErrorType implements ErrorDescriptor {
         "최소 입찰 증가폭을 만족하는 금액만 입찰할 수 있습니다",
         Level.INFO
     ),
+    ROOM_AUCTION_POSITION_LIMIT_EXCEEDED(
+        HttpStatus.CONFLICT,
+        "ROOM_AUCTION_POSITION_LIMIT_EXCEEDED",
+        "같은 포지션 선수는 팀당 제한 인원까지만 배정할 수 있습니다",
+        Level.INFO
+    ),
     ROOM_AUCTION_ROUND_NOT_ENDED(
         HttpStatus.CONFLICT,
         "ROOM_AUCTION_ROUND_NOT_ENDED",

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomProgressResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomProgressResponse.java
@@ -8,20 +8,29 @@ record RoomProgressResponse(
     Integer currentRound,
     String currentLeaderId,
     List<String> currentRoundLeaderIds,
-    Instant currentAuctionRoundEndsAt
+    Instant currentAuctionRoundEndsAt,
+    AuctionTargetResponse currentAuctionTarget,
+    Integer highestBidAmount,
+    String leadingLeaderId,
+    Integer bidCount
 ) {
     static RoomProgressResponse from(Room room) {
         if (room.getStatus() != RoomStatus.IN_PROGRESS) {
-            return new RoomProgressResponse(null, null, null, null, null);
+            return new RoomProgressResponse(null, null, null, null, null, null, null, null, null);
         }
 
         if (room.getMode() == RoomMode.AUCTION) {
+            RoomBid winningBid = room.currentWinningBid();
             return new RoomProgressResponse(
                 null,
                 room.getCurrentAuctionRound(),
                 null,
                 null,
-                room.getCurrentAuctionRoundEndsAt()
+                room.getCurrentAuctionRoundEndsAt(),
+                AuctionTargetResponse.from(room.currentAuctionTarget()),
+                winningBid == null ? null : winningBid.amount(),
+                winningBid == null ? null : winningBid.teamLeaderId().value(),
+                room.currentBidCount()
             );
         }
 
@@ -31,6 +40,10 @@ record RoomProgressResponse(
             progress.currentRound(),
             progress.currentLeaderId(),
             progress.currentRoundLeaderIds(),
+            null,
+            null,
+            null,
+            null,
             null
         );
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomTemplateSpec.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomTemplateSpec.java
@@ -9,9 +9,23 @@ record RoomTemplateSpec(
     Integer budget,
     int pickBanTime,
     Integer minBidUnit,
+    Integer positionLimit,
     DraftOrderStrategy draftOrderStrategy,
     List<Player> players
 ) {
+    RoomTemplateSpec(
+        Mode mode,
+        int teamCount,
+        int teamSize,
+        Integer budget,
+        int pickBanTime,
+        Integer minBidUnit,
+        DraftOrderStrategy draftOrderStrategy,
+        List<Player> players
+    ) {
+        this(mode, teamCount, teamSize, budget, pickBanTime, minBidUnit, null, draftOrderStrategy, players);
+    }
+
     public enum Mode {
         AUCTION,
         DRAFT

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -74,3 +74,14 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-min-bid-unit.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 7-room-position-limit
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-position-limit.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-room-position-limit.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-position-limit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rooms ADD COLUMN position_limit INT;

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
@@ -3,6 +3,7 @@ package com.naminhyeok.fantazzk.room;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ class RoomResponseTest {
     private static final String GUEST_ONE_ACTION_TOKEN = "guest-1-action-token";
     private static final String GUEST_TWO_ID = "guest-2";
     private static final String GUEST_TWO_ACTION_TOKEN = "guest-2-action-token";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     @Test
     void 드래프트_방_응답은_자리_기준_예상_시작_순서를_슬롯으로_반환한다() {
@@ -84,6 +86,21 @@ class RoomResponseTest {
         assertThat(response.draftOrderPreview()).isNull();
     }
 
+    @Test
+    void 진행중인_경매_방_응답은_현재_경매_타깃과_최고_입찰_상태를_포함한다() {
+        Room room = startedAuctionRoom();
+        room.placeBid(new TeamLeaderId(HOST_ID), 100, CREATED_AT.plusSeconds(1));
+        room.placeBid(new TeamLeaderId(GUEST_ONE_ID), 150, CREATED_AT.plusSeconds(2));
+
+        var json = OBJECT_MAPPER.valueToTree(RoomResponse.from(room));
+
+        assertThat(json.at("/progress/currentAuctionTarget/name").asText()).isEqualTo("선수1");
+        assertThat(json.at("/progress/currentAuctionTarget/position").asText()).isEqualTo("TOP");
+        assertThat(json.at("/progress/highestBidAmount").asInt()).isEqualTo(150);
+        assertThat(json.at("/progress/leadingLeaderId").asText()).isEqualTo(GUEST_ONE_ID);
+        assertThat(json.at("/progress/bidCount").asInt()).isEqualTo(2);
+    }
+
     private Room threeTeamDraftRoom() {
         return Room.createFromTemplate(
             "DRF001",
@@ -106,5 +123,32 @@ class RoomResponseTest {
             ),
             CREATED_AT
         );
+    }
+
+    private Room startedAuctionRoom() {
+        Room room =
+            Room.createFromTemplate(
+                "AUC002",
+                new TeamLeaderId(HOST_ID),
+                "호스트",
+                HOST_ACTION_TOKEN,
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.AUCTION,
+                    2,
+                    2,
+                    300,
+                    15,
+                    10,
+                    null,
+                    List.of(
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+                    )
+                ),
+                CREATED_AT
+            );
+        room.join(new TeamLeaderId(GUEST_ONE_ID), "게스트1", GUEST_ONE_ACTION_TOKEN);
+        room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
+        return room;
     }
 }


### PR DESCRIPTION
## 작업 내용
- room 생성 시 템플릿의 `positionLimit`가 `RoomTemplateSpec`과 `Room` aggregate까지 전달되도록 연결했습니다.
- 경매 입찰 및 정산 시 같은 팀이 포지션 제한을 넘는 선수에게 접근하지 못하도록 `ROOM_AUCTION_POSITION_LIMIT_EXCEEDED` 규칙을 추가했습니다.
- `rooms.position_limit` 컬럼과 Liquibase 변경셋을 추가해 포지션 제한이 persistence / schema 검증까지 이어지도록 맞췄습니다.
- 공개 room snapshot의 `progress`에 `currentAuctionTarget`, `highestBidAmount`, `leadingLeaderId`, `bidCount`를 추가했습니다.
- `GET /api/v1/rooms/{code}` 와 `POST /api/v1/rooms/{code}/auction/progress` 만으로 현재 경매 라운드 상태를 복원할 수 있도록 테스트를 보강했습니다.

## 변경 이유
현재 템플릿에는 경매 포지션 제한이 있었지만 room 도메인 규칙으로는 집행되지 않아 실제 팀빌딩 제약으로 동작하지 않았습니다. 또한 공개 room snapshot에는 현재 경매 타깃과 최고 입찰 상태가 없어, 재연결이나 이벤트 누락 상황에서 클라이언트가 authoritative 한 현재 경매 상태를 복원하기 어려웠습니다.

## 영향
- 경매 팀빌딩에서 포지션 제한이 실제 도메인 규칙으로 강제됩니다.
- 클라이언트는 공개 room snapshot만으로 현재 경매 대상 선수와 최고 입찰 상태를 확인할 수 있습니다.
- 이후 Supabase Realtime 이슈(#76)에서 room snapshot을 전파할 기반이 정리됩니다.

## 검증
- `./gradlew check integrationTest`
- `./gradlew integrationTest --tests 'com.naminhyeok.fantazzk.room.RoomAuctionIntegrationTest.같은_포지션_제한에_걸리는_선수에게는_재조회_후에도_입찰할_수_없다'`
- `./gradlew test --tests 'com.naminhyeok.fantazzk.room.RoomResponseTest'`
- `./gradlew integrationTest --tests 'com.naminhyeok.fantazzk.room.RoomApiIntegrationTest.get은_경매의_deadline_projection을_반환한다' --tests 'com.naminhyeok.fantazzk.room.RoomApiIntegrationTest.auctionProgress는_due된_경매를_정산한_latest_snapshot을_반환한다'`

## 관련 이슈
- Closes #74
- Closes #75
- Next: #76