### PR TITLE
로컬 포트 7200, 7201을 CORS 허용 목록에 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ cors:
   allowed-origins:
     - http://localhost:3000
     - http://localhost:5173
+    - http://localhost:7200
+    - http://localhost:7201
 
 logging:
   level:
@@ -102,6 +104,8 @@ cors:
   allowed-origins:
     - http://localhost:3000
     - http://localhost:5173
+    - http://localhost:7200
+    - http://localhost:7201
     - https://dev-fantazzk.vercel.app
 
 logging:


### PR DESCRIPTION
## Summary

- 기본 프로파일 및 dev 프로파일 CORS `allowed-origins`에 `http://localhost:7200`, `http://localhost:7201` 추가
- 로컬 개발 서버를 해당 포트로 띄운 프론트엔드에서 API 호출이 가능하도록 허용

## Affected profiles

- default (로컬)
- dev

production 프로파일은 대상 아님.