### PR TITLE
room, draft, auction 모듈 경계를 분리한다

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
@@ -39,6 +39,10 @@ class LiquibasePostgresSmokeTest {
         assertThat(isNullable("rooms", "position_limit")).isTrue();
         assertThat(countIndex("rooms", "idx_rooms_status_created_at")).isEqualTo(1);
         assertThat(indexColumns("rooms", "idx_rooms_status_created_at")).containsExactly("status", "created_at");
+        assertThat(countTable("room_team_member")).isEqualTo(1);
+        assertThat(countColumn("room_team_member", "player_id")).isEqualTo(1);
+        assertThat(isNullable("room_team_member", "player_id")).isFalse();
+        assertThat(countColumn("room_team_member", "player_name")).isEqualTo(0);
     }
 
     private Integer countTable(String tableName) {

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibasePostgresSmokeTest.java
@@ -43,6 +43,10 @@ class LiquibasePostgresSmokeTest {
         assertThat(countColumn("room_team_member", "player_id")).isEqualTo(1);
         assertThat(isNullable("room_team_member", "player_id")).isFalse();
         assertThat(countColumn("room_team_member", "player_name")).isEqualTo(0);
+        assertThat(countTable("draft_room")).isEqualTo(1);
+        assertThat(countColumn("draft_room", "state_json")).isEqualTo(1);
+        assertThat(countTable("auction_room")).isEqualTo(1);
+        assertThat(countColumn("auction_room", "snapshot_json")).isEqualTo(1);
     }
 
     private Integer countTable(String tableName) {

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -53,6 +53,10 @@ class LiquibaseSmokeTest {
         assertThat(countColumn("room_team_member", "player_id")).isEqualTo(1);
         assertThat(isNullable("room_team_member", "player_id")).isFalse();
         assertThat(countColumn("room_team_member", "player_name")).isEqualTo(0);
+        assertThat(countTable("draft_room")).isEqualTo(1);
+        assertThat(countColumn("draft_room", "state_json")).isEqualTo(1);
+        assertThat(countTable("auction_room")).isEqualTo(1);
+        assertThat(countColumn("auction_room", "snapshot_json")).isEqualTo(1);
         assertThat(countTable("room_bid")).isEqualTo(1);
         assertThat(countColumn("room_bid", "bid_sequence")).isEqualTo(1);
         assertThat(countTable("event_publication")).isEqualTo(1);

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/LiquibaseSmokeTest.java
@@ -50,6 +50,9 @@ class LiquibaseSmokeTest {
         assertThat(countColumn("room_team_leader", "draft_position")).isEqualTo(1);
         assertThat(countColumn("room_team_leader", "action_token")).isEqualTo(1);
         assertThat(countTable("room_team_member")).isEqualTo(1);
+        assertThat(countColumn("room_team_member", "player_id")).isEqualTo(1);
+        assertThat(isNullable("room_team_member", "player_id")).isFalse();
+        assertThat(countColumn("room_team_member", "player_name")).isEqualTo(0);
         assertThat(countTable("room_bid")).isEqualTo(1);
         assertThat(countColumn("room_bid", "bid_sequence")).isEqualTo(1);
         assertThat(countTable("event_publication")).isEqualTo(1);

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -63,7 +63,7 @@ class RoomApiIntegrationTest {
     @Test
     void auctionProgress는_due된_경매를_정산한_latest_snapshot을_반환한다() {
         Room room = startedAuctionRoom("ROOM10", CREATED_AT.minusSeconds(30));
-        room.placeBid(new TeamLeaderId("host-ROOM10"), 100, CREATED_AT.plusSeconds(1));
+        room.placeBid(new TeamLeaderId("host-ROOM10"), 100, CREATED_AT.minusSeconds(30));
         rooms.save(room);
 
         HttpHeaders headers = new HttpHeaders();
@@ -111,7 +111,7 @@ class RoomApiIntegrationTest {
         assertThat(body.success().progress().leadingLeaderId()).isEqualTo("host-ROOM11");
         assertThat(body.success().progress().bidCount()).isEqualTo(1);
         assertThat(body.success().progress().currentAuctionRoundEndsAt())
-            .isEqualTo(Instant.parse("2026-04-09T00:00:45Z"));
+            .isEqualTo(Instant.parse("2026-04-09T00:00:46Z"));
     }
 
     private Room startedAuctionRoom(String code, Instant createdAt) {

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomApiIntegrationTest.java
@@ -82,6 +82,7 @@ class RoomApiIntegrationTest {
         assertThat(body.success().code()).isEqualTo("ROOM10");
         assertThat(body.success().status()).isEqualTo("IN_PROGRESS");
         assertThat(body.success().progress().currentRound()).isEqualTo(2);
+        assertThat(body.success().progress().currentAuctionTarget().playerId()).isEqualTo(1);
         assertThat(body.success().progress().currentAuctionTarget().name()).isEqualTo("선수2");
         assertThat(body.success().progress().currentAuctionTarget().position()).isEqualTo("JUNGLE");
         assertThat(body.success().progress().highestBidAmount()).isNull();
@@ -105,6 +106,7 @@ class RoomApiIntegrationTest {
         assertThat(body.resultType()).isEqualTo("SUCCESS");
         assertThat(body.success().code()).isEqualTo("ROOM11");
         assertThat(body.success().progress().currentRound()).isEqualTo(1);
+        assertThat(body.success().progress().currentAuctionTarget().playerId()).isEqualTo(0);
         assertThat(body.success().progress().currentAuctionTarget().name()).isEqualTo("선수1");
         assertThat(body.success().progress().currentAuctionTarget().position()).isEqualTo("TOP");
         assertThat(body.success().progress().highestBidAmount()).isEqualTo(120);

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomAuctionIntegrationTest.java
@@ -94,11 +94,12 @@ class RoomAuctionIntegrationTest {
             .extracting(RoomBid::teamLeaderId, RoomBid::amount)
             .containsExactly(guest.getId(), 150);
         assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
+        assertThat(settlement.playerId()).isEqualTo(new RoomPlayerId(0));
         assertThat(settlement.playerName()).isEqualTo("선수1");
         assertThat(reloaded.getPlayers().getFirst().getPosition()).isEqualTo("TOP");
         assertThat(reloaded.getMembers()).singleElement()
-            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerName)
-            .containsExactly(guest.getId(), "선수1");
+            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerId)
+            .containsExactly(guest.getId(), new RoomPlayerId(0));
         assertThat(reloaded.getLeaders().stream().filter(it -> it.getId().equals(guest.getId())).findFirst().orElseThrow().getRemainingBudget())
             .isEqualTo(150);
         assertThat(reloaded.getCurrentAuctionRound()).isEqualTo(2);

--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/RoomDraftIntegrationTest.java
@@ -59,15 +59,15 @@ class RoomDraftIntegrationTest {
         selectDraftPosition.select(created.room().getCode(), guest.getActionToken(), 1);
         startRoom.start(created.room().getCode(), created.leader().getActionToken());
 
-        Room picked = pickDraft.pick(created.room().getCode(), guest.getActionToken(), "선수1");
+        Room picked = pickDraft.pick(created.room().getCode(), guest.getActionToken(), new RoomPlayerId(0));
 
         Room reloaded = rooms.findByCode(created.room().getCode()).orElseThrow();
 
-        assertThat(picked.getMembers().getLast().playerName()).isEqualTo("선수1");
+        assertThat(picked.getMembers().getLast().playerId()).isEqualTo(new RoomPlayerId(0));
         assertThat(reloaded.getMembers()).singleElement()
-            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerName)
-            .containsExactly(guest.getId(), "선수1");
-        assertThat(reloaded.getPlayers().stream().filter(it -> it.getName().equals("선수1")).findFirst().orElseThrow().getStatus())
+            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerId)
+            .containsExactly(guest.getId(), new RoomPlayerId(0));
+        assertThat(reloaded.getPlayers().stream().filter(it -> it.getId().equals(new RoomPlayerId(0))).findFirst().orElseThrow().getStatus())
             .isEqualTo(PlayerStatus.ASSIGNED);
         assertThat(reloaded.getCurrentTurnIndex()).isEqualTo(1);
     }
@@ -92,7 +92,7 @@ class RoomDraftIntegrationTest {
         selectDraftPosition.select(created.room().getCode(), guest.getActionToken(), 1);
         startRoom.start(created.room().getCode(), created.leader().getActionToken());
 
-        assertThatThrownBy(() -> pickDraft.pick(created.room().getCode(), created.leader().getActionToken(), "없는선수"))
+        assertThatThrownBy(() -> pickDraft.pick(created.room().getCode(), created.leader().getActionToken(), new RoomPlayerId(99)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_PICK_OUT_OF_TURN));
     }
@@ -121,8 +121,8 @@ class RoomDraftIntegrationTest {
         selectDraftPosition.select(created.room().getCode(), guest.getActionToken(), 2);
         startRoom.start(created.room().getCode(), host.getActionToken());
 
-        pickDraft.pick(created.room().getCode(), host.getActionToken(), "선수1");
-        pickDraft.pick(created.room().getCode(), guest.getActionToken(), "선수2");
+        pickDraft.pick(created.room().getCode(), host.getActionToken(), new RoomPlayerId(0));
+        pickDraft.pick(created.room().getCode(), guest.getActionToken(), new RoomPlayerId(1));
 
         entityManager.flush();
         entityManager.clear();
@@ -130,7 +130,7 @@ class RoomDraftIntegrationTest {
 
         assertThat(reloadedAfterSecondPick.getCurrentTurnIndex()).isEqualTo(2);
 
-        Room thirdPick = pickDraft.pick(created.room().getCode(), guest.getActionToken(), "선수3");
+        Room thirdPick = pickDraft.pick(created.room().getCode(), guest.getActionToken(), new RoomPlayerId(2));
 
         entityManager.flush();
         entityManager.clear();
@@ -138,11 +138,11 @@ class RoomDraftIntegrationTest {
 
         assertThat(thirdPick.getMembers().getLast().teamLeaderId()).isEqualTo(guest.getId());
         assertThat(reloadedAfterThirdPick.getMembers())
-            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerName)
+            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerId)
             .containsExactly(
-                tuple(host.getId(), "선수1"),
-                tuple(guest.getId(), "선수2"),
-                tuple(guest.getId(), "선수3")
+                tuple(host.getId(), new RoomPlayerId(0)),
+                tuple(guest.getId(), new RoomPlayerId(1)),
+                tuple(guest.getId(), new RoomPlayerId(2))
             );
         assertThat(reloadedAfterThirdPick.getCurrentTurnIndex()).isEqualTo(3);
     }

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionBid.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.auction;
+
+public record AuctionBid(
+    int round,
+    int sequence,
+    String leaderId,
+    int amount
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionOutcome.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionOutcome.java
@@ -1,0 +1,6 @@
+package com.naminhyeok.fantazzk.auction;
+
+public enum AuctionOutcome {
+    SOLD,
+    PASSED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayer.java
@@ -15,6 +15,14 @@ final class AuctionPlayer {
         this.status = AuctionPlayerStatus.AVAILABLE;
     }
 
+    AuctionPlayer(int playerId, String name, String position, int displayOrder, AuctionPlayerStatus status) {
+        this.playerId = playerId;
+        this.name = name;
+        this.position = position;
+        this.displayOrder = displayOrder;
+        this.status = status;
+    }
+
     int playerId() {
         return playerId;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayer.java
@@ -1,0 +1,45 @@
+package com.naminhyeok.fantazzk.auction;
+
+final class AuctionPlayer {
+    private final int playerId;
+    private final String name;
+    private final String position;
+    private int displayOrder;
+    private AuctionPlayerStatus status;
+
+    AuctionPlayer(int playerId, String name, String position, int displayOrder) {
+        this.playerId = playerId;
+        this.name = name;
+        this.position = position;
+        this.displayOrder = displayOrder;
+        this.status = AuctionPlayerStatus.AVAILABLE;
+    }
+
+    int playerId() {
+        return playerId;
+    }
+
+    String name() {
+        return name;
+    }
+
+    String position() {
+        return position;
+    }
+
+    int displayOrder() {
+        return displayOrder;
+    }
+
+    boolean available() {
+        return status == AuctionPlayerStatus.AVAILABLE;
+    }
+
+    void assign() {
+        status = AuctionPlayerStatus.ASSIGNED;
+    }
+
+    void moveToBack(int nextDisplayOrder) {
+        displayOrder = nextDisplayOrder;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayerSeed.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayerSeed.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.auction;
+
+public record AuctionPlayerSeed(
+    int playerId,
+    String name,
+    String position,
+    int displayOrder
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayerStatus.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionPlayerStatus.java
@@ -1,0 +1,6 @@
+package com.naminhyeok.fantazzk.auction;
+
+enum AuctionPlayerStatus {
+    AVAILABLE,
+    ASSIGNED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoom.java
@@ -6,9 +6,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import org.jmolecules.ddd.types.AggregateRoot;
 
-public final class AuctionRoom implements AggregateRoot<AuctionRoom, AuctionRoomId> {
+public final class AuctionRoom {
     private final AuctionRoomId id;
     private final String code;
     private final Instant createdAt;
@@ -57,7 +56,6 @@ public final class AuctionRoom implements AggregateRoot<AuctionRoom, AuctionRoom
         this.currentAuctionRoundEndsAt = null;
     }
 
-    @Override
     public AuctionRoomId getId() {
         return id;
     }
@@ -92,6 +90,43 @@ public final class AuctionRoom implements AggregateRoot<AuctionRoom, AuctionRoom
             .map(player -> new AuctionPlayer(player.playerId(), player.name(), player.position(), player.displayOrder()))
             .forEach(room.players::add);
         room.leaders.add(new AuctionTeamLeader(hostLeaderId, hostNickname.trim(), setup.budget()));
+        return room;
+    }
+
+    static AuctionRoom restore(AuctionRoomSnapshot snapshot) {
+        AuctionRoom room =
+            new AuctionRoom(
+                snapshot.code(),
+                snapshot.createdAt(),
+                snapshot.hostLeaderId(),
+                snapshot.teamCount(),
+                snapshot.teamSize(),
+                snapshot.budget(),
+                snapshot.pickBanTime(),
+                snapshot.minBidUnit(),
+                snapshot.positionLimit()
+            );
+        room.leaders.addAll(snapshot.leaders().stream()
+            .map(leader -> new AuctionTeamLeader(leader.leaderId(), leader.nickname(), leader.remainingBudget()))
+            .toList());
+        room.players.addAll(snapshot.players().stream()
+            .map(player -> new AuctionPlayer(
+                player.playerId(),
+                player.name(),
+                player.position(),
+                player.displayOrder(),
+                player.status()
+            ))
+            .toList());
+        room.members.addAll(snapshot.members().stream()
+            .map(member -> new AuctionTeamMember(member.leaderId(), member.playerId(), member.sequence()))
+            .toList());
+        room.bids.addAll(snapshot.bids().stream()
+            .map(bid -> new AuctionBid(bid.round(), bid.sequence(), bid.leaderId(), bid.amount()))
+            .toList());
+        room.status = snapshot.status();
+        room.currentAuctionRound = snapshot.currentAuctionRound();
+        room.currentAuctionRoundEndsAt = snapshot.currentAuctionRoundEndsAt();
         return room;
     }
 
@@ -207,17 +242,92 @@ public final class AuctionRoom implements AggregateRoot<AuctionRoom, AuctionRoom
 
     AuctionRoomState readState() {
         if (status == AuctionRoomStatus.WAITING) {
-            return new AuctionRoomState(code, status, null, null, null, null, 0);
+            return new AuctionRoomState(
+                code,
+                status,
+                leaderStates(),
+                playerStates(),
+                memberStates(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                0
+            );
         }
 
         return new AuctionRoomState(
             code,
             status,
+            leaderStates(),
+            playerStates(),
+            memberStates(),
             currentAuctionRound,
             currentAuctionRoundEndsAt,
             currentTargetSnapshot(),
             currentHighestBidAmount(),
+            currentWinningBid() == null ? null : currentWinningBid().leaderId(),
             currentBidCount()
+        );
+    }
+
+    private List<AuctionRoomState.Leader> leaderStates() {
+        return leaders.stream()
+            .map(leader -> new AuctionRoomState.Leader(leader.leaderId(), leader.nickname(), leader.remainingBudget()))
+            .toList();
+    }
+
+    private List<AuctionRoomState.Player> playerStates() {
+        return players.stream()
+            .map(player -> new AuctionRoomState.Player(
+                player.playerId(),
+                player.name(),
+                player.position(),
+                player.displayOrder(),
+                !player.available()
+            ))
+            .toList();
+    }
+
+    private List<AuctionRoomState.Member> memberStates() {
+        return members.stream()
+            .map(member -> new AuctionRoomState.Member(member.leaderId(), member.playerId(), member.sequence()))
+            .toList();
+    }
+
+    AuctionRoomSnapshot snapshot() {
+        return new AuctionRoomSnapshot(
+            code,
+            createdAt,
+            hostLeaderId,
+            teamCount,
+            teamSize,
+            budget,
+            pickBanTime,
+            minBidUnit,
+            positionLimit,
+            status,
+            currentAuctionRound,
+            currentAuctionRoundEndsAt,
+            leaders.stream()
+                .map(leader -> new AuctionRoomSnapshot.Leader(leader.leaderId(), leader.nickname(), leader.remainingBudget()))
+                .toList(),
+            players.stream()
+                .map(player -> new AuctionRoomSnapshot.Player(
+                    player.playerId(),
+                    player.name(),
+                    player.position(),
+                    player.displayOrder(),
+                    player.available() ? AuctionPlayerStatus.AVAILABLE : AuctionPlayerStatus.ASSIGNED
+                ))
+                .toList(),
+            members.stream()
+                .map(member -> new AuctionRoomSnapshot.Member(member.leaderId(), member.playerId(), member.sequence()))
+                .toList(),
+            bids.stream()
+                .map(bid -> new AuctionRoomSnapshot.Bid(bid.round(), bid.sequence(), bid.leaderId(), bid.amount()))
+                .toList()
         );
     }
 

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoom.java
@@ -1,0 +1,330 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jmolecules.ddd.types.AggregateRoot;
+
+public final class AuctionRoom implements AggregateRoot<AuctionRoom, AuctionRoomId> {
+    private final AuctionRoomId id;
+    private final String code;
+    private final Instant createdAt;
+    private final String hostLeaderId;
+    private final int teamCount;
+    private final int teamSize;
+    private final Integer budget;
+    private final int pickBanTime;
+    private final Integer minBidUnit;
+    private final Integer positionLimit;
+    private final List<AuctionPlayer> players;
+    private final List<AuctionTeamLeader> leaders;
+    private final List<AuctionTeamMember> members;
+    private final List<AuctionBid> bids;
+    private AuctionRoomStatus status;
+    private Integer currentAuctionRound;
+    private Instant currentAuctionRoundEndsAt;
+
+    private AuctionRoom(
+        String code,
+        Instant createdAt,
+        String hostLeaderId,
+        int teamCount,
+        int teamSize,
+        Integer budget,
+        int pickBanTime,
+        Integer minBidUnit,
+        Integer positionLimit
+    ) {
+        this.id = new AuctionRoomId(UUID.randomUUID());
+        this.code = code;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt must not be null");
+        this.hostLeaderId = Objects.requireNonNull(hostLeaderId, "hostLeaderId must not be null");
+        this.teamCount = teamCount;
+        this.teamSize = teamSize;
+        this.budget = budget;
+        this.pickBanTime = pickBanTime;
+        this.minBidUnit = minBidUnit;
+        this.positionLimit = positionLimit;
+        this.players = new ArrayList<>();
+        this.leaders = new ArrayList<>();
+        this.members = new ArrayList<>();
+        this.bids = new ArrayList<>();
+        this.status = AuctionRoomStatus.WAITING;
+        this.currentAuctionRound = null;
+        this.currentAuctionRoundEndsAt = null;
+    }
+
+    @Override
+    public AuctionRoomId getId() {
+        return id;
+    }
+
+    public static AuctionRoom create(
+        String code,
+        String hostLeaderId,
+        String hostNickname,
+        Instant createdAt,
+        AuctionRoomSetup setup
+    ) {
+        Objects.requireNonNull(hostNickname, "hostNickname must not be null");
+        Objects.requireNonNull(setup, "setup must not be null");
+        AuctionRoom room =
+            new AuctionRoom(
+                code,
+                createdAt,
+                hostLeaderId,
+                setup.teamCount(),
+                setup.teamSize(),
+                setup.budget(),
+                setup.pickBanTime(),
+                setup.minBidUnit(),
+                setup.positionLimit()
+            );
+        int requiredPlayerCount = setup.teamCount() * (setup.teamSize() - 1);
+        if (setup.players().size() != requiredPlayerCount) {
+            throw new IllegalArgumentException("선수 수는 정확히 " + requiredPlayerCount + "명이어야 합니다");
+        }
+        setup.players().stream()
+            .sorted(Comparator.comparingInt(AuctionPlayerSeed::displayOrder))
+            .map(player -> new AuctionPlayer(player.playerId(), player.name(), player.position(), player.displayOrder()))
+            .forEach(room.players::add);
+        room.leaders.add(new AuctionTeamLeader(hostLeaderId, hostNickname.trim(), setup.budget()));
+        return room;
+    }
+
+    void addLeader(String leaderId, String nickname) {
+        requireWaiting();
+        if (leaders.size() >= teamCount) {
+            throw AuctionRoomException.leaderLimitReached();
+        }
+
+        String normalizedNickname = normalizeNickname(nickname);
+        boolean taken =
+            leaders.stream()
+                .map(AuctionTeamLeader::nickname)
+                .map(this::normalizeNickname)
+                .anyMatch(normalizedNickname::equals);
+        if (taken) {
+            throw AuctionRoomException.nicknameTaken(nickname);
+        }
+
+        leaders.add(new AuctionTeamLeader(leaderId, nickname.trim(), budget));
+    }
+
+    void start(String callerLeaderId, Instant now) {
+        requireWaiting();
+        if (!hostLeaderId.equals(callerLeaderId)) {
+            throw AuctionRoomException.hostForbidden(callerLeaderId);
+        }
+        if (leaders.size() != teamCount) {
+            throw AuctionRoomException.leadersNotFull();
+        }
+
+        status = AuctionRoomStatus.IN_PROGRESS;
+        currentAuctionRound = 1;
+        currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
+    }
+
+    AuctionBid placeBid(String leaderId, int amount, Instant now) {
+        requireInProgress();
+        requireCurrentRound();
+        if (currentAuctionRoundEndsAt != null && !now.isBefore(currentAuctionRoundEndsAt)) {
+            throw AuctionRoomException.roundNotEnded();
+        }
+        if (amount <= 0) {
+            throw AuctionRoomException.amountNotPositive();
+        }
+
+        AuctionTeamLeader leader = findLeader(leaderId);
+        AuctionPlayer target = requireCurrentTarget();
+        validateAuctionPositionLimit(leaderId, target);
+
+        if (leader.remainingBudget() != null && leader.remainingBudget() < amount) {
+            throw AuctionRoomException.budgetExceeded();
+        }
+
+        Integer highestBidAmount = currentHighestBidAmount();
+        if (highestBidAmount == null) {
+            if (minBidUnit != null && amount < minBidUnit) {
+                throw AuctionRoomException.minUnitNotMet();
+            }
+        } else {
+            if (amount <= highestBidAmount) {
+                throw AuctionRoomException.tooLow();
+            }
+            if (minBidUnit != null && amount < highestBidAmount + minBidUnit) {
+                throw AuctionRoomException.minUnitNotMet();
+            }
+        }
+
+        int sequence = currentBidCount() + 1;
+        AuctionBid bid = new AuctionBid(currentAuctionRound, sequence, leaderId, amount);
+        bids.add(bid);
+        currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
+        return bid;
+    }
+
+    AuctionSettlement settle(Instant now) {
+        requireInProgress();
+        requireCurrentRound();
+        if (currentAuctionRoundEndsAt == null) {
+            throw AuctionRoomException.roundMissing();
+        }
+        if (now.isBefore(currentAuctionRoundEndsAt)) {
+            throw AuctionRoomException.roundNotEnded();
+        }
+
+        AuctionPlayer target = requireCurrentTarget();
+        AuctionBid winningBid = currentWinningBid();
+
+        if (winningBid == null) {
+            int maxOrder = players.stream().mapToInt(AuctionPlayer::displayOrder).max().orElse(0);
+            target.moveToBack(maxOrder + 1);
+            currentAuctionRound += 1;
+            currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
+            return new AuctionSettlement(target.playerId(), target.name(), AuctionOutcome.PASSED);
+        }
+
+        AuctionTeamLeader winner = findLeader(winningBid.leaderId());
+        validateAuctionPositionLimit(winner.leaderId(), target);
+        target.assign();
+        winner.spend(winningBid.amount());
+        members.add(new AuctionTeamMember(winner.leaderId(), target.playerId(), members.size()));
+
+        if (members.size() == teamCount * (teamSize - 1)) {
+            status = AuctionRoomStatus.COMPLETED;
+            currentAuctionRoundEndsAt = null;
+        } else {
+            currentAuctionRound += 1;
+            currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
+        }
+
+        return new AuctionSettlement(target.playerId(), target.name(), AuctionOutcome.SOLD);
+    }
+
+    AuctionRoomState readState() {
+        if (status == AuctionRoomStatus.WAITING) {
+            return new AuctionRoomState(code, status, null, null, null, null, 0);
+        }
+
+        return new AuctionRoomState(
+            code,
+            status,
+            currentAuctionRound,
+            currentAuctionRoundEndsAt,
+            currentTargetSnapshot(),
+            currentHighestBidAmount(),
+            currentBidCount()
+        );
+    }
+
+    private AuctionTarget currentTargetSnapshot() {
+        AuctionPlayer target = currentTargetOrNull();
+        return target == null ? null : new AuctionTarget(target.playerId(), target.name(), target.position());
+    }
+
+    private AuctionPlayer currentTargetOrNull() {
+        if (status != AuctionRoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return null;
+        }
+        return players.stream()
+            .filter(AuctionPlayer::available)
+            .min(Comparator.comparingInt(AuctionPlayer::displayOrder))
+            .orElse(null);
+    }
+
+    private AuctionPlayer requireCurrentTarget() {
+        AuctionPlayer target = currentTargetOrNull();
+        if (target == null) {
+            throw AuctionRoomException.targetMissing();
+        }
+        return target;
+    }
+
+    private Integer currentHighestBidAmount() {
+        if (status != AuctionRoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return null;
+        }
+        return bids.stream()
+            .filter(bid -> bid.round() == currentAuctionRound)
+            .map(AuctionBid::amount)
+            .max(Integer::compareTo)
+            .orElse(null);
+    }
+
+    private AuctionBid currentWinningBid() {
+        if (status != AuctionRoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return null;
+        }
+        return bids.stream()
+            .filter(bid -> bid.round() == currentAuctionRound)
+            .max(Comparator.comparingInt(AuctionBid::amount))
+            .orElse(null);
+    }
+
+    private int currentBidCount() {
+        if (status != AuctionRoomStatus.IN_PROGRESS || currentAuctionRound == null) {
+            return 0;
+        }
+        return (int) bids.stream().filter(bid -> bid.round() == currentAuctionRound).count();
+    }
+
+    private AuctionTeamLeader findLeader(String leaderId) {
+        return leaders.stream()
+            .filter(leader -> leader.leaderId().equals(leaderId))
+            .findFirst()
+            .orElseThrow(() -> AuctionRoomException.bidderMissing(leaderId));
+    }
+
+    private void validateAuctionPositionLimit(String leaderId, AuctionPlayer target) {
+        if (positionLimit == null) {
+            return;
+        }
+
+        long assignedCount =
+            members.stream()
+                .filter(member -> member.leaderId().equals(leaderId))
+                .map(this::findAssignedPlayerPosition)
+                .filter(target.position()::equals)
+                .count();
+        if (assignedCount >= positionLimit) {
+            throw AuctionRoomException.positionLimitExceeded();
+        }
+    }
+
+    private String findAssignedPlayerPosition(AuctionTeamMember member) {
+        return findPlayer(member.playerId()).position();
+    }
+
+    private AuctionPlayer findPlayer(int playerId) {
+        return players.stream()
+            .filter(player -> player.playerId() == playerId)
+            .findFirst()
+            .orElseThrow(() -> AuctionRoomException.playerMissing(playerId));
+    }
+
+    private void requireWaiting() {
+        if (status != AuctionRoomStatus.WAITING) {
+            throw AuctionRoomException.roomNotWaiting();
+        }
+    }
+
+    private void requireInProgress() {
+        if (status != AuctionRoomStatus.IN_PROGRESS) {
+            throw AuctionRoomException.roomNotInProgress();
+        }
+    }
+
+    private void requireCurrentRound() {
+        if (currentAuctionRound == null) {
+            throw AuctionRoomException.roundMissing();
+        }
+    }
+
+    private String normalizeNickname(String nickname) {
+        return nickname.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomException.java
@@ -1,0 +1,83 @@
+package com.naminhyeok.fantazzk.auction;
+
+final class AuctionRoomException extends RuntimeException {
+    private AuctionRoomException(String message) {
+        super(message);
+    }
+
+    static AuctionRoomException roomNotFound(String code) {
+        return new AuctionRoomException("경매 방을 찾을 수 없습니다: " + code);
+    }
+
+    static AuctionRoomException hostForbidden(String leaderId) {
+        return new AuctionRoomException("호스트만 경매를 시작할 수 있습니다: " + leaderId);
+    }
+
+    static AuctionRoomException roomNotWaiting() {
+        return new AuctionRoomException("대기 중인 경매 방이 아닙니다");
+    }
+
+    static AuctionRoomException roomNotInProgress() {
+        return new AuctionRoomException("진행 중인 경매가 아닙니다");
+    }
+
+    static AuctionRoomException roundMissing() {
+        return new AuctionRoomException("현재 경매 라운드가 없습니다");
+    }
+
+    static AuctionRoomException roundNotEnded() {
+        return new AuctionRoomException("경매 라운드가 아직 종료되지 않았습니다");
+    }
+
+    static AuctionRoomException leaderLimitReached() {
+        return new AuctionRoomException("경매 팀장 수가 가득 찼습니다");
+    }
+
+    static AuctionRoomException leadersNotFull() {
+        return new AuctionRoomException("경매 팀장 수가 아직 채워지지 않았습니다");
+    }
+
+    static AuctionRoomException nicknameTaken(String nickname) {
+        return new AuctionRoomException("이미 사용 중인 닉네임입니다: " + nickname);
+    }
+
+    static AuctionRoomException leaderMissing(String leaderId) {
+        return new AuctionRoomException("방에 없는 팀장입니다: " + leaderId);
+    }
+
+    static AuctionRoomException bidderMissing(String leaderId) {
+        return new AuctionRoomException("입찰자를 찾을 수 없습니다: " + leaderId);
+    }
+
+    static AuctionRoomException targetMissing() {
+        return new AuctionRoomException("입찰할 선수가 없습니다");
+    }
+
+    static AuctionRoomException amountNotPositive() {
+        return new AuctionRoomException("입찰 금액은 0보다 커야 합니다");
+    }
+
+    static AuctionRoomException budgetExceeded() {
+        return new AuctionRoomException("예산이 부족합니다");
+    }
+
+    static AuctionRoomException tooLow() {
+        return new AuctionRoomException("현재 최고가보다 낮거나 같은 입찰입니다");
+    }
+
+    static AuctionRoomException minUnitNotMet() {
+        return new AuctionRoomException("최소 입찰 단위를 만족하지 않습니다");
+    }
+
+    static AuctionRoomException positionLimitExceeded() {
+        return new AuctionRoomException("포지션 제한을 초과했습니다");
+    }
+
+    static AuctionRoomException winnerMissing(String leaderId) {
+        return new AuctionRoomException("낙찰된 팀장을 찾을 수 없습니다: " + leaderId);
+    }
+
+    static AuctionRoomException playerMissing(int playerId) {
+        return new AuctionRoomException("선수를 찾을 수 없습니다: " + playerId);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomId.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomId.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.util.UUID;
+import org.jmolecules.ddd.types.Identifier;
+
+public record AuctionRoomId(UUID value) implements Identifier {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycle.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycle.java
@@ -1,0 +1,44 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+import org.jmolecules.ddd.annotation.Service;
+
+@Service
+public class AuctionRoomLifecycle {
+    private final AuctionRooms rooms;
+
+    public AuctionRoomLifecycle(AuctionRooms rooms) {
+        this.rooms = rooms;
+    }
+
+    public AuctionRoomState create(String code, String hostLeaderId, String hostNickname, Instant createdAt, AuctionRoomSetup setup) {
+        AuctionRoom room = AuctionRoom.create(code, hostLeaderId, hostNickname, createdAt, setup);
+        rooms.save(room);
+        return room.readState();
+    }
+
+    public AuctionRoomState addLeader(String code, String leaderId, String nickname) {
+        AuctionRoom room = loadRoom(code);
+        room.addLeader(leaderId, nickname);
+        rooms.saveAndFlush(room);
+        return room.readState();
+    }
+
+    public AuctionRoomState start(String code, String hostLeaderId, Instant now) {
+        AuctionRoom room = loadRoom(code);
+        room.start(hostLeaderId, now);
+        rooms.saveAndFlush(room);
+        return room.readState();
+    }
+
+    public AuctionSettlement settle(String code, Instant now) {
+        AuctionRoom room = loadRoom(code);
+        AuctionSettlement settlement = room.settle(now);
+        rooms.saveAndFlush(room);
+        return settlement;
+    }
+
+    private AuctionRoom loadRoom(String code) {
+        return rooms.findByCode(code).orElseThrow(() -> AuctionRoomException.roomNotFound(code));
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycle.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycle.java
@@ -1,8 +1,10 @@
 package com.naminhyeok.fantazzk.auction;
 
 import java.time.Instant;
+import org.springframework.stereotype.Component;
 import org.jmolecules.ddd.annotation.Service;
 
+@Component
 @Service
 public class AuctionRoomLifecycle {
     private final AuctionRooms rooms;

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlay.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlay.java
@@ -1,8 +1,10 @@
 package com.naminhyeok.fantazzk.auction;
 
 import java.time.Instant;
+import org.springframework.stereotype.Component;
 import org.jmolecules.ddd.annotation.Service;
 
+@Component
 @Service
 public class AuctionRoomPlay {
     private final AuctionRooms rooms;

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlay.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlay.java
@@ -1,0 +1,20 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+import org.jmolecules.ddd.annotation.Service;
+
+@Service
+public class AuctionRoomPlay {
+    private final AuctionRooms rooms;
+
+    public AuctionRoomPlay(AuctionRooms rooms) {
+        this.rooms = rooms;
+    }
+
+    public AuctionBid placeBid(String code, String leaderId, int amount, Instant now) {
+        AuctionRoom room = rooms.findByCode(code).orElseThrow(() -> AuctionRoomException.roomNotFound(code));
+        AuctionBid bid = room.placeBid(leaderId, amount, now);
+        rooms.saveAndFlush(room);
+        return bid;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomSetup.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomSetup.java
@@ -1,0 +1,14 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.util.List;
+
+public record AuctionRoomSetup(
+    int teamCount,
+    int teamSize,
+    Integer budget,
+    int pickBanTime,
+    Integer minBidUnit,
+    Integer positionLimit,
+    List<AuctionPlayerSeed> players
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomSnapshot.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomSnapshot.java
@@ -1,0 +1,35 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+import java.util.List;
+
+record AuctionRoomSnapshot(
+    String code,
+    Instant createdAt,
+    String hostLeaderId,
+    int teamCount,
+    int teamSize,
+    Integer budget,
+    int pickBanTime,
+    Integer minBidUnit,
+    Integer positionLimit,
+    AuctionRoomStatus status,
+    Integer currentAuctionRound,
+    Instant currentAuctionRoundEndsAt,
+    List<Leader> leaders,
+    List<Player> players,
+    List<Member> members,
+    List<Bid> bids
+) {
+    record Leader(String leaderId, String nickname, Integer remainingBudget) {
+    }
+
+    record Player(int playerId, String name, String position, int displayOrder, AuctionPlayerStatus status) {
+    }
+
+    record Member(String leaderId, int playerId, int sequence) {
+    }
+
+    record Bid(int round, int sequence, String leaderId, int amount) {
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomState.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomState.java
@@ -1,0 +1,14 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+
+public record AuctionRoomState(
+    String code,
+    AuctionRoomStatus status,
+    Integer currentRound,
+    Instant currentRoundEndsAt,
+    AuctionTarget currentTarget,
+    Integer highestBidAmount,
+    int bidCount
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomState.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomState.java
@@ -1,14 +1,41 @@
 package com.naminhyeok.fantazzk.auction;
 
 import java.time.Instant;
+import java.util.List;
 
 public record AuctionRoomState(
     String code,
     AuctionRoomStatus status,
+    List<Leader> leaders,
+    List<Player> players,
+    List<Member> members,
     Integer currentRound,
     Instant currentRoundEndsAt,
     AuctionTarget currentTarget,
     Integer highestBidAmount,
+    String leadingLeaderId,
     int bidCount
 ) {
+    public record Leader(
+        String leaderId,
+        String nickname,
+        Integer remainingBudget
+    ) {
+    }
+
+    public record Player(
+        int playerId,
+        String name,
+        String position,
+        int displayOrder,
+        boolean assigned
+    ) {
+    }
+
+    public record Member(
+        String leaderId,
+        int playerId,
+        int assignOrder
+    ) {
+    }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReader.java
@@ -1,0 +1,18 @@
+package com.naminhyeok.fantazzk.auction;
+
+import org.jmolecules.ddd.annotation.Service;
+
+@Service
+public class AuctionRoomStateReader {
+    private final AuctionRooms rooms;
+
+    public AuctionRoomStateReader(AuctionRooms rooms) {
+        this.rooms = rooms;
+    }
+
+    public AuctionRoomState read(String code) {
+        return rooms.findByCode(code)
+            .map(AuctionRoom::readState)
+            .orElseThrow(() -> AuctionRoomException.roomNotFound(code));
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReader.java
@@ -1,7 +1,9 @@
 package com.naminhyeok.fantazzk.auction;
 
+import org.springframework.stereotype.Component;
 import org.jmolecules.ddd.annotation.Service;
 
+@Component
 @Service
 public class AuctionRoomStateReader {
     private final AuctionRooms rooms;

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStatus.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRoomStatus.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.auction;
+
+public enum AuctionRoomStatus {
+    WAITING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRooms.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.jmolecules.ddd.annotation.Repository;
 
 @Repository
-public interface AuctionRooms {
+interface AuctionRooms {
     AuctionRoom save(AuctionRoom room);
 
     AuctionRoom saveAndFlush(AuctionRoom room);

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionRooms.java
@@ -1,0 +1,16 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.util.List;
+import java.util.Optional;
+import org.jmolecules.ddd.annotation.Repository;
+
+@Repository
+public interface AuctionRooms {
+    AuctionRoom save(AuctionRoom room);
+
+    AuctionRoom saveAndFlush(AuctionRoom room);
+
+    Optional<AuctionRoom> findByCode(String code);
+
+    List<AuctionRoom> findInProgressAuctionRooms();
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionSettlement.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionSettlement.java
@@ -1,0 +1,8 @@
+package com.naminhyeok.fantazzk.auction;
+
+public record AuctionSettlement(
+    int playerId,
+    String playerName,
+    AuctionOutcome outcome
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTarget.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTarget.java
@@ -1,0 +1,8 @@
+package com.naminhyeok.fantazzk.auction;
+
+public record AuctionTarget(
+    int playerId,
+    String name,
+    String position
+) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTeamLeader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTeamLeader.java
@@ -1,0 +1,36 @@
+package com.naminhyeok.fantazzk.auction;
+
+final class AuctionTeamLeader {
+    private final String leaderId;
+    private final String nickname;
+    private Integer remainingBudget;
+
+    AuctionTeamLeader(String leaderId, String nickname, Integer remainingBudget) {
+        this.leaderId = leaderId;
+        this.nickname = nickname;
+        this.remainingBudget = remainingBudget;
+    }
+
+    String leaderId() {
+        return leaderId;
+    }
+
+    String nickname() {
+        return nickname;
+    }
+
+    Integer remainingBudget() {
+        return remainingBudget;
+    }
+
+    void spend(int amount) {
+        if (remainingBudget == null) {
+            return;
+        }
+        int nextBudget = remainingBudget - amount;
+        if (nextBudget < 0) {
+            throw AuctionRoomException.budgetExceeded();
+        }
+        remainingBudget = nextBudget;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTeamMember.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/AuctionTeamMember.java
@@ -1,0 +1,25 @@
+package com.naminhyeok.fantazzk.auction;
+
+final class AuctionTeamMember {
+    private final String leaderId;
+    private final int playerId;
+    private final int sequence;
+
+    AuctionTeamMember(String leaderId, int playerId, int sequence) {
+        this.leaderId = leaderId;
+        this.playerId = playerId;
+        this.sequence = sequence;
+    }
+
+    String leaderId() {
+        return leaderId;
+    }
+
+    int playerId() {
+        return playerId;
+    }
+
+    int sequence() {
+        return sequence;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRoomEntity.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRoomEntity.java
@@ -1,0 +1,33 @@
+package com.naminhyeok.fantazzk.auction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "auction_room")
+class JpaAuctionRoomEntity {
+    @Id
+    @Column(name = "room_code", nullable = false, updatable = false)
+    private String roomCode;
+
+    @Column(name = "snapshot_json", nullable = false, columnDefinition = "TEXT")
+    private String snapshotJson;
+
+    protected JpaAuctionRoomEntity() {
+    }
+
+    JpaAuctionRoomEntity(String roomCode, String snapshotJson) {
+        this.roomCode = roomCode;
+        this.snapshotJson = snapshotJson;
+    }
+
+    String roomCode() {
+        return roomCode;
+    }
+
+    String snapshotJson() {
+        return snapshotJson;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRoomRepository.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRoomRepository.java
@@ -1,0 +1,13 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+interface JpaAuctionRoomRepository extends Repository<JpaAuctionRoomEntity, String> {
+    JpaAuctionRoomEntity save(JpaAuctionRoomEntity entity);
+
+    Optional<JpaAuctionRoomEntity> findById(String roomCode);
+
+    List<JpaAuctionRoomEntity> findAll();
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/JpaAuctionRooms.java
@@ -1,0 +1,62 @@
+package com.naminhyeok.fantazzk.auction;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JpaAuctionRooms implements AuctionRooms {
+    private final JpaAuctionRoomRepository repository;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    JpaAuctionRooms(JpaAuctionRoomRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public AuctionRoom save(AuctionRoom room) {
+        repository.save(new JpaAuctionRoomEntity(room.readState().code(), writeSnapshot(room.snapshot())));
+        return room;
+    }
+
+    @Override
+    public AuctionRoom saveAndFlush(AuctionRoom room) {
+        return save(room);
+    }
+
+    @Override
+    public Optional<AuctionRoom> findByCode(String code) {
+        return repository.findById(code)
+            .map(JpaAuctionRoomEntity::snapshotJson)
+            .map(this::readSnapshot)
+            .map(AuctionRoom::restore);
+    }
+
+    @Override
+    public List<AuctionRoom> findInProgressAuctionRooms() {
+        return repository.findAll().stream()
+            .map(JpaAuctionRoomEntity::snapshotJson)
+            .map(this::readSnapshot)
+            .map(AuctionRoom::restore)
+            .filter(room -> room.readState().status() == AuctionRoomStatus.IN_PROGRESS)
+            .toList();
+    }
+
+    private String writeSnapshot(AuctionRoomSnapshot snapshot) {
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("경매 상태를 직렬화하지 못했습니다", ex);
+        }
+    }
+
+    private AuctionRoomSnapshot readSnapshot(String snapshotJson) {
+        try {
+            return objectMapper.readValue(snapshotJson, AuctionRoomSnapshot.class);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("경매 상태를 역직렬화하지 못했습니다", ex);
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/auction/package-info.java
+++ b/src/main/java/com/naminhyeok/fantazzk/auction/package-info.java
@@ -1,0 +1,4 @@
+@ApplicationModule
+package com.naminhyeok.fantazzk.auction;
+
+import org.springframework.modulith.ApplicationModule;

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeader.java
@@ -1,0 +1,39 @@
+package com.naminhyeok.fantazzk.draft;
+
+final class DraftLeader {
+    private final DraftLeaderId id;
+    private final String nickname;
+    private Integer draftPosition;
+
+    DraftLeader(String leaderId, String nickname) {
+        this.id = new DraftLeaderId(leaderId);
+        this.nickname = normalizeNickname(nickname);
+    }
+
+    String id() {
+        return id.value();
+    }
+
+    String nickname() {
+        return nickname;
+    }
+
+    Integer draftPosition() {
+        return draftPosition;
+    }
+
+    void assignDraftPosition(int draftPosition) {
+        this.draftPosition = draftPosition;
+    }
+
+    void clearDraftPosition() {
+        this.draftPosition = null;
+    }
+
+    private String normalizeNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("팀장 닉네임은 비어 있을 수 없습니다");
+        }
+        return nickname.trim();
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeader.java
@@ -10,6 +10,12 @@ final class DraftLeader {
         this.nickname = normalizeNickname(nickname);
     }
 
+    DraftLeader(String leaderId, String nickname, Integer draftPosition) {
+        this.id = new DraftLeaderId(leaderId);
+        this.nickname = normalizeNickname(nickname);
+        this.draftPosition = draftPosition;
+    }
+
     String id() {
         return id.value();
     }

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeaderId.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftLeaderId.java
@@ -1,0 +1,11 @@
+package com.naminhyeok.fantazzk.draft;
+
+import org.jmolecules.ddd.types.Identifier;
+
+record DraftLeaderId(String value) implements Identifier {
+    DraftLeaderId {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("팀장 식별자는 비어 있을 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftMember.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftMember.java
@@ -1,0 +1,4 @@
+package com.naminhyeok.fantazzk.draft;
+
+record DraftMember(String leaderId, int playerId, int assignOrder) {
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftOrderStrategy.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftOrderStrategy.java
@@ -1,0 +1,6 @@
+package com.naminhyeok.fantazzk.draft;
+
+public enum DraftOrderStrategy {
+    SNAKE,
+    FIXED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayer.java
@@ -1,0 +1,41 @@
+package com.naminhyeok.fantazzk.draft;
+
+final class DraftPlayer {
+    private final DraftPlayerId id;
+    private final String name;
+    private final String position;
+    private final int displayOrder;
+    private DraftPlayerStatus status;
+
+    DraftPlayer(DraftPlayerSpec spec) {
+        this.id = new DraftPlayerId(spec.playerId());
+        this.name = spec.name().trim();
+        this.position = spec.position().trim();
+        this.displayOrder = spec.displayOrder();
+        this.status = DraftPlayerStatus.AVAILABLE;
+    }
+
+    DraftPlayerId id() {
+        return id;
+    }
+
+    String name() {
+        return name;
+    }
+
+    String position() {
+        return position;
+    }
+
+    int displayOrder() {
+        return displayOrder;
+    }
+
+    DraftPlayerStatus status() {
+        return status;
+    }
+
+    void assign() {
+        status = DraftPlayerStatus.ASSIGNED;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayer.java
@@ -15,6 +15,14 @@ final class DraftPlayer {
         this.status = DraftPlayerStatus.AVAILABLE;
     }
 
+    DraftPlayer(int playerId, String name, String position, int displayOrder, DraftPlayerStatus status) {
+        this.id = new DraftPlayerId(playerId);
+        this.name = name.trim();
+        this.position = position.trim();
+        this.displayOrder = displayOrder;
+        this.status = status;
+    }
+
     DraftPlayerId id() {
         return id;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerId.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerId.java
@@ -1,0 +1,11 @@
+package com.naminhyeok.fantazzk.draft;
+
+import org.jmolecules.ddd.types.Identifier;
+
+record DraftPlayerId(int value) implements Identifier {
+    DraftPlayerId {
+        if (value < 0) {
+            throw new IllegalArgumentException("선수 식별자는 음수일 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerSpec.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerSpec.java
@@ -1,0 +1,23 @@
+package com.naminhyeok.fantazzk.draft;
+
+public record DraftPlayerSpec(
+    int playerId,
+    String name,
+    String position,
+    int displayOrder
+) {
+    public DraftPlayerSpec {
+        if (playerId < 0) {
+            throw new IllegalArgumentException("선수 식별자는 음수일 수 없습니다");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("선수 이름은 비어 있을 수 없습니다");
+        }
+        if (position == null || position.isBlank()) {
+            throw new IllegalArgumentException("선수 포지션은 비어 있을 수 없습니다");
+        }
+        if (displayOrder < 0) {
+            throw new IllegalArgumentException("선수 표시 순서는 음수일 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerStatus.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftPlayerStatus.java
@@ -1,0 +1,6 @@
+package com.naminhyeok.fantazzk.draft;
+
+enum DraftPlayerStatus {
+    AVAILABLE,
+    ASSIGNED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftProgress.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftProgress.java
@@ -1,0 +1,49 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+record DraftProgress(
+    int currentTurnIndex,
+    int currentRound,
+    String currentLeaderId,
+    List<String> currentRoundLeaderIds
+) {
+    static DraftProgress from(
+        List<String> roundOneLeaderIds,
+        DraftOrderStrategy strategy,
+        int currentTurnIndex
+    ) {
+        List<String> baseOrder = List.copyOf(roundOneLeaderIds);
+        if (baseOrder.isEmpty()) {
+            throw new IllegalArgumentException("드래프트 순서가 비어 있습니다");
+        }
+
+        int roundSize = baseOrder.size();
+        int currentRound = currentTurnIndex / roundSize + 1;
+        int turnOffsetInRound = currentTurnIndex % roundSize;
+        List<String> currentRoundLeaderIds = currentRoundLeaderIds(baseOrder, strategy, currentRound);
+
+        return new DraftProgress(
+            currentTurnIndex,
+            currentRound,
+            currentRoundLeaderIds.get(turnOffsetInRound),
+            currentRoundLeaderIds
+        );
+    }
+
+    private static List<String> currentRoundLeaderIds(
+        List<String> baseOrder,
+        DraftOrderStrategy strategy,
+        int currentRound
+    ) {
+        if (strategy == DraftOrderStrategy.FIXED || currentRound % 2 == 1) {
+            return baseOrder;
+        }
+
+        List<String> reversed = new ArrayList<>(baseOrder);
+        Collections.reverse(reversed);
+        return List.copyOf(reversed);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoom.java
@@ -1,0 +1,289 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import org.jmolecules.ddd.types.AggregateRoot;
+
+class DraftRoom implements AggregateRoot<DraftRoom, DraftRoomId> {
+    private final DraftRoomId id;
+    private final int teamCount;
+    private final int teamSize;
+    private final DraftOrderStrategy draftOrderStrategy;
+    private final List<DraftLeader> leaders;
+    private final List<DraftPlayer> players;
+    private final List<DraftMember> members;
+    private DraftRoomStatus status;
+    private Integer currentTurnIndex;
+
+    private DraftRoom(
+        DraftRoomId id,
+        int teamCount,
+        int teamSize,
+        DraftOrderStrategy draftOrderStrategy,
+        List<DraftPlayer> players
+    ) {
+        if (teamCount <= 0) {
+            throw new IllegalArgumentException("팀 수는 0보다 커야 합니다");
+        }
+        if (teamSize <= 0) {
+            throw new IllegalArgumentException("팀 크기는 0보다 커야 합니다");
+        }
+        this.id = id;
+        this.teamCount = teamCount;
+        this.teamSize = teamSize;
+        this.draftOrderStrategy = Objects.requireNonNull(draftOrderStrategy, "드래프트 순서 전략은 필수입니다");
+        this.leaders = new ArrayList<>();
+        this.players = new ArrayList<>(players);
+        this.members = new ArrayList<>();
+        this.status = DraftRoomStatus.WAITING;
+        this.currentTurnIndex = null;
+    }
+
+    static DraftRoom create(
+        DraftRoomId id,
+        int teamCount,
+        int teamSize,
+        DraftOrderStrategy draftOrderStrategy,
+        List<DraftPlayerSpec> playerSpecs
+    ) {
+        int requiredPlayerCount = teamCount * (teamSize - 1);
+        if (playerSpecs.size() != requiredPlayerCount) {
+            throw new IllegalArgumentException("선수 수는 정확히 " + requiredPlayerCount + "명이어야 합니다");
+        }
+
+        List<DraftPlayer> players = playerSpecs.stream()
+            .map(DraftPlayer::new)
+            .sorted(Comparator.comparingInt(DraftPlayer::displayOrder))
+            .toList();
+
+        return new DraftRoom(id, teamCount, teamSize, draftOrderStrategy, players);
+    }
+
+    public DraftRoomId getId() {
+        return id;
+    }
+
+    void addLeader(String leaderId, String nickname) {
+        validateWaiting();
+        if (leaders.size() >= teamCount) {
+            throw new IllegalStateException("드래프트 팀장이 이미 가득 찼습니다");
+        }
+
+        String normalizedNickname = normalizeNickname(nickname);
+        boolean taken =
+            leaders.stream()
+                .map(DraftLeader::nickname)
+                .map(this::normalizeNickname)
+                .anyMatch(normalizedNickname::equals);
+        if (taken) {
+            throw new IllegalStateException("팀장 닉네임이 이미 사용 중입니다");
+        }
+
+        leaders.add(new DraftLeader(leaderId, nickname));
+    }
+
+    void selectDraftPosition(String leaderId, int draftPosition) {
+        validateDraftPositionChange(draftPosition);
+
+        DraftLeader caller = requireLeader(leaderId);
+        boolean taken =
+            leaders.stream()
+                .filter(leader -> !leader.id().equals(leaderId))
+                .anyMatch(leader -> Integer.valueOf(draftPosition).equals(leader.draftPosition()));
+        if (taken) {
+            throw new IllegalStateException("드래프트 자리가 이미 사용 중입니다");
+        }
+
+        caller.assignDraftPosition(draftPosition);
+    }
+
+    void clearDraftPosition(String leaderId) {
+        validateDraftModeWaiting();
+        requireLeader(leaderId).clearDraftPosition();
+    }
+
+    void start() {
+        validateWaiting();
+        DraftRoomReadiness readiness = readiness();
+        if (readiness != DraftRoomReadiness.READY) {
+            throw DraftRoomStateInvalidException.roomNotReadyForStart(readiness);
+        }
+
+        status = DraftRoomStatus.IN_PROGRESS;
+        currentTurnIndex = 0;
+    }
+
+    DraftMember pick(String leaderId, int playerId) {
+        if (status != DraftRoomStatus.IN_PROGRESS) {
+            throw DraftRoomStateInvalidException.roomNotInProgress();
+        }
+
+        DraftProgress progress = requireCurrentDraftProgress();
+        if (!progress.currentLeaderId().equals(leaderId)) {
+            throw new IllegalStateException("현재 턴이 아닙니다");
+        }
+
+        DraftPlayer player = requireAvailablePlayer(playerId);
+        player.assign();
+
+        DraftMember member = new DraftMember(leaderId, player.id().value(), members.size());
+        members.add(member);
+
+        currentTurnIndex += 1;
+        if (members.size() == players.size()) {
+            status = DraftRoomStatus.COMPLETED;
+        }
+
+        return member;
+    }
+
+    DraftRoomState snapshot() {
+        return new DraftRoomState(
+            id.value(),
+            status,
+            readiness(),
+            teamCount,
+            teamSize,
+            draftOrderStrategy,
+            leaders.stream()
+                .map(leader -> new DraftRoomState.Leader(leader.id(), leader.nickname(), leader.draftPosition()))
+                .toList(),
+            players.stream()
+                .map(player -> new DraftRoomState.Player(
+                    player.id().value(),
+                    player.name(),
+                    player.position(),
+                    player.displayOrder(),
+                    player.status() == DraftPlayerStatus.ASSIGNED
+                ))
+                .toList(),
+            members.stream()
+                .map(member -> new DraftRoomState.Member(member.leaderId(), member.playerId(), member.assignOrder()))
+                .toList(),
+            new DraftRoomState.OrderPreview(draftOrderPreview()),
+            status == DraftRoomStatus.IN_PROGRESS ? currentDraftProgressAsState() : null
+        );
+    }
+
+    private List<DraftRoomState.OrderSlot> draftOrderPreview() {
+        Map<Integer, DraftLeader> leadersByDraftPosition =
+            leaders.stream()
+                .filter(leader -> leader.draftPosition() != null)
+                .collect(java.util.stream.Collectors.toMap(DraftLeader::draftPosition, leader -> leader));
+
+        return IntStream.rangeClosed(1, teamCount)
+            .mapToObj(draftPosition -> {
+                DraftLeader leader = leadersByDraftPosition.get(draftPosition);
+                if (leader == null) {
+                    return DraftRoomState.OrderSlot.empty(draftPosition);
+                }
+                return DraftRoomState.OrderSlot.from(draftPosition, leader);
+            })
+            .toList();
+    }
+
+    private DraftRoomState.Progress currentDraftProgressAsState() {
+        DraftProgress progress = requireCurrentDraftProgress();
+        return new DraftRoomState.Progress(
+            progress.currentTurnIndex(),
+            progress.currentRound(),
+            progress.currentLeaderId(),
+            progress.currentRoundLeaderIds()
+        );
+    }
+
+    private DraftRoomReadiness readiness() {
+        if (status == DraftRoomStatus.IN_PROGRESS) {
+            return DraftRoomReadiness.IN_PROGRESS;
+        }
+        if (status == DraftRoomStatus.COMPLETED) {
+            return DraftRoomReadiness.COMPLETED;
+        }
+        if (leaders.size() < teamCount) {
+            return DraftRoomReadiness.WAITING_FOR_LEADERS;
+        }
+        if (!hasConfirmedDraftPositions()) {
+            return DraftRoomReadiness.WAITING_FOR_DRAFT_POSITIONS;
+        }
+        return DraftRoomReadiness.READY;
+    }
+
+    private void validateWaiting() {
+        if (status != DraftRoomStatus.WAITING) {
+            throw DraftRoomStateInvalidException.roomNotWaiting();
+        }
+    }
+
+    private void validateDraftModeWaiting() {
+        validateWaiting();
+    }
+
+    private void validateDraftPositionChange(int draftPosition) {
+        validateDraftModeWaiting();
+        if (draftPosition < 1 || draftPosition > teamCount) {
+            throw new IllegalArgumentException("드래프트 자리는 1 이상 " + teamCount + " 이하여야 합니다");
+        }
+    }
+
+    private boolean hasConfirmedDraftPositions() {
+        return leaders.stream().allMatch(leader -> leader.draftPosition() != null)
+            && leaders.stream().map(DraftLeader::draftPosition).distinct().count() == teamCount;
+    }
+
+    private DraftLeader requireLeader(String leaderId) {
+        return leaders.stream()
+            .filter(leader -> leader.id().equals(leaderId))
+            .findFirst()
+            .orElseThrow(() -> DraftRoomStateInvalidException.leaderMissing(leaderId));
+    }
+
+    private DraftPlayer requireAvailablePlayer(int playerId) {
+        return players.stream()
+            .filter(player -> player.id().value() == playerId)
+            .filter(player -> player.status() == DraftPlayerStatus.AVAILABLE)
+            .findFirst()
+            .orElseThrow(() -> DraftRoomStateInvalidException.playerMissing(playerId));
+    }
+
+    private DraftProgress requireCurrentDraftProgress() {
+        if (status != DraftRoomStatus.IN_PROGRESS || currentTurnIndex == null) {
+            throw DraftRoomStateInvalidException.currentTurnMissing();
+        }
+
+        List<String> leaderIds = leadersInDraftOrder();
+        try {
+            return DraftProgress.from(leaderIds, draftOrderStrategy, currentTurnIndex);
+        } catch (IllegalArgumentException ex) {
+            throw DraftRoomStateInvalidException.draftLeaderOrderEmpty();
+        }
+    }
+
+    private List<String> leadersInDraftOrder() {
+        if (leaders.isEmpty()) {
+            throw DraftRoomStateInvalidException.draftLeaderOrderEmpty();
+        }
+
+        DraftLeader leaderWithoutDraftPosition =
+            leaders.stream().filter(leader -> leader.draftPosition() == null).findFirst().orElse(null);
+        if (leaderWithoutDraftPosition != null) {
+            throw DraftRoomStateInvalidException.draftPositionMissing(leaderWithoutDraftPosition.id());
+        }
+
+        return leaders.stream()
+            .sorted(Comparator.comparingInt(DraftLeader::draftPosition))
+            .map(DraftLeader::id)
+            .toList();
+    }
+
+    private String normalizeNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("팀장 닉네임은 비어 있을 수 없습니다");
+        }
+        return nickname.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoom.java
@@ -7,9 +7,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
-import org.jmolecules.ddd.types.AggregateRoot;
 
-class DraftRoom implements AggregateRoot<DraftRoom, DraftRoomId> {
+class DraftRoom {
     private final DraftRoomId id;
     private final int teamCount;
     private final int teamSize;
@@ -62,6 +61,36 @@ class DraftRoom implements AggregateRoot<DraftRoom, DraftRoomId> {
             .toList();
 
         return new DraftRoom(id, teamCount, teamSize, draftOrderStrategy, players);
+    }
+
+    static DraftRoom restore(DraftRoomState state) {
+        List<DraftPlayer> players = state.players().stream()
+            .map(player -> new DraftPlayer(
+                player.playerId(),
+                player.name(),
+                player.position(),
+                player.displayOrder(),
+                player.assigned() ? DraftPlayerStatus.ASSIGNED : DraftPlayerStatus.AVAILABLE
+            ))
+            .sorted(Comparator.comparingInt(DraftPlayer::displayOrder))
+            .toList();
+
+        DraftRoom room = new DraftRoom(
+            new DraftRoomId(state.roomCode()),
+            state.teamCount(),
+            state.teamSize(),
+            state.draftOrderStrategy(),
+            players
+        );
+        room.leaders.addAll(state.leaders().stream()
+            .map(leader -> new DraftLeader(leader.leaderId(), leader.nickname(), leader.draftPosition()))
+            .toList());
+        room.members.addAll(state.members().stream()
+            .map(member -> new DraftMember(member.leaderId(), member.playerId(), member.assignOrder()))
+            .toList());
+        room.status = state.status();
+        room.currentTurnIndex = state.progress() == null ? null : state.progress().currentTurnIndex();
+        return room;
     }
 
     public DraftRoomId getId() {

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomId.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomId.java
@@ -1,0 +1,16 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.UUID;
+import org.jmolecules.ddd.types.Identifier;
+
+record DraftRoomId(String value) implements Identifier {
+    DraftRoomId {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("드래프트 방 식별자는 비어 있을 수 없습니다");
+        }
+    }
+
+    static DraftRoomId random() {
+        return new DraftRoomId(UUID.randomUUID().toString());
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycle.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycle.java
@@ -2,10 +2,10 @@ package com.naminhyeok.fantazzk.draft;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 public class DraftRoomLifecycle {

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycle.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycle.java
@@ -1,0 +1,68 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@org.jmolecules.ddd.annotation.Service
+@RequiredArgsConstructor
+public class DraftRoomLifecycle {
+    private final DraftRooms draftRooms;
+
+    @Transactional
+    public DraftRoomState create(
+        String roomCode,
+        int teamCount,
+        int teamSize,
+        DraftOrderStrategy draftOrderStrategy,
+        List<DraftPlayerSpec> players
+    ) {
+        DraftRoomId roomId = new DraftRoomId(roomCode);
+        if (draftRooms.findById(roomId).isPresent()) {
+            throw new IllegalStateException("드래프트 방이 이미 존재합니다: " + roomCode);
+        }
+
+        DraftRoom draftRoom = DraftRoom.create(roomId, teamCount, teamSize, draftOrderStrategy, players);
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    @Transactional
+    public DraftRoomState addLeader(String roomCode, String leaderId, String nickname) {
+        DraftRoom draftRoom = load(roomCode);
+        draftRoom.addLeader(leaderId, nickname);
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    @Transactional
+    public DraftRoomState selectDraftPosition(String roomCode, String leaderId, int draftPosition) {
+        DraftRoom draftRoom = load(roomCode);
+        draftRoom.selectDraftPosition(leaderId, draftPosition);
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    @Transactional
+    public DraftRoomState clearDraftPosition(String roomCode, String leaderId) {
+        DraftRoom draftRoom = load(roomCode);
+        draftRoom.clearDraftPosition(leaderId);
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    @Transactional
+    public DraftRoomState start(String roomCode) {
+        DraftRoom draftRoom = load(roomCode);
+        draftRoom.start();
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    private DraftRoom load(String roomCode) {
+        return draftRooms.findById(new DraftRoomId(roomCode))
+            .orElseThrow(() -> new IllegalArgumentException("드래프트 방을 찾을 수 없습니다: " + roomCode));
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomPlay.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomPlay.java
@@ -1,0 +1,25 @@
+package com.naminhyeok.fantazzk.draft;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@org.jmolecules.ddd.annotation.Service
+@RequiredArgsConstructor
+public class DraftRoomPlay {
+    private final DraftRooms draftRooms;
+
+    @Transactional
+    public DraftRoomState pick(String roomCode, String leaderId, int playerId) {
+        DraftRoom draftRoom = load(roomCode);
+        draftRoom.pick(leaderId, playerId);
+        draftRooms.save(draftRoom);
+        return draftRoom.snapshot();
+    }
+
+    private DraftRoom load(String roomCode) {
+        return draftRooms.findById(new DraftRoomId(roomCode))
+            .orElseThrow(() -> new IllegalArgumentException("드래프트 방을 찾을 수 없습니다: " + roomCode));
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomPlay.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomPlay.java
@@ -1,10 +1,10 @@
 package com.naminhyeok.fantazzk.draft;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 public class DraftRoomPlay {

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomReadiness.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomReadiness.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.draft;
+
+public enum DraftRoomReadiness {
+    WAITING_FOR_LEADERS,
+    WAITING_FOR_DRAFT_POSITIONS,
+    READY,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomState.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomState.java
@@ -1,0 +1,65 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.List;
+
+public record DraftRoomState(
+    String roomCode,
+    DraftRoomStatus status,
+    DraftRoomReadiness readiness,
+    int teamCount,
+    int teamSize,
+    DraftOrderStrategy draftOrderStrategy,
+    List<Leader> leaders,
+    List<Player> players,
+    List<Member> members,
+    OrderPreview draftOrderPreview,
+    Progress progress
+) {
+    public record Leader(
+        String leaderId,
+        String nickname,
+        Integer draftPosition
+    ) {
+    }
+
+    public record Player(
+        int playerId,
+        String name,
+        String position,
+        int displayOrder,
+        boolean assigned
+    ) {
+    }
+
+    public record Member(
+        String leaderId,
+        int playerId,
+        int assignOrder
+    ) {
+    }
+
+    public record OrderPreview(List<OrderSlot> slots) {
+    }
+
+    public record OrderSlot(
+        int draftPosition,
+        String leaderId,
+        String nickname
+    ) {
+        static OrderSlot empty(int draftPosition) {
+            return new OrderSlot(draftPosition, null, null);
+        }
+
+        static OrderSlot from(int draftPosition, DraftLeader leader) {
+            return new OrderSlot(draftPosition, leader.id(), leader.nickname());
+        }
+    }
+
+    public record Progress(
+        int currentTurnIndex,
+        int currentRound,
+        String currentLeaderId,
+        List<String> currentRoundLeaderIds
+    ) {
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateInvalidException.java
@@ -1,0 +1,55 @@
+package com.naminhyeok.fantazzk.draft;
+
+import com.naminhyeok.fantazzk.InvalidDomainStateException;
+
+final class DraftRoomStateInvalidException extends InvalidDomainStateException {
+    private DraftRoomStateInvalidException(String message) {
+        super(message, null);
+    }
+
+    static DraftRoomStateInvalidException roomAlreadyStarted() {
+        return new DraftRoomStateInvalidException("드래프트가 이미 시작되었습니다");
+    }
+
+    static DraftRoomStateInvalidException roomAlreadyCompleted() {
+        return new DraftRoomStateInvalidException("드래프트가 이미 완료되었습니다");
+    }
+
+    static DraftRoomStateInvalidException roomNotWaiting() {
+        return new DraftRoomStateInvalidException("대기 중인 드래프트 방이 아닙니다");
+    }
+
+    static DraftRoomStateInvalidException roomNotInProgress() {
+        return new DraftRoomStateInvalidException("진행 중인 드래프트 방이 아닙니다");
+    }
+
+    static DraftRoomStateInvalidException roomNotReadyForStart(DraftRoomReadiness readiness) {
+        return switch (readiness) {
+            case WAITING_FOR_LEADERS -> new DraftRoomStateInvalidException("드래프트를 시작할 수 없습니다: 팀장이 부족합니다");
+            case WAITING_FOR_DRAFT_POSITIONS -> new DraftRoomStateInvalidException("드래프트를 시작할 수 없습니다: 드래프트 자리가 아직 확정되지 않았습니다");
+            case READY -> new DraftRoomStateInvalidException("드래프트를 시작할 수 있습니다");
+            case IN_PROGRESS -> roomAlreadyStarted();
+            case COMPLETED -> roomAlreadyCompleted();
+        };
+    }
+
+    static DraftRoomStateInvalidException leaderMissing(String leaderId) {
+        return new DraftRoomStateInvalidException("팀장을 찾을 수 없습니다: " + leaderId);
+    }
+
+    static DraftRoomStateInvalidException playerMissing(int playerId) {
+        return new DraftRoomStateInvalidException("선수를 찾을 수 없습니다: " + playerId);
+    }
+
+    static DraftRoomStateInvalidException draftPositionMissing(String leaderId) {
+        return new DraftRoomStateInvalidException("드래프트 순서를 계산할 수 없습니다: draftPosition missing, leaderId=" + leaderId);
+    }
+
+    static DraftRoomStateInvalidException draftLeaderOrderEmpty() {
+        return new DraftRoomStateInvalidException("드래프트 순서가 비어 있습니다");
+    }
+
+    static DraftRoomStateInvalidException currentTurnMissing() {
+        return new DraftRoomStateInvalidException("드래프트 턴 정보를 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateReader.java
@@ -1,10 +1,10 @@
 package com.naminhyeok.fantazzk.draft;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 public class DraftRoomStateReader {

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateReader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStateReader.java
@@ -1,0 +1,19 @@
+package com.naminhyeok.fantazzk.draft;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@org.jmolecules.ddd.annotation.Service
+@RequiredArgsConstructor
+public class DraftRoomStateReader {
+    private final DraftRooms draftRooms;
+
+    @Transactional(readOnly = true)
+    public DraftRoomState read(String roomCode) {
+        return draftRooms.findById(new DraftRoomId(roomCode))
+            .map(DraftRoom::snapshot)
+            .orElseThrow(() -> new IllegalArgumentException("드래프트 방을 찾을 수 없습니다: " + roomCode));
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStatus.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRoomStatus.java
@@ -1,0 +1,7 @@
+package com.naminhyeok.fantazzk.draft;
+
+public enum DraftRoomStatus {
+    WAITING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRooms.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import org.jmolecules.ddd.annotation.Repository;
 
 @Repository
-interface DraftRooms extends org.jmolecules.ddd.types.Repository<DraftRoom, DraftRoomId> {
+interface DraftRooms {
     DraftRoom save(DraftRoom draftRoom);
 
     Optional<DraftRoom> findById(DraftRoomId id);

--- a/src/main/java/com/naminhyeok/fantazzk/draft/DraftRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/DraftRooms.java
@@ -1,0 +1,11 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.Optional;
+import org.jmolecules.ddd.annotation.Repository;
+
+@Repository
+interface DraftRooms extends org.jmolecules.ddd.types.Repository<DraftRoom, DraftRoomId> {
+    DraftRoom save(DraftRoom draftRoom);
+
+    Optional<DraftRoom> findById(DraftRoomId id);
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRoomEntity.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRoomEntity.java
@@ -1,0 +1,33 @@
+package com.naminhyeok.fantazzk.draft;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "draft_room")
+class JpaDraftRoomEntity {
+    @Id
+    @Column(name = "room_code", nullable = false, updatable = false)
+    private String roomCode;
+
+    @Column(name = "state_json", nullable = false, columnDefinition = "TEXT")
+    private String stateJson;
+
+    protected JpaDraftRoomEntity() {
+    }
+
+    JpaDraftRoomEntity(String roomCode, String stateJson) {
+        this.roomCode = roomCode;
+        this.stateJson = stateJson;
+    }
+
+    String roomCode() {
+        return roomCode;
+    }
+
+    String stateJson() {
+        return stateJson;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRoomRepository.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRoomRepository.java
@@ -1,0 +1,10 @@
+package com.naminhyeok.fantazzk.draft;
+
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+interface JpaDraftRoomRepository extends Repository<JpaDraftRoomEntity, String> {
+    JpaDraftRoomEntity save(JpaDraftRoomEntity entity);
+
+    Optional<JpaDraftRoomEntity> findById(String roomCode);
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/JpaDraftRooms.java
@@ -1,0 +1,46 @@
+package com.naminhyeok.fantazzk.draft;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JpaDraftRooms implements DraftRooms {
+    private final JpaDraftRoomRepository repository;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    JpaDraftRooms(JpaDraftRoomRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public DraftRoom save(DraftRoom draftRoom) {
+        repository.save(new JpaDraftRoomEntity(draftRoom.getId().value(), writeState(draftRoom.snapshot())));
+        return draftRoom;
+    }
+
+    @Override
+    public Optional<DraftRoom> findById(DraftRoomId id) {
+        return repository.findById(id.value())
+            .map(JpaDraftRoomEntity::stateJson)
+            .map(this::readState)
+            .map(DraftRoom::restore);
+    }
+
+    private String writeState(DraftRoomState state) {
+        try {
+            return objectMapper.writeValueAsString(state);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("드래프트 상태를 직렬화하지 못했습니다", ex);
+        }
+    }
+
+    private DraftRoomState readState(String stateJson) {
+        try {
+            return objectMapper.readValue(stateJson, DraftRoomState.class);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("드래프트 상태를 역직렬화하지 못했습니다", ex);
+        }
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/draft/package-info.java
+++ b/src/main/java/com/naminhyeok/fantazzk/draft/package-info.java
@@ -1,0 +1,4 @@
+@ApplicationModule
+package com.naminhyeok.fantazzk.draft;
+
+import org.springframework.modulith.ApplicationModule;

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionSettlement.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionSettlement.java
@@ -1,6 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
 record AuctionSettlement(
+    RoomPlayerId playerId,
     String playerName,
     AuctionOutcome outcome
 ) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
@@ -1,6 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
 record AuctionTargetResponse(
+    int playerId,
     String name,
     String position
 ) {
@@ -8,6 +9,6 @@ record AuctionTargetResponse(
         if (player == null) {
             return null;
         }
-        return new AuctionTargetResponse(player.getName(), player.getPosition());
+        return new AuctionTargetResponse(player.getId().value(), player.getName(), player.getPosition());
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
@@ -3,19 +3,18 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
 import com.naminhyeok.fantazzk.draft.DraftRoomState;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class ClearDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final DraftRoomLifecycle draftRoomLifecycle;
 
-    @Autowired
     ClearDraftPosition(
         Rooms rooms,
         RoomActionAuthorizer roomActionAuthorizer,
@@ -26,10 +25,6 @@ class ClearDraftPosition {
         this.roomActionAuthorizer = roomActionAuthorizer;
         this.roomSnapshotPublisher = roomSnapshotPublisher;
         this.draftRoomLifecycle = draftRoomLifecycle;
-    }
-
-    ClearDraftPosition(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
-        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/ClearDraftPosition.java
@@ -1,24 +1,52 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import lombok.RequiredArgsConstructor;
+import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
+import com.naminhyeok.fantazzk.draft.DraftRoomState;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class ClearDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
+    private final DraftRoomLifecycle draftRoomLifecycle;
+
+    @Autowired
+    ClearDraftPosition(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        DraftRoomLifecycle draftRoomLifecycle
+    ) {
+        this.rooms = rooms;
+        this.roomActionAuthorizer = roomActionAuthorizer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.draftRoomLifecycle = draftRoomLifecycle;
+    }
+
+    ClearDraftPosition(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
+        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
+    }
 
     @Transactional
     public Room clear(String code, String actionToken) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            room.clearDraftPosition(caller.getId());
+            if (draftRoomLifecycle != null) {
+                try {
+                    DraftRoomState draftState = draftRoomLifecycle.clearDraftPosition(code, caller.getId().value());
+                    room.applyDraftState(draftState);
+                } catch (RuntimeException ex) {
+                    room.clearDraftPosition(caller.getId());
+                }
+            } else {
+                room.clearDraftPosition(caller.getId());
+            }
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
             return saved;

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
@@ -1,18 +1,23 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionPlayerSeed;
+import com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle;
+import com.naminhyeok.fantazzk.auction.AuctionRoomSetup;
 import com.naminhyeok.fantazzk.CoreException;
+import com.naminhyeok.fantazzk.draft.DraftOrderStrategy;
+import com.naminhyeok.fantazzk.draft.DraftPlayerSpec;
+import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
 import com.naminhyeok.fantazzk.template.TemplateCatalog;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
 
 @Service
-@RequiredArgsConstructor
 class CreateRoom {
     private static final int MAX_ROOM_CODE_ATTEMPTS = 3;
     private static final String ROOM_CODE_CONSTRAINT = "uk_rooms_code";
@@ -25,6 +30,37 @@ class CreateRoom {
     private final TeamLeaderIdentityIssuer teamLeaderIdentityIssuer;
     private final Clock clock;
     private final RoomCodeGenerator roomCodeGenerator;
+    private final DraftRoomLifecycle draftRoomLifecycle;
+    private final AuctionRoomLifecycle auctionRoomLifecycle;
+
+    @Autowired
+    CreateRoom(
+        CreateRoomAttempt createRoomAttempt,
+        TemplateCatalog templateCatalog,
+        TeamLeaderIdentityIssuer teamLeaderIdentityIssuer,
+        Clock clock,
+        RoomCodeGenerator roomCodeGenerator,
+        DraftRoomLifecycle draftRoomLifecycle,
+        AuctionRoomLifecycle auctionRoomLifecycle
+    ) {
+        this.createRoomAttempt = createRoomAttempt;
+        this.templateCatalog = templateCatalog;
+        this.teamLeaderIdentityIssuer = teamLeaderIdentityIssuer;
+        this.clock = clock;
+        this.roomCodeGenerator = roomCodeGenerator;
+        this.draftRoomLifecycle = draftRoomLifecycle;
+        this.auctionRoomLifecycle = auctionRoomLifecycle;
+    }
+
+    CreateRoom(
+        CreateRoomAttempt createRoomAttempt,
+        TemplateCatalog templateCatalog,
+        TeamLeaderIdentityIssuer teamLeaderIdentityIssuer,
+        Clock clock,
+        RoomCodeGenerator roomCodeGenerator
+    ) {
+        this(createRoomAttempt, templateCatalog, teamLeaderIdentityIssuer, clock, roomCodeGenerator, null, null);
+    }
 
     public RoomSessionResult create(UUID templateId, String hostNickname) {
         TemplateCatalog.TemplateBlueprint template = getTemplate(templateId);
@@ -34,7 +70,7 @@ class CreateRoom {
         for (int attempt = 1; attempt <= MAX_ROOM_CODE_ATTEMPTS; attempt++) {
             Room room = newRoom(template, hostLeaderId, identity.actionToken(), hostNickname);
             try {
-                Room saved = createRoomAttempt.save(room);
+                Room saved = createRoomAttempt.save(room, savedRoom -> createGameplay(savedRoom, template, hostLeaderId, hostNickname));
                 return new RoomSessionResult(saved, findLeader(saved, hostLeaderId));
             } catch (DataIntegrityViolationException ex) {
                 if (!isRoomCodeCollision(ex)) {
@@ -103,6 +139,48 @@ class CreateRoom {
 
     private String generateCode() {
         return roomCodeGenerator.generate();
+    }
+
+    private void createGameplay(
+        Room room,
+        TemplateCatalog.TemplateBlueprint template,
+        TeamLeaderId hostLeaderId,
+        String hostNickname
+    ) {
+        if (draftRoomLifecycle == null || auctionRoomLifecycle == null) {
+            return;
+        }
+        if (room.getMode() == RoomMode.DRAFT) {
+            draftRoomLifecycle.create(
+                room.getCode(),
+                template.teamCount(),
+                template.teamSize(),
+                DraftOrderStrategy.valueOf(template.draftOrderStrategy().name()),
+                template.players().stream()
+                    .map(player -> new DraftPlayerSpec(player.playerIndex(), player.name(), player.position(), player.playerIndex()))
+                    .toList()
+            );
+            draftRoomLifecycle.addLeader(room.getCode(), hostLeaderId.value(), hostNickname);
+            return;
+        }
+
+        auctionRoomLifecycle.create(
+            room.getCode(),
+            hostLeaderId.value(),
+            hostNickname,
+            room.getCreatedAt(),
+            new AuctionRoomSetup(
+                template.teamCount(),
+                template.teamSize(),
+                template.budget(),
+                template.pickBanTime(),
+                template.minBidUnit(),
+                template.positionLimit(),
+                template.players().stream()
+                    .map(player -> new AuctionPlayerSeed(player.playerIndex(), player.name(), player.position(), player.playerIndex()))
+                    .toList()
+            )
+        );
     }
 
     private boolean isRoomCodeCollision(Throwable throwable) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoom.java
@@ -13,11 +13,11 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class CreateRoom {
     private static final int MAX_ROOM_CODE_ATTEMPTS = 3;
     private static final String ROOM_CODE_CONSTRAINT = "uk_rooms_code";
@@ -33,7 +33,6 @@ class CreateRoom {
     private final DraftRoomLifecycle draftRoomLifecycle;
     private final AuctionRoomLifecycle auctionRoomLifecycle;
 
-    @Autowired
     CreateRoom(
         CreateRoomAttempt createRoomAttempt,
         TemplateCatalog templateCatalog,
@@ -50,16 +49,6 @@ class CreateRoom {
         this.roomCodeGenerator = roomCodeGenerator;
         this.draftRoomLifecycle = draftRoomLifecycle;
         this.auctionRoomLifecycle = auctionRoomLifecycle;
-    }
-
-    CreateRoom(
-        CreateRoomAttempt createRoomAttempt,
-        TemplateCatalog templateCatalog,
-        TeamLeaderIdentityIssuer teamLeaderIdentityIssuer,
-        Clock clock,
-        RoomCodeGenerator roomCodeGenerator
-    ) {
-        this(createRoomAttempt, templateCatalog, teamLeaderIdentityIssuer, clock, roomCodeGenerator, null, null);
     }
 
     public RoomSessionResult create(UUID templateId, String hostNickname) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomAttempt.java
@@ -1,5 +1,6 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -11,7 +12,9 @@ class CreateRoomAttempt {
     private final Rooms rooms;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    Room save(Room room) {
-        return rooms.saveAndFlush(room);
+    Room save(Room room, Consumer<Room> followUp) {
+        Room saved = rooms.saveAndFlush(room);
+        followUp.accept(saved);
+        return saved;
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomAttempt.java
@@ -2,11 +2,11 @@ package com.naminhyeok.fantazzk.room;
 
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @RequiredArgsConstructor
 class CreateRoomAttempt {
     private final Rooms rooms;

--- a/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/FindJoinableRooms.java
@@ -2,10 +2,11 @@ package com.naminhyeok.fantazzk.room;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 class FindJoinableRooms {
     private static final int JOINABLE_ROOM_LIMIT = 5;

--- a/src/main/java/com/naminhyeok/fantazzk/room/GetRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GetRoom.java
@@ -2,10 +2,11 @@ package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 class GetRoom {
     private final Rooms rooms;

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinRoom.java
@@ -1,24 +1,52 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle;
 import com.naminhyeok.fantazzk.CoreException;
-import lombok.RequiredArgsConstructor;
+import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class JoinRoom {
     private final Rooms rooms;
     private final TeamLeaderIdentityIssuer teamLeaderIdentityIssuer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
+    private final DraftRoomLifecycle draftRoomLifecycle;
+    private final AuctionRoomLifecycle auctionRoomLifecycle;
+
+    @Autowired
+    JoinRoom(
+        Rooms rooms,
+        TeamLeaderIdentityIssuer teamLeaderIdentityIssuer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        DraftRoomLifecycle draftRoomLifecycle,
+        AuctionRoomLifecycle auctionRoomLifecycle
+    ) {
+        this.rooms = rooms;
+        this.teamLeaderIdentityIssuer = teamLeaderIdentityIssuer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.draftRoomLifecycle = draftRoomLifecycle;
+        this.auctionRoomLifecycle = auctionRoomLifecycle;
+    }
+
+    JoinRoom(Rooms rooms, TeamLeaderIdentityIssuer teamLeaderIdentityIssuer, RoomSnapshotPublisher roomSnapshotPublisher) {
+        this(rooms, teamLeaderIdentityIssuer, roomSnapshotPublisher, null, null);
+    }
 
     @Transactional
     public RoomSessionResult join(String code, String nickname) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             TeamLeaderIdentityIssuer.TeamLeaderIdentity identity = teamLeaderIdentityIssuer.issue();
-            room.join(new TeamLeaderId(identity.leaderId()), nickname, identity.actionToken());
+            TeamLeaderId leaderId = new TeamLeaderId(identity.leaderId());
+            room.join(leaderId, nickname, identity.actionToken());
+            if (room.getMode() == RoomMode.DRAFT && draftRoomLifecycle != null) {
+                draftRoomLifecycle.addLeader(code, leaderId.value(), nickname);
+            } else if (room.getMode() == RoomMode.AUCTION && auctionRoomLifecycle != null) {
+                auctionRoomLifecycle.addLeader(code, leaderId.value(), nickname);
+            }
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
             return new RoomSessionResult(saved, saved.getLeaders().getLast());

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinRoom.java
@@ -3,12 +3,12 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class JoinRoom {
     private final Rooms rooms;
     private final TeamLeaderIdentityIssuer teamLeaderIdentityIssuer;
@@ -16,7 +16,6 @@ class JoinRoom {
     private final DraftRoomLifecycle draftRoomLifecycle;
     private final AuctionRoomLifecycle auctionRoomLifecycle;
 
-    @Autowired
     JoinRoom(
         Rooms rooms,
         TeamLeaderIdentityIssuer teamLeaderIdentityIssuer,
@@ -29,10 +28,6 @@ class JoinRoom {
         this.roomSnapshotPublisher = roomSnapshotPublisher;
         this.draftRoomLifecycle = draftRoomLifecycle;
         this.auctionRoomLifecycle = auctionRoomLifecycle;
-    }
-
-    JoinRoom(Rooms rooms, TeamLeaderIdentityIssuer teamLeaderIdentityIssuer, RoomSnapshotPublisher roomSnapshotPublisher) {
-        this(rooms, teamLeaderIdentityIssuer, roomSnapshotPublisher, null, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
@@ -14,11 +14,11 @@ class PickDraft {
     private final RoomSnapshotPublisher roomSnapshotPublisher;
 
     @Transactional
-    public Room pick(String code, String actionToken, String playerName) {
+    public Room pick(String code, String actionToken, RoomPlayerId playerId) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            room.pick(caller.getId(), playerName);
+            room.pick(caller.getId(), playerId);
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
             return saved;

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
@@ -1,24 +1,52 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import lombok.RequiredArgsConstructor;
+import com.naminhyeok.fantazzk.draft.DraftRoomPlay;
+import com.naminhyeok.fantazzk.draft.DraftRoomState;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class PickDraft {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
+    private final DraftRoomPlay draftRoomPlay;
+
+    @Autowired
+    PickDraft(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        DraftRoomPlay draftRoomPlay
+    ) {
+        this.rooms = rooms;
+        this.roomActionAuthorizer = roomActionAuthorizer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.draftRoomPlay = draftRoomPlay;
+    }
+
+    PickDraft(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
+        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
+    }
 
     @Transactional
     public Room pick(String code, String actionToken, RoomPlayerId playerId) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            room.pick(caller.getId(), playerId);
+            if (draftRoomPlay != null) {
+                try {
+                    DraftRoomState draftState = draftRoomPlay.pick(code, caller.getId().value(), playerId.value());
+                    room.applyDraftState(draftState);
+                } catch (RuntimeException ex) {
+                    room.pick(caller.getId(), playerId);
+                }
+            } else {
+                room.pick(caller.getId(), playerId);
+            }
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
             return saved;

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
@@ -3,19 +3,18 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.draft.DraftRoomPlay;
 import com.naminhyeok.fantazzk.draft.DraftRoomState;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class PickDraft {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final DraftRoomPlay draftRoomPlay;
 
-    @Autowired
     PickDraft(
         Rooms rooms,
         RoomActionAuthorizer roomActionAuthorizer,
@@ -26,10 +25,6 @@ class PickDraft {
         this.roomActionAuthorizer = roomActionAuthorizer;
         this.roomSnapshotPublisher = roomSnapshotPublisher;
         this.draftRoomPlay = draftRoomPlay;
-    }
-
-    PickDraft(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
-        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraftRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraftRequest.java
@@ -1,8 +1,10 @@
 package com.naminhyeok.fantazzk.room;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 record PickDraftRequest(
-    @NotBlank(message = "선수 이름은 비어 있을 수 없습니다") String playerName
+    @NotNull(message = "선수 식별자는 필수입니다")
+    @PositiveOrZero(message = "선수 식별자는 0 이상이어야 합니다") Integer playerId
 ) {
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
@@ -1,30 +1,78 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionRoomPlay;
+import com.naminhyeok.fantazzk.auction.AuctionRoomState;
+import com.naminhyeok.fantazzk.auction.AuctionRoomStateReader;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class PlaceBid {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final Clock clock;
+    private final AuctionRoomPlay auctionRoomPlay;
+    private final AuctionRoomStateReader auctionRoomStateReader;
+    private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
+
+    @Autowired
+    PlaceBid(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        Clock clock,
+        AuctionRoomPlay auctionRoomPlay,
+        AuctionRoomStateReader auctionRoomStateReader,
+        RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler
+    ) {
+        this.rooms = rooms;
+        this.roomActionAuthorizer = roomActionAuthorizer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.clock = clock;
+        this.auctionRoomPlay = auctionRoomPlay;
+        this.auctionRoomStateReader = auctionRoomStateReader;
+        this.roomAuctionDeadlineScheduler = roomAuctionDeadlineScheduler;
+    }
+
+    PlaceBid(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        Clock clock
+    ) {
+        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, clock, null, null, null);
+    }
 
     @Transactional
     public Room place(String code, String actionToken, int amount) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            room.placeBid(caller.getId(), amount, Instant.now(clock));
+            Instant now = Instant.now(clock);
+            if (auctionRoomPlay != null && auctionRoomStateReader != null) {
+                try {
+                    com.naminhyeok.fantazzk.auction.AuctionBid bid = auctionRoomPlay.placeBid(code, caller.getId().value(), amount, now);
+                    AuctionRoomState auctionState = auctionRoomStateReader.read(code);
+                    room.applyAuctionState(auctionState);
+                    room.recordBidProjection(bid.round(), bid.sequence(), caller.getId(), bid.amount());
+                    if (roomAuctionDeadlineScheduler != null) {
+                        roomAuctionDeadlineScheduler.refreshAfterCommit(code, auctionState.currentRoundEndsAt());
+                    }
+                } catch (RuntimeException ex) {
+                    room.placeBid(caller.getId(), amount, now);
+                }
+            } else {
+                room.placeBid(caller.getId(), amount, now);
+            }
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
-            return saved;
+            return rooms.findByCode(code).orElse(saved);
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }

--- a/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
@@ -6,12 +6,12 @@ import com.naminhyeok.fantazzk.auction.AuctionRoomStateReader;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class PlaceBid {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
@@ -21,7 +21,6 @@ class PlaceBid {
     private final AuctionRoomStateReader auctionRoomStateReader;
     private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
 
-    @Autowired
     PlaceBid(
         Rooms rooms,
         RoomActionAuthorizer roomActionAuthorizer,
@@ -38,15 +37,6 @@ class PlaceBid {
         this.auctionRoomPlay = auctionRoomPlay;
         this.auctionRoomStateReader = auctionRoomStateReader;
         this.roomAuctionDeadlineScheduler = roomAuctionDeadlineScheduler;
-    }
-
-    PlaceBid(
-        Rooms rooms,
-        RoomActionAuthorizer roomActionAuthorizer,
-        RoomSnapshotPublisher roomSnapshotPublisher,
-        Clock clock
-    ) {
-        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, clock, null, null, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -1,5 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionRoomState;
+import com.naminhyeok.fantazzk.draft.DraftRoomState;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.room.event.AuctionSettled;
 import com.naminhyeok.fantazzk.room.event.BidPlaced;
@@ -21,7 +23,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Locale;
 import java.util.UUID;
@@ -534,6 +538,69 @@ class Room implements AggregateRoot<Room, RoomId> {
             .filter(leader -> leader.getId().equals(teamLeaderId))
             .findFirst()
             .orElseThrow(() -> RoomStateInvalidException.leaderMissing(teamLeaderId));
+    }
+
+    void applyDraftState(DraftRoomState state) {
+        Map<String, DraftRoomState.Leader> leadersById = new HashMap<>();
+        state.leaders().forEach(leader -> leadersById.put(leader.leaderId(), leader));
+        leaders.forEach(leader -> {
+            DraftRoomState.Leader draftLeader = leadersById.get(leader.getId().value());
+            leader.syncDraftPosition(draftLeader == null ? null : draftLeader.draftPosition());
+        });
+
+        players.clear();
+        state.players().forEach(player -> players.add(
+            new RoomPlayer(
+                new RoomPlayerId(player.playerId()),
+                player.name(),
+                player.position(),
+                player.displayOrder(),
+                player.assigned() ? PlayerStatus.ASSIGNED : PlayerStatus.AVAILABLE
+            )
+        ));
+
+        members.clear();
+        state.members().forEach(member -> members.add(
+            new RoomTeamMember(new TeamLeaderId(member.leaderId()), new RoomPlayerId(member.playerId()), member.assignOrder())
+        ));
+
+        currentTurnIndex = state.progress() == null ? null : state.progress().currentTurnIndex();
+        currentAuctionRound = null;
+        currentAuctionRoundEndsAt = null;
+        bids.clear();
+    }
+
+    void applyAuctionState(AuctionRoomState state) {
+        Map<String, AuctionRoomState.Leader> leadersById = new HashMap<>();
+        state.leaders().forEach(leader -> leadersById.put(leader.leaderId(), leader));
+        leaders.forEach(leader -> {
+            AuctionRoomState.Leader auctionLeader = leadersById.get(leader.getId().value());
+            leader.syncRemainingBudget(auctionLeader == null ? null : auctionLeader.remainingBudget());
+        });
+
+        players.clear();
+        state.players().forEach(player -> players.add(
+            new RoomPlayer(
+                new RoomPlayerId(player.playerId()),
+                player.name(),
+                player.position(),
+                player.displayOrder(),
+                player.assigned() ? PlayerStatus.ASSIGNED : PlayerStatus.AVAILABLE
+            )
+        ));
+
+        members.clear();
+        state.members().forEach(member -> members.add(
+            new RoomTeamMember(new TeamLeaderId(member.leaderId()), new RoomPlayerId(member.playerId()), member.assignOrder())
+        ));
+
+        currentTurnIndex = null;
+        currentAuctionRound = state.currentRound();
+        currentAuctionRoundEndsAt = state.currentRoundEndsAt();
+    }
+
+    void recordBidProjection(int round, int sequence, TeamLeaderId leaderId, int amount) {
+        bids.add(RoomBid.projection(round, sequence, leaderId, amount));
     }
 
     @DomainEvents

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -311,6 +311,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             );
         RoomBid bid = new RoomBid(currentAuctionRound, nextSequence, teamLeaderId, amount);
         bids.add(bid);
+        currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
         registerEvent(new BidPlaced(code, teamLeaderId.value(), amount, currentAuctionRound, currentAuctionRoundEndsAt));
         return bid;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -346,7 +346,7 @@ class Room implements AggregateRoot<Room, RoomId> {
             target.moveToBack(maxOrder + 1);
             currentAuctionRound += 1;
             currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
-            AuctionSettlement settlement = new AuctionSettlement(target.getName(), AuctionOutcome.PASSED);
+            AuctionSettlement settlement = new AuctionSettlement(target.getId(), target.getName(), AuctionOutcome.PASSED);
             registerEvent(new AuctionSettled(code, settlement.outcome().name(), currentAuctionRoundEndsAt));
             return settlement;
         }
@@ -360,7 +360,7 @@ class Room implements AggregateRoot<Room, RoomId> {
         validateAuctionPositionLimit(winner.getId(), target);
         target.assign();
         winner.spend(winningBid.amount());
-        members.add(new RoomTeamMember(winningBid.teamLeaderId(), target.getName(), members.size()));
+        members.add(new RoomTeamMember(winningBid.teamLeaderId(), target.getId(), members.size()));
 
         if (members.size() == teamCount * (teamSize - 1)) {
             status = RoomStatus.COMPLETED;
@@ -369,12 +369,12 @@ class Room implements AggregateRoot<Room, RoomId> {
             currentAuctionRound += 1;
             currentAuctionRoundEndsAt = now.plusSeconds(pickBanTime);
         }
-        AuctionSettlement settlement = new AuctionSettlement(target.getName(), AuctionOutcome.SOLD);
+        AuctionSettlement settlement = new AuctionSettlement(target.getId(), target.getName(), AuctionOutcome.SOLD);
         registerEvent(new AuctionSettled(code, settlement.outcome().name(), currentAuctionRoundEndsAt));
         return settlement;
     }
 
-    RoomTeamMember pick(TeamLeaderId teamLeaderId, String playerName) {
+    RoomTeamMember pick(TeamLeaderId teamLeaderId, RoomPlayerId playerId) {
         if (status != RoomStatus.IN_PROGRESS) {
             throw CoreException.of(RoomErrorType.ROOM_PLAY_REQUIRES_IN_PROGRESS);
         }
@@ -389,13 +389,13 @@ class Room implements AggregateRoot<Room, RoomId> {
 
         RoomPlayer player =
             players.stream()
-                .filter(it -> it.getName().equals(playerName))
+                .filter(it -> it.getId().equals(playerId))
                 .filter(it -> it.getStatus() == PlayerStatus.AVAILABLE)
                 .findFirst()
                 .orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_PICK_PLAYER_NOT_AVAILABLE));
 
         player.assign();
-        RoomTeamMember member = new RoomTeamMember(teamLeaderId, player.getName(), members.size());
+        RoomTeamMember member = new RoomTeamMember(teamLeaderId, player.getId(), members.size());
         members.add(member);
 
         currentTurnIndex += 1;
@@ -519,11 +519,14 @@ class Room implements AggregateRoot<Room, RoomId> {
     }
 
     private String findAssignedPlayerPosition(RoomTeamMember member) {
+        return findPlayer(member.playerId()).getPosition();
+    }
+
+    RoomPlayer findPlayer(RoomPlayerId playerId) {
         return players.stream()
-            .filter(player -> player.getName().equals(member.playerName()))
+            .filter(player -> player.getId().equals(playerId))
             .findFirst()
-            .map(RoomPlayer::getPosition)
-            .orElse(null);
+            .orElseThrow(() -> RoomStateInvalidException.playerMissing(playerId));
     }
 
     private RoomTeamLeader getLeader(TeamLeaderId teamLeaderId) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineScheduler.java
@@ -12,6 +12,8 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -33,6 +35,19 @@ class RoomAuctionDeadlineScheduler {
         }
 
         schedule(code, deadline);
+    }
+
+    void refreshAfterCommit(String code, Instant deadline) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            refresh(code, deadline);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                refresh(code, deadline);
+            }
+        });
     }
 
     private void schedule(String code, Instant deadline) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomBid.java
@@ -33,6 +33,10 @@ final class RoomBid implements ValueObject {
         this.amount = amount;
     }
 
+    static RoomBid projection(int round, int sequence, TeamLeaderId teamLeaderId, int amount) {
+        return new RoomBid(round, new BidSequence(sequence), teamLeaderId, amount);
+    }
+
     int round() {
         return round;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomDraftApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomDraftApiController.java
@@ -26,7 +26,7 @@ class RoomDraftApiController {
         @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken,
         @Valid @RequestBody PickDraftRequest request
     ) {
-        return ApiResponse.success(RoomResponse.from(pickDraft.pick(code, actionToken, request.playerName())));
+        return ApiResponse.success(RoomResponse.from(pickDraft.pick(code, actionToken, new RoomPlayerId(request.playerId()))));
     }
 
     @PutMapping("/{code}/draft-position")

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomMemberResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomMemberResponse.java
@@ -2,13 +2,15 @@ package com.naminhyeok.fantazzk.room;
 
 record RoomMemberResponse(
     String teamLeaderId,
+    int playerId,
     String playerName,
     int assignOrder
 ) {
-    static RoomMemberResponse from(RoomTeamMember member) {
+    static RoomMemberResponse from(RoomTeamMember member, RoomPlayer player) {
         return new RoomMemberResponse(
             member.teamLeaderId().value(),
-            member.playerName(),
+            member.playerId().value(),
+            player.getName(),
             member.assignOrder()
         );
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayer.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayer.java
@@ -37,6 +37,14 @@ class RoomPlayer {
         this.status = PlayerStatus.AVAILABLE;
     }
 
+    RoomPlayer(RoomPlayerId id, String name, String position, int displayOrder, PlayerStatus status) {
+        this.id = id;
+        this.name = name;
+        this.position = position;
+        this.displayOrder = displayOrder;
+        this.status = status;
+    }
+
     public RoomPlayerId getId() {
         return id;
     }
@@ -47,5 +55,10 @@ class RoomPlayer {
 
     void moveToBack(int nextOrder) {
         this.displayOrder = nextOrder;
+    }
+
+    void sync(int displayOrder, PlayerStatus status) {
+        this.displayOrder = displayOrder;
+        this.status = status;
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
@@ -1,6 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
 record RoomPlayerResponse(
+    int playerId,
     String name,
     String position,
     int displayOrder,
@@ -8,6 +9,7 @@ record RoomPlayerResponse(
 ) {
     static RoomPlayerResponse from(RoomPlayer player) {
         return new RoomPlayerResponse(
+            player.getId().value(),
             player.getName(),
             player.getPosition(),
             player.getDisplayOrder(),

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomResponse.java
@@ -1,6 +1,9 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.Map;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 record RoomResponse(
     String code,
@@ -19,6 +22,9 @@ record RoomResponse(
     RoomProgressResponse progress
 ) {
     static RoomResponse from(Room room) {
+        List<RoomPlayer> players = room.getPlayers();
+        Map<RoomPlayerId, RoomPlayer> playersById = players.stream()
+            .collect(Collectors.toMap(RoomPlayer::getId, Function.identity()));
         return new RoomResponse(
             room.getCode(),
             room.getStatus().name(),
@@ -31,8 +37,13 @@ record RoomResponse(
             room.getStartReadiness().name(),
             DraftOrderPreviewResponse.from(room),
             room.getLeaders().stream().map(TeamLeaderResponse::from).toList(),
-            room.getPlayers().stream().map(RoomPlayerResponse::from).toList(),
-            room.getMembers().stream().map(RoomMemberResponse::from).toList(),
+            players.stream().map(RoomPlayerResponse::from).toList(),
+            room.getMembers().stream()
+                .map(member -> {
+                    RoomPlayer player = playersById.get(member.playerId());
+                    return RoomMemberResponse.from(member, player == null ? room.findPlayer(member.playerId()) : player);
+                })
+                .toList(),
             RoomProgressResponse.from(room)
         );
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStateInvalidException.java
@@ -49,7 +49,15 @@ final class RoomStateInvalidException extends InvalidDomainStateException {
         return new RoomStateInvalidException("팀장을 찾을 수 없습니다: " + leaderIdValue(leaderId));
     }
 
+    static RoomStateInvalidException playerMissing(RoomPlayerId playerId) {
+        return new RoomStateInvalidException("선수를 찾을 수 없습니다: " + playerIdValue(playerId));
+    }
+
     private static String leaderIdValue(TeamLeaderId leaderId) {
         return leaderId == null ? "null" : leaderId.value();
+    }
+
+    private static String playerIdValue(RoomPlayerId playerId) {
+        return playerId == null ? "null" : Integer.toString(playerId.value());
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamLeader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamLeader.java
@@ -59,4 +59,12 @@ class RoomTeamLeader {
     void clearDraftPosition() {
         this.draftPosition = null;
     }
+
+    void syncDraftPosition(Integer draftPosition) {
+        this.draftPosition = draftPosition;
+    }
+
+    void syncRemainingBudget(Integer remainingBudget) {
+        this.remainingBudget = remainingBudget;
+    }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamMember.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomTeamMember.java
@@ -15,17 +15,18 @@ final class RoomTeamMember implements ValueObject {
     @Column(name = "team_leader_id")
     @Convert(converter = TeamLeaderId.JpaConverter.class)
     private TeamLeaderId teamLeaderId;
-    @Column(name = "player_name")
-    private String playerName;
+    @Column(name = "player_id")
+    @Convert(converter = RoomPlayerId.JpaConverter.class)
+    private RoomPlayerId playerId;
     @Column(name = "assign_order")
     private int assignOrder;
 
     RoomTeamMember() {
     }
 
-    RoomTeamMember(TeamLeaderId teamLeaderId, String playerName, int assignOrder) {
+    RoomTeamMember(TeamLeaderId teamLeaderId, RoomPlayerId playerId, int assignOrder) {
         this.teamLeaderId = teamLeaderId;
-        this.playerName = playerName;
+        this.playerId = playerId;
         this.assignOrder = assignOrder;
     }
 
@@ -33,8 +34,8 @@ final class RoomTeamMember implements ValueObject {
         return teamLeaderId;
     }
 
-    String playerName() {
-        return playerName;
+    RoomPlayerId playerId() {
+        return playerId;
     }
 
     int assignOrder() {

--- a/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
@@ -1,24 +1,52 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.CoreException;
-import lombok.RequiredArgsConstructor;
+import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
+import com.naminhyeok.fantazzk.draft.DraftRoomState;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class SelectDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
+    private final DraftRoomLifecycle draftRoomLifecycle;
+
+    @Autowired
+    SelectDraftPosition(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        DraftRoomLifecycle draftRoomLifecycle
+    ) {
+        this.rooms = rooms;
+        this.roomActionAuthorizer = roomActionAuthorizer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.draftRoomLifecycle = draftRoomLifecycle;
+    }
+
+    SelectDraftPosition(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
+        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
+    }
 
     @Transactional
     public Room select(String code, String actionToken, int draftPosition) {
         try {
             Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            room.selectDraftPosition(caller.getId(), draftPosition);
+            if (draftRoomLifecycle != null) {
+                try {
+                    DraftRoomState draftState = draftRoomLifecycle.selectDraftPosition(code, caller.getId().value(), draftPosition);
+                    room.applyDraftState(draftState);
+                } catch (RuntimeException ex) {
+                    room.selectDraftPosition(caller.getId(), draftPosition);
+                }
+            } else {
+                room.selectDraftPosition(caller.getId(), draftPosition);
+            }
             Room saved = rooms.saveAndFlush(room);
             roomSnapshotPublisher.publishAfterCommit(saved);
             return saved;

--- a/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPosition.java
@@ -3,19 +3,18 @@ package com.naminhyeok.fantazzk.room;
 import com.naminhyeok.fantazzk.CoreException;
 import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
 import com.naminhyeok.fantazzk.draft.DraftRoomState;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class SelectDraftPosition {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final DraftRoomLifecycle draftRoomLifecycle;
 
-    @Autowired
     SelectDraftPosition(
         Rooms rooms,
         RoomActionAuthorizer roomActionAuthorizer,
@@ -26,10 +25,6 @@ class SelectDraftPosition {
         this.roomActionAuthorizer = roomActionAuthorizer;
         this.roomSnapshotPublisher = roomSnapshotPublisher;
         this.draftRoomLifecycle = draftRoomLifecycle;
-    }
-
-    SelectDraftPosition(Rooms rooms, RoomActionAuthorizer roomActionAuthorizer, RoomSnapshotPublisher roomSnapshotPublisher) {
-        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
@@ -34,6 +34,6 @@ class SettleAuction {
         if (room.getCurrentAuctionRoundEndsAt() == null) {
             return;
         }
-        roomAuctionDeadlineScheduler.ifAvailable(scheduler -> scheduler.schedule(room));
+        roomAuctionDeadlineScheduler.ifAvailable(scheduler -> scheduler.refreshAfterCommit(room.getCode(), room.getCurrentAuctionRoundEndsAt()));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuction.java
@@ -4,9 +4,10 @@ import com.naminhyeok.fantazzk.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 class SettleAuction {
     private final SettleAuctionAttempt settleAuctionAttempt;

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
@@ -1,27 +1,70 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle;
+import com.naminhyeok.fantazzk.auction.AuctionRoomState;
+import com.naminhyeok.fantazzk.auction.AuctionRoomStateReader;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class SettleAuctionAttempt {
     private final Rooms rooms;
     private final Clock clock;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
+    private final AuctionRoomLifecycle auctionRoomLifecycle;
+    private final AuctionRoomStateReader auctionRoomStateReader;
+
+    @Autowired
+    SettleAuctionAttempt(
+        Rooms rooms,
+        Clock clock,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        AuctionRoomLifecycle auctionRoomLifecycle,
+        AuctionRoomStateReader auctionRoomStateReader
+    ) {
+        this.rooms = rooms;
+        this.clock = clock;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.auctionRoomLifecycle = auctionRoomLifecycle;
+        this.auctionRoomStateReader = auctionRoomStateReader;
+    }
+
+    SettleAuctionAttempt(Rooms rooms, Clock clock, RoomSnapshotPublisher roomSnapshotPublisher) {
+        this(rooms, clock, roomSnapshotPublisher, null, null);
+    }
 
     @Transactional
     AuctionSettlement settle(String code) {
         Instant now = Instant.now(clock);
         Room room = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
-        AuctionSettlement settlement = room.settleAuction(now);
+        if (auctionRoomLifecycle == null || auctionRoomStateReader == null) {
+            AuctionSettlement settlement = room.settleAuction(now);
+            Room saved = rooms.saveAndFlush(room);
+            roomSnapshotPublisher.publishAfterCommit(saved);
+            return settlement;
+        }
+        com.naminhyeok.fantazzk.auction.AuctionSettlement settlement;
+        try {
+            settlement = auctionRoomLifecycle.settle(code, now);
+            AuctionRoomState auctionState = auctionRoomStateReader.read(code);
+            room.applyAuctionState(auctionState);
+        } catch (RuntimeException ex) {
+            AuctionSettlement legacySettlement = room.settleAuction(now);
+            Room saved = rooms.saveAndFlush(room);
+            roomSnapshotPublisher.publishAfterCommit(saved);
+            return legacySettlement;
+        }
         Room saved = rooms.saveAndFlush(room);
         roomSnapshotPublisher.publishAfterCommit(saved);
-        return settlement;
+        return new AuctionSettlement(
+            new RoomPlayerId(settlement.playerId()),
+            settlement.playerName(),
+            AuctionOutcome.valueOf(settlement.outcome().name())
+        );
     }
 
     @Transactional
@@ -32,7 +75,17 @@ class SettleAuctionAttempt {
             return room;
         }
 
-        room.settleAuction(now);
+        if (auctionRoomLifecycle == null || auctionRoomStateReader == null) {
+            room.settleAuction(now);
+        } else {
+            try {
+                auctionRoomLifecycle.settle(code, now);
+                AuctionRoomState auctionState = auctionRoomStateReader.read(code);
+                room.applyAuctionState(auctionState);
+            } catch (RuntimeException ex) {
+                room.settleAuction(now);
+            }
+        }
         Room saved = rooms.saveAndFlush(room);
         roomSnapshotPublisher.publishAfterCommit(saved);
         return saved;

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
@@ -6,11 +6,10 @@ import com.naminhyeok.fantazzk.auction.AuctionRoomStateReader;
 import com.naminhyeok.fantazzk.CoreException;
 import java.time.Clock;
 import java.time.Instant;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 class SettleAuctionAttempt {
     private final Rooms rooms;
     private final Clock clock;
@@ -18,7 +17,6 @@ class SettleAuctionAttempt {
     private final AuctionRoomLifecycle auctionRoomLifecycle;
     private final AuctionRoomStateReader auctionRoomStateReader;
 
-    @Autowired
     SettleAuctionAttempt(
         Rooms rooms,
         Clock clock,
@@ -31,10 +29,6 @@ class SettleAuctionAttempt {
         this.roomSnapshotPublisher = roomSnapshotPublisher;
         this.auctionRoomLifecycle = auctionRoomLifecycle;
         this.auctionRoomStateReader = auctionRoomStateReader;
-    }
-
-    SettleAuctionAttempt(Rooms rooms, Clock clock, RoomSnapshotPublisher roomSnapshotPublisher) {
-        this(rooms, clock, roomSnapshotPublisher, null, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
@@ -1,30 +1,86 @@
 package com.naminhyeok.fantazzk.room;
 
+import com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle;
+import com.naminhyeok.fantazzk.auction.AuctionRoomState;
 import com.naminhyeok.fantazzk.CoreException;
+import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
+import com.naminhyeok.fantazzk.draft.DraftRoomState;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 class StartRoom {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final Clock clock;
+    private final DraftRoomLifecycle draftRoomLifecycle;
+    private final AuctionRoomLifecycle auctionRoomLifecycle;
+    private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
+
+    @Autowired
+    StartRoom(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        Clock clock,
+        DraftRoomLifecycle draftRoomLifecycle,
+        AuctionRoomLifecycle auctionRoomLifecycle,
+        RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler
+    ) {
+        this.rooms = rooms;
+        this.roomActionAuthorizer = roomActionAuthorizer;
+        this.roomSnapshotPublisher = roomSnapshotPublisher;
+        this.clock = clock;
+        this.draftRoomLifecycle = draftRoomLifecycle;
+        this.auctionRoomLifecycle = auctionRoomLifecycle;
+        this.roomAuctionDeadlineScheduler = roomAuctionDeadlineScheduler;
+    }
+
+    StartRoom(
+        Rooms rooms,
+        RoomActionAuthorizer roomActionAuthorizer,
+        RoomSnapshotPublisher roomSnapshotPublisher,
+        Clock clock
+    ) {
+        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, clock, null, null, null);
+    }
 
     @Transactional
     public Room start(String code, String actionToken) {
         try {
             Room loaded = rooms.findByCode(code).orElseThrow(() -> CoreException.of(RoomErrorType.ROOM_NOT_FOUND));
             RoomTeamLeader caller = roomActionAuthorizer.authenticate(loaded, actionToken);
-            loaded.start(caller.getId(), Instant.now(clock));
+            Instant now = Instant.now(clock);
+            if (loaded.getMode() == RoomMode.DRAFT && draftRoomLifecycle != null) {
+                try {
+                    DraftRoomState draftState = draftRoomLifecycle.start(code);
+                    loaded.start(caller.getId(), now);
+                    loaded.applyDraftState(draftState);
+                } catch (RuntimeException ex) {
+                    loaded.start(caller.getId(), now);
+                }
+            } else if (loaded.getMode() == RoomMode.AUCTION && auctionRoomLifecycle != null) {
+                try {
+                    AuctionRoomState auctionState = auctionRoomLifecycle.start(code, caller.getId().value(), now);
+                    loaded.start(caller.getId(), now);
+                    loaded.applyAuctionState(auctionState);
+                } catch (RuntimeException ex) {
+                    loaded.start(caller.getId(), now);
+                }
+            } else {
+                loaded.start(caller.getId(), now);
+            }
             Room saved = rooms.saveAndFlush(loaded);
             roomSnapshotPublisher.publishAfterCommit(saved);
-            return saved;
+            if (saved.getMode() == RoomMode.AUCTION && roomAuctionDeadlineScheduler != null) {
+                roomAuctionDeadlineScheduler.refreshAfterCommit(saved.getCode(), saved.getCurrentAuctionRoundEndsAt());
+            }
+            return rooms.findByCode(code).orElse(saved);
         } catch (OptimisticLockingFailureException ex) {
             throw CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION);
         }

--- a/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/StartRoom.java
@@ -7,12 +7,12 @@ import com.naminhyeok.fantazzk.draft.DraftRoomLifecycle;
 import com.naminhyeok.fantazzk.draft.DraftRoomState;
 import java.time.Clock;
 import java.time.Instant;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 class StartRoom {
     private final Rooms rooms;
     private final RoomActionAuthorizer roomActionAuthorizer;
@@ -22,7 +22,6 @@ class StartRoom {
     private final AuctionRoomLifecycle auctionRoomLifecycle;
     private final RoomAuctionDeadlineScheduler roomAuctionDeadlineScheduler;
 
-    @Autowired
     StartRoom(
         Rooms rooms,
         RoomActionAuthorizer roomActionAuthorizer,
@@ -39,15 +38,6 @@ class StartRoom {
         this.draftRoomLifecycle = draftRoomLifecycle;
         this.auctionRoomLifecycle = auctionRoomLifecycle;
         this.roomAuctionDeadlineScheduler = roomAuctionDeadlineScheduler;
-    }
-
-    StartRoom(
-        Rooms rooms,
-        RoomActionAuthorizer roomActionAuthorizer,
-        RoomSnapshotPublisher roomSnapshotPublisher,
-        Clock clock
-    ) {
-        this(rooms, roomActionAuthorizer, roomSnapshotPublisher, clock, null, null, null);
     }
 
     @Transactional

--- a/src/main/java/com/naminhyeok/fantazzk/room/package-info.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/package-info.java
@@ -1,4 +1,4 @@
-@ApplicationModule(allowedDependencies = "template")
+@ApplicationModule(allowedDependencies = { "template", "draft", "auction" })
 package com.naminhyeok.fantazzk.room;
 
 import org.springframework.modulith.ApplicationModule;

--- a/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplate.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplate.java
@@ -1,10 +1,11 @@
 package com.naminhyeok.fantazzk.template;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 class CreateTemplate {
     private final Templates templates;

--- a/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/FindTemplates.java
@@ -3,10 +3,11 @@ package com.naminhyeok.fantazzk.template;
 import com.naminhyeok.fantazzk.CoreException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
+@org.jmolecules.ddd.annotation.Service
 @RequiredArgsConstructor
 class FindTemplates {
     private final Templates templates;

--- a/src/main/java/com/naminhyeok/fantazzk/template/ProvideTemplateCatalog.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/ProvideTemplateCatalog.java
@@ -3,9 +3,9 @@ package com.naminhyeok.fantazzk.template;
 import com.naminhyeok.fantazzk.CoreException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
 class ProvideTemplateCatalog implements TemplateCatalog {
     private final FindTemplates findTemplates;

--- a/src/main/resources/db/changelog/db.changelog-draft-auction-modules.sql
+++ b/src/main/resources/db/changelog/db.changelog-draft-auction-modules.sql
@@ -1,0 +1,11 @@
+CREATE TABLE draft_room
+(
+    room_code  VARCHAR(255) PRIMARY KEY,
+    state_json TEXT NOT NULL
+);
+
+CREATE TABLE auction_room
+(
+    room_code      VARCHAR(255) PRIMARY KEY,
+    snapshot_json  TEXT NOT NULL
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -85,3 +85,14 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-position-limit.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 8-room-player-id
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-room-player-id.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -96,3 +96,14 @@ databaseChangeLog:
             path: db/changelog/db.changelog-room-player-id.sql
             splitStatements: true
             stripComments: false
+  - changeSet:
+      id: 9-draft-auction-modules
+      author: codex
+      changes:
+        - sqlFile:
+            dbms: h2,postgresql
+            encoding: UTF-8
+            endDelimiter: ;
+            path: db/changelog/db.changelog-draft-auction-modules.sql
+            splitStatements: true
+            stripComments: false

--- a/src/main/resources/db/changelog/db.changelog-room-player-id.sql
+++ b/src/main/resources/db/changelog/db.changelog-room-player-id.sql
@@ -1,0 +1,12 @@
+ALTER TABLE room_team_member ADD COLUMN player_id INT;
+
+UPDATE room_team_member
+SET player_id = (
+    SELECT room_player.room_player_id
+    FROM room_player
+    WHERE room_player.players_room_id = room_team_member.members_room_id
+      AND room_player.name = room_team_member.player_name
+);
+
+ALTER TABLE room_team_member ALTER COLUMN player_id SET NOT NULL;
+ALTER TABLE room_team_member DROP COLUMN player_name;

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionModuleStructureTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionModuleStructureTest.java
@@ -11,8 +11,6 @@ class AuctionModuleStructureTest {
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomPlay")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomStateReader")).isTrue();
-        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRooms")).isTrue();
-        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoom")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomState")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionSettlement")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionBid")).isTrue();
@@ -24,6 +22,8 @@ class AuctionModuleStructureTest {
     @Test
     void 내부_도메인_구성은_package_private이다() throws Exception {
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomId")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRooms")).isFalse();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoom")).isTrue();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionPlayer")).isFalse();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionTeamLeader")).isFalse();
         assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionTeamMember")).isFalse();

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionModuleStructureTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionModuleStructureTest.java
@@ -1,0 +1,36 @@
+package com.naminhyeok.fantazzk.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Test;
+
+class AuctionModuleStructureTest {
+    @Test
+    void 공개_계약은_애플리케이션_서비스와_상태_표현만_노출한다() throws Exception {
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomLifecycle")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomPlay")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomStateReader")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRooms")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoom")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomState")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionSettlement")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionBid")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionTarget")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomSetup")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionPlayerSeed")).isTrue();
+    }
+
+    @Test
+    void 내부_도메인_구성은_package_private이다() throws Exception {
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomId")).isTrue();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionPlayer")).isFalse();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionTeamLeader")).isFalse();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionTeamMember")).isFalse();
+        assertThat(isPublic("com.naminhyeok.fantazzk.auction.AuctionRoomException")).isFalse();
+    }
+
+    private boolean isPublic(String className) throws Exception {
+        return Modifier.isPublic(Class.forName(className).getModifiers());
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycleTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomLifecycleTest.java
@@ -1,0 +1,94 @@
+package com.naminhyeok.fantazzk.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuctionRoomLifecycleTest {
+    @Test
+    void 생성하면_저장하고_초기_상태를_돌려준다() {
+        RecordingAuctionRooms rooms = new RecordingAuctionRooms();
+        AuctionRoomLifecycle lifecycle = new AuctionRoomLifecycle(rooms);
+
+        AuctionRoomState state = lifecycle.create(
+            "ROOM01",
+            AuctionTestFixtures.HOST_ID,
+            AuctionTestFixtures.HOST_NICKNAME,
+            AuctionTestFixtures.CREATED_AT,
+            AuctionTestFixtures.setup()
+        );
+
+        assertThat(rooms.savedRoom).isNotNull();
+        assertThat(state.code()).isEqualTo("ROOM01");
+        assertThat(state.status()).isEqualTo(AuctionRoomStatus.WAITING);
+        assertThat(state.currentRound()).isNull();
+    }
+
+    @Test
+    void 팀장을_추가하면_saveAndFlush를_호출한다() {
+        RecordingAuctionRooms rooms = new RecordingAuctionRooms(AuctionTestFixtures.waitingRoom());
+        AuctionRoomLifecycle lifecycle = new AuctionRoomLifecycle(rooms);
+
+        AuctionRoomState state = lifecycle.addLeader("ROOM01", AuctionTestFixtures.GUEST_ID, AuctionTestFixtures.GUEST_NICKNAME);
+
+        assertThat(rooms.saveAndFlushCalled).isTrue();
+        assertThat(state.status()).isEqualTo(AuctionRoomStatus.WAITING);
+    }
+
+    @Test
+    void 시작하면_라운드가_초기화된다() {
+        RecordingAuctionRooms rooms = new RecordingAuctionRooms(AuctionTestFixtures.waitingRoomWithGuestLeader());
+        AuctionRoomLifecycle lifecycle = new AuctionRoomLifecycle(rooms);
+
+        AuctionRoomState state = lifecycle.start("ROOM01", AuctionTestFixtures.HOST_ID, AuctionTestFixtures.CREATED_AT);
+
+        assertThat(state.currentRound()).isEqualTo(1);
+        assertThat(state.currentRoundEndsAt()).isEqualTo(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME));
+    }
+
+    @Test
+    void 정산하면_정산결과를_돌려준다() {
+        RecordingAuctionRooms rooms = new RecordingAuctionRooms(AuctionTestFixtures.startedRoomWithWinningBid());
+        AuctionRoomLifecycle lifecycle = new AuctionRoomLifecycle(rooms);
+
+        AuctionSettlement settlement = lifecycle.settle("ROOM01", AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 2L));
+
+        assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
+        assertThat(rooms.saveAndFlushCalled).isTrue();
+    }
+
+    private static final class RecordingAuctionRooms implements AuctionRooms {
+        private AuctionRoom savedRoom;
+        private boolean saveAndFlushCalled;
+
+        private RecordingAuctionRooms() {
+        }
+
+        private RecordingAuctionRooms(AuctionRoom room) {
+            this.savedRoom = room;
+        }
+
+        @Override
+        public AuctionRoom save(AuctionRoom room) {
+            this.savedRoom = room;
+            return room;
+        }
+
+        @Override
+        public AuctionRoom saveAndFlush(AuctionRoom room) {
+            this.savedRoom = room;
+            this.saveAndFlushCalled = true;
+            return room;
+        }
+
+        @Override
+        public java.util.Optional<AuctionRoom> findByCode(String code) {
+            return java.util.Optional.ofNullable(savedRoom).filter(room -> room.readState().code().equals(code));
+        }
+
+        @Override
+        public java.util.List<AuctionRoom> findInProgressAuctionRooms() {
+            return java.util.List.of();
+        }
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlayTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomPlayTest.java
@@ -1,0 +1,50 @@
+package com.naminhyeok.fantazzk.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuctionRoomPlayTest {
+    @Test
+    void 입찰하면_저장하고_입찰_정보를_돌려준다() {
+        RecordingAuctionRooms rooms = new RecordingAuctionRooms(AuctionTestFixtures.startedRoom());
+        AuctionRoomPlay play = new AuctionRoomPlay(rooms);
+
+        AuctionBid bid = play.placeBid("ROOM01", AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+
+        assertThat(bid.amount()).isEqualTo(100);
+        assertThat(rooms.saveAndFlushCalled).isTrue();
+    }
+
+    private static final class RecordingAuctionRooms implements AuctionRooms {
+        private AuctionRoom savedRoom;
+        private boolean saveAndFlushCalled;
+
+        private RecordingAuctionRooms(AuctionRoom room) {
+            this.savedRoom = room;
+        }
+
+        @Override
+        public AuctionRoom save(AuctionRoom room) {
+            this.savedRoom = room;
+            return room;
+        }
+
+        @Override
+        public AuctionRoom saveAndFlush(AuctionRoom room) {
+            this.savedRoom = room;
+            this.saveAndFlushCalled = true;
+            return room;
+        }
+
+        @Override
+        public java.util.Optional<AuctionRoom> findByCode(String code) {
+            return java.util.Optional.ofNullable(savedRoom).filter(room -> room.readState().code().equals(code));
+        }
+
+        @Override
+        public java.util.List<AuctionRoom> findInProgressAuctionRooms() {
+            return java.util.List.of();
+        }
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReaderTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomStateReaderTest.java
@@ -1,0 +1,17 @@
+package com.naminhyeok.fantazzk.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuctionRoomStateReaderTest {
+    @Test
+    void 상태를_스냅샷으로_읽는다() {
+        AuctionRoomStateReader reader = new AuctionRoomStateReader(AuctionTestFixtures.inMemoryRooms(AuctionTestFixtures.startedRoom()));
+
+        AuctionRoomState state = reader.read("ROOM01");
+
+        assertThat(state.currentRound()).isEqualTo(1);
+        assertThat(state.currentTarget().playerId()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionRoomTest.java
@@ -1,0 +1,208 @@
+package com.naminhyeok.fantazzk.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AuctionRoomTest {
+    @Test
+    void 경매_방을_시작하면_1라운드_deadline이_생성된다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoomWithGuestLeader();
+
+        room.start(AuctionTestFixtures.HOST_ID, AuctionTestFixtures.CREATED_AT);
+
+        AuctionRoomState state = room.readState();
+        assertThat(state.currentRound()).isEqualTo(1);
+        assertThat(state.currentRoundEndsAt()).isEqualTo(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME));
+    }
+
+    @Test
+    void deadline_전에는_경매를_정산할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        assertThatThrownBy(() -> room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(10)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("경매 라운드가 아직 종료되지 않았습니다");
+    }
+
+    @Test
+    void deadline_가_지나면_입찰할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("경매 라운드가 아직 종료되지 않았습니다");
+    }
+
+    @Test
+    void 현재_최고가보다_낮거나_같은_입찰은_할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.GUEST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(2)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("현재 최고가보다 낮거나 같은 입찰입니다");
+    }
+
+    @Test
+    void 첫_입찰은_최소_입찰_단위_이상이어야_한다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.HOST_ID, 5, AuctionTestFixtures.CREATED_AT.plusSeconds(1)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("최소 입찰 단위를 만족하지 않습니다");
+    }
+
+    @Test
+    void 이후_입찰은_현재_최고가보다_최소_입찰_단위만큼_높아야_한다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.GUEST_ID, 105, AuctionTestFixtures.CREATED_AT.plusSeconds(2)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("최소 입찰 단위를 만족하지 않습니다");
+    }
+
+    @Test
+    void 최소_입찰_단위를_만족하면_다음_입찰을_할_수_있다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+        AuctionBid bid = room.placeBid(AuctionTestFixtures.GUEST_ID, 110, AuctionTestFixtures.CREATED_AT.plusSeconds(2));
+
+        assertThat(bid.amount()).isEqualTo(110);
+        assertThat(bid.sequence()).isEqualTo(2);
+        assertThat(room.readState().currentRoundEndsAt()).isEqualTo(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 2L));
+    }
+
+    @Test
+    void 진행_중이_아니면_입찰할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoom();
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("진행 중인 경매가 아닙니다");
+    }
+
+    @Test
+    void 팀장_닉네임이_중복되면_추가할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoom();
+
+        assertThatThrownBy(() -> room.addLeader("guest-2", "호스트"))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("이미 사용 중인 닉네임입니다: 호스트");
+    }
+
+    @Test
+    void 예산이_부족하면_입찰할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.HOST_ID, 400, AuctionTestFixtures.CREATED_AT.plusSeconds(1)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("예산이 부족합니다");
+    }
+
+    @Test
+    void 입찰_금액은_0보다_커야_한다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        for (int amount : List.of(0, -1)) {
+            assertThatThrownBy(() -> room.placeBid(AuctionTestFixtures.HOST_ID, amount, AuctionTestFixtures.CREATED_AT.plusSeconds(1)))
+                .isInstanceOf(AuctionRoomException.class)
+                .hasMessage("입찰 금액은 0보다 커야 합니다");
+        }
+    }
+
+    @Test
+    void 방에_없는_팀장_id로는_입찰할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        assertThatThrownBy(() -> room.placeBid("unknown-leader", 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1)))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("입찰자를 찾을 수 없습니다: unknown-leader");
+    }
+
+    @Test
+    void 낙찰되면_선수가_배정되고_예산이_차감되며_다음_라운드로_진행한다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        AuctionBid firstBid = room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+        AuctionBid secondBid = room.placeBid(AuctionTestFixtures.GUEST_ID, 150, AuctionTestFixtures.CREATED_AT.plusSeconds(2));
+
+        AuctionSettlement settlement = room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 2L));
+        AuctionRoomState state = room.readState();
+
+        assertThat(firstBid.sequence()).isEqualTo(1);
+        assertThat(secondBid.sequence()).isEqualTo(2);
+        assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
+        assertThat(settlement.playerId()).isEqualTo(0);
+        assertThat(settlement.playerName()).isEqualTo("선수1");
+        assertThat(state.currentRound()).isEqualTo(2);
+        assertThat(state.currentRoundEndsAt()).isEqualTo(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME * 2L + 2L));
+        assertThat(state.currentTarget().playerId()).isEqualTo(1);
+    }
+
+    @Test
+    void 새_경매_라운드가_시작되면_입찰_순번은_다시_처음부터_시작한다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+        room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 1L));
+
+        AuctionBid nextRoundBid = room.placeBid(AuctionTestFixtures.HOST_ID, 120, AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 1L));
+
+        assertThat(nextRoundBid.sequence()).isEqualTo(1);
+        assertThat(nextRoundBid.round()).isEqualTo(2);
+    }
+
+    @Test
+    void 모든_선수를_배정하면_deadline이_사라진다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoomWithGuestLeader();
+        room.start(AuctionTestFixtures.HOST_ID, AuctionTestFixtures.CREATED_AT);
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 100, AuctionTestFixtures.CREATED_AT.plusSeconds(1));
+        room.placeBid(AuctionTestFixtures.GUEST_ID, 150, AuctionTestFixtures.CREATED_AT.plusSeconds(2));
+        room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 2L));
+
+        room.placeBid(AuctionTestFixtures.HOST_ID, 120, AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 1L));
+        room.placeBid(AuctionTestFixtures.GUEST_ID, 130, AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME + 2L));
+        room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME * 2L + 2L));
+
+        assertThat(room.readState().status()).isEqualTo(AuctionRoomStatus.COMPLETED);
+        assertThat(room.readState().currentRoundEndsAt()).isNull();
+    }
+
+    @Test
+    void 진행_중이_아니면_낙찰_처리를_할_수_없다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoom();
+
+        assertThatThrownBy(() -> room.settle(AuctionTestFixtures.CREATED_AT))
+            .isInstanceOf(AuctionRoomException.class)
+            .hasMessage("진행 중인 경매가 아닙니다");
+    }
+
+    @Test
+    void 시작되지_않은_경매는_라운드가_없다() {
+        AuctionRoom room = AuctionTestFixtures.waitingRoom();
+
+        assertThat(room.readState().currentRound()).isNull();
+        assertThat(room.readState().currentTarget()).isNull();
+    }
+
+    @Test
+    void 입찰_없으면_정산시_패스하고_선수를_뒤로_보낸다() {
+        AuctionRoom room = AuctionTestFixtures.startedRoom();
+
+        AuctionSettlement settlement = room.settle(AuctionTestFixtures.CREATED_AT.plusSeconds(AuctionTestFixtures.PICK_BAN_TIME));
+
+        assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.PASSED);
+        assertThat(settlement.playerId()).isEqualTo(0);
+        assertThat(room.readState().currentRound()).isEqualTo(2);
+        assertThat(room.readState().currentTarget().playerId()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/auction/AuctionTestFixtures.java
+++ b/src/test/java/com/naminhyeok/fantazzk/auction/AuctionTestFixtures.java
@@ -1,0 +1,127 @@
+package com.naminhyeok.fantazzk.auction;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+final class AuctionTestFixtures {
+    static final Instant CREATED_AT = Instant.parse("2026-04-09T00:00:00Z");
+    static final int PICK_BAN_TIME = 45;
+    static final int MIN_BID_UNIT = 10;
+    static final String HOST_ID = "host-1";
+    static final String HOST_NICKNAME = "호스트";
+    static final String GUEST_ID = "guest-1";
+    static final String GUEST_NICKNAME = "게스트";
+
+    private AuctionTestFixtures() {
+    }
+
+    static AuctionRoomSetup setup() {
+        return new AuctionRoomSetup(
+            2,
+            2,
+            300,
+            PICK_BAN_TIME,
+            MIN_BID_UNIT,
+            null,
+            List.of(
+                new AuctionPlayerSeed(0, "선수1", "TOP", 0),
+                new AuctionPlayerSeed(1, "선수2", "JUNGLE", 1)
+            )
+        );
+    }
+
+    static AuctionRoom waitingRoom() {
+        return AuctionRoom.create("ROOM01", HOST_ID, HOST_NICKNAME, CREATED_AT, setup());
+    }
+
+    static AuctionRoom waitingRoomWithGuestLeader() {
+        AuctionRoom room = waitingRoom();
+        room.addLeader(GUEST_ID, GUEST_NICKNAME);
+        return room;
+    }
+
+    static AuctionRoom startedRoom() {
+        AuctionRoom room = waitingRoomWithGuestLeader();
+        room.start(HOST_ID, CREATED_AT);
+        return room;
+    }
+
+    static AuctionRoom startedRoomWithoutBids() {
+        return startedRoom();
+    }
+
+    static AuctionRoom startedRoomWithWinningBid() {
+        AuctionRoom room = startedRoom();
+        room.placeBid(HOST_ID, 100, CREATED_AT.plusSeconds(1));
+        room.placeBid(GUEST_ID, 150, CREATED_AT.plusSeconds(2));
+        return room;
+    }
+
+    static AuctionRoom startedRoomWithPassedRound() {
+        AuctionRoom room = startedRoom();
+        room.settle(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+        return room;
+    }
+
+    static AuctionRooms inMemoryRooms(AuctionRoom room) {
+        return new InMemoryAuctionRooms(room);
+    }
+
+    static AuctionRooms emptyRooms() {
+        return new InMemoryAuctionRooms();
+    }
+
+    static AuctionRoomSetup setupWithThreePlayers() {
+        return new AuctionRoomSetup(
+            2,
+            2,
+            300,
+            PICK_BAN_TIME,
+            MIN_BID_UNIT,
+            null,
+            List.of(
+                new AuctionPlayerSeed(0, "선수1", "TOP", 0),
+                new AuctionPlayerSeed(1, "선수2", "JUNGLE", 1),
+                new AuctionPlayerSeed(2, "선수3", "MID", 2)
+            )
+        );
+    }
+
+    private static final class InMemoryAuctionRooms implements AuctionRooms {
+        private final Map<String, AuctionRoom> rooms = new LinkedHashMap<>();
+
+        private InMemoryAuctionRooms() {
+        }
+
+        private InMemoryAuctionRooms(AuctionRoom room) {
+            rooms.put(room.readState().code(), room);
+        }
+
+        @Override
+        public AuctionRoom save(AuctionRoom room) {
+            rooms.put(room.readState().code(), room);
+            return room;
+        }
+
+        @Override
+        public AuctionRoom saveAndFlush(AuctionRoom room) {
+            rooms.put(room.readState().code(), room);
+            return room;
+        }
+
+        @Override
+        public Optional<AuctionRoom> findByCode(String code) {
+            return Optional.ofNullable(rooms.get(code));
+        }
+
+        @Override
+        public List<AuctionRoom> findInProgressAuctionRooms() {
+            return rooms.values().stream()
+                .filter(room -> room.readState().status() == AuctionRoomStatus.IN_PROGRESS)
+                .toList();
+        }
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycleTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/draft/DraftRoomLifecycleTest.java
@@ -1,0 +1,59 @@
+package com.naminhyeok.fantazzk.draft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DraftRoomLifecycleTest {
+    private static final String ROOM_CODE = "ROOM01";
+
+    @Test
+    void 공개_애플리케이션_서피스는_같은_저장소를_공유한다() {
+        InMemoryDraftRooms draftRooms = new InMemoryDraftRooms();
+        DraftRoomLifecycle lifecycle = new DraftRoomLifecycle(draftRooms);
+        DraftRoomPlay play = new DraftRoomPlay(draftRooms);
+        DraftRoomStateReader reader = new DraftRoomStateReader(draftRooms);
+
+        DraftRoomState created = lifecycle.create(
+            ROOM_CODE,
+            2,
+            2,
+            DraftOrderStrategy.SNAKE,
+            List.of(
+                new DraftPlayerSpec(0, "선수1", "TOP", 0),
+                new DraftPlayerSpec(1, "선수2", "JUNGLE", 1)
+            )
+        );
+        lifecycle.addLeader(ROOM_CODE, "host-1", "호스트");
+        lifecycle.addLeader(ROOM_CODE, "guest-1", "게스트");
+        lifecycle.selectDraftPosition(ROOM_CODE, "host-1", 1);
+        lifecycle.selectDraftPosition(ROOM_CODE, "guest-1", 2);
+        DraftRoomState started = lifecycle.start(ROOM_CODE);
+        DraftRoomState afterPick = play.pick(ROOM_CODE, "host-1", 0);
+        DraftRoomState read = reader.read(ROOM_CODE);
+
+        assertThat(created.readiness()).isEqualTo(DraftRoomReadiness.WAITING_FOR_LEADERS);
+        assertThat(started.status()).isEqualTo(DraftRoomStatus.IN_PROGRESS);
+        assertThat(afterPick.progress().currentTurnIndex()).isEqualTo(1);
+        assertThat(read.members()).hasSize(1);
+    }
+
+    private static final class InMemoryDraftRooms implements DraftRooms {
+        private final Map<DraftRoomId, DraftRoom> store = new LinkedHashMap<>();
+
+        @Override
+        public DraftRoom save(DraftRoom draftRoom) {
+            store.put(draftRoom.getId(), draftRoom);
+            return draftRoom;
+        }
+
+        @Override
+        public Optional<DraftRoom> findById(DraftRoomId id) {
+            return Optional.ofNullable(store.get(id));
+        }
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/draft/DraftRoomTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/draft/DraftRoomTest.java
@@ -1,0 +1,276 @@
+package com.naminhyeok.fantazzk.draft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DraftRoomTest {
+    private static final String HOST_ID = "host-1";
+    private static final String GUEST_ID = "guest-1";
+
+    @Test
+    void 방을_생성하면_선수가_순서대로_정렬된다() {
+        DraftRoom room = DraftRoom.create(
+            new DraftRoomId("ROOM01"),
+            2,
+            2,
+            DraftOrderStrategy.SNAKE,
+            List.of(
+                new DraftPlayerSpec(1, "선수B", "JUNGLE", 1),
+                new DraftPlayerSpec(0, "선수A", "TOP", 0)
+            )
+        );
+
+        assertThat(room.snapshot().players())
+            .extracting(DraftRoomState.Player::playerId, DraftRoomState.Player::name, DraftRoomState.Player::position)
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(0, "선수A", "TOP"),
+                org.assertj.core.groups.Tuple.tuple(1, "선수B", "JUNGLE")
+            );
+        assertThat(room.snapshot().readiness()).isEqualTo(DraftRoomReadiness.WAITING_FOR_LEADERS);
+    }
+
+    @Test
+    void 선수_수는_팀_구성에_맞아야_한다() {
+        assertThatThrownBy(() ->
+            DraftRoom.create(
+                new DraftRoomId("ROOM01"),
+                2,
+                2,
+                DraftOrderStrategy.SNAKE,
+                List.of(new DraftPlayerSpec(0, "선수A", "TOP", 0))
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("선수 수는 정확히 2명이어야 합니다");
+    }
+
+    @Nested
+    class 팀장_배치 {
+        @Test
+        void 팀장을_추가하면_중복_닉네임을_막는다() {
+            DraftRoom room = waitingDraftRoom();
+            room.addLeader(HOST_ID, "Faker");
+
+            assertThatThrownBy(() -> room.addLeader(GUEST_ID, "  faker  "))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("팀장 닉네임이 이미 사용 중입니다");
+        }
+
+        @Test
+        void 드래프트_자리를_선택하면_팀장에게_확정된다() {
+            DraftRoom room = waitingDraftRoom();
+            room.addLeader(HOST_ID, "호스트");
+            room.addLeader(GUEST_ID, "게스트");
+
+            room.selectDraftPosition(HOST_ID, 2);
+
+            assertThat(room.snapshot().leaders())
+                .extracting(DraftRoomState.Leader::leaderId, DraftRoomState.Leader::draftPosition)
+                .containsExactly(
+                    org.assertj.core.groups.Tuple.tuple(HOST_ID, 2),
+                    org.assertj.core.groups.Tuple.tuple(GUEST_ID, null)
+                );
+            assertThat(room.snapshot().readiness()).isEqualTo(DraftRoomReadiness.WAITING_FOR_DRAFT_POSITIONS);
+        }
+
+        @Test
+        void 이미_선점된_드래프트_자리는_선택할_수_없다() {
+            DraftRoom room = waitingDraftRoom();
+            room.addLeader(HOST_ID, "호스트");
+            room.addLeader(GUEST_ID, "게스트");
+            room.selectDraftPosition(HOST_ID, 1);
+
+            assertThatThrownBy(() -> room.selectDraftPosition(GUEST_ID, 1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("드래프트 자리가 이미 사용 중입니다");
+        }
+
+        @Test
+        void 드래프트_자리를_취소하면_미선택으로_돌아간다() {
+            DraftRoom room = waitingDraftRoom();
+            room.addLeader(HOST_ID, "호스트");
+            room.addLeader(GUEST_ID, "게스트");
+            room.selectDraftPosition(HOST_ID, 1);
+
+            room.clearDraftPosition(HOST_ID);
+
+            assertThat(room.snapshot().leaders())
+                .extracting(DraftRoomState.Leader::leaderId, DraftRoomState.Leader::draftPosition)
+                .containsExactly(
+                    org.assertj.core.groups.Tuple.tuple(HOST_ID, null),
+                    org.assertj.core.groups.Tuple.tuple(GUEST_ID, null)
+                );
+        }
+    }
+
+    @Nested
+    class 시작 {
+        @Test
+        void 드래프트_방은_자리_확정이_끝나야_시작할_수_있다() {
+            DraftRoom room = waitingDraftRoom();
+            room.addLeader(HOST_ID, "호스트");
+            room.addLeader(GUEST_ID, "게스트");
+            room.selectDraftPosition(HOST_ID, 1);
+
+            assertThat(room.snapshot().readiness()).isEqualTo(DraftRoomReadiness.WAITING_FOR_DRAFT_POSITIONS);
+            assertThatThrownBy(room::start)
+                .isInstanceOf(DraftRoomStateInvalidException.class)
+                .hasMessage("드래프트를 시작할 수 없습니다: 드래프트 자리가 아직 확정되지 않았습니다");
+        }
+
+        @Test
+        void 드래프트_방을_시작하면_현재_턴이_초기화된다() {
+            DraftRoom room = startedDraftRoom();
+
+            assertThat(room.snapshot().status()).isEqualTo(DraftRoomStatus.IN_PROGRESS);
+            assertThat(room.snapshot().progress()).isNotNull();
+            assertThat(room.snapshot().progress().currentTurnIndex()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    class 진행 {
+        @Test
+        void 현재_턴의_팀장이_선수를_픽할_수_있다() {
+            DraftRoom room = startedDraftRoom();
+
+            DraftMember member = room.pick(HOST_ID, 0);
+
+            assertThat(member.leaderId()).isEqualTo(HOST_ID);
+            assertThat(member.playerId()).isEqualTo(0);
+            assertThat(room.snapshot().players())
+                .extracting(DraftRoomState.Player::assigned)
+                .containsExactly(true, false);
+            assertThat(room.snapshot().progress().currentTurnIndex()).isEqualTo(1);
+        }
+
+        @Test
+        void 자신의_턴이_아니면_픽할_수_없다() {
+            DraftRoom room = startedDraftRoom();
+
+            assertThatThrownBy(() -> room.pick(GUEST_ID, 0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("현재 턴이 아닙니다");
+        }
+
+        @Test
+        void 이미_배정된_선수는_픽할_수_없다() {
+            DraftRoom room = startedDraftRoom();
+            room.pick(HOST_ID, 0);
+
+            assertThatThrownBy(() -> room.pick(GUEST_ID, 0))
+                .isInstanceOf(DraftRoomStateInvalidException.class)
+                .hasMessage("선수를 찾을 수 없습니다: 0");
+        }
+
+        @Test
+        void 존재하지_않는_선수는_픽할_수_없다() {
+            DraftRoom room = startedDraftRoom();
+
+            assertThatThrownBy(() -> room.pick(HOST_ID, 99))
+                .isInstanceOf(DraftRoomStateInvalidException.class)
+                .hasMessage("선수를 찾을 수 없습니다: 99");
+        }
+
+        @Test
+        void 모든_픽이_완료되면_방이_완료된다() {
+            DraftRoom room = startedDraftRoom();
+
+            room.pick(HOST_ID, 0);
+            room.pick(GUEST_ID, 1);
+
+            assertThat(room.snapshot().status()).isEqualTo(DraftRoomStatus.COMPLETED);
+            assertThat(room.snapshot().readiness()).isEqualTo(DraftRoomReadiness.COMPLETED);
+            assertThat(room.snapshot().members()).hasSize(2);
+        }
+
+        @Test
+        void SNAKE_드래프트는_2라운드에서_역순으로_진행된다() {
+            DraftRoom room = startedDraftRoom(DraftOrderStrategy.SNAKE, 3, List.of("선수1", "선수2", "선수3", "선수4"));
+
+            room.pick(HOST_ID, 0);
+            room.pick(GUEST_ID, 1);
+
+            assertThatThrownBy(() -> room.pick(HOST_ID, 2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("현재 턴이 아닙니다");
+
+            DraftMember thirdPick = room.pick(GUEST_ID, 2);
+
+            assertThat(thirdPick.leaderId()).isEqualTo(GUEST_ID);
+            assertThat(room.snapshot().progress().currentTurnIndex()).isEqualTo(3);
+            assertThat(room.snapshot().progress().currentRoundLeaderIds()).containsExactly(GUEST_ID, HOST_ID);
+        }
+
+        @Test
+        void FIXED_드래프트는_2라운드에서도_같은_순서로_진행된다() {
+            DraftRoom room = startedDraftRoom(DraftOrderStrategy.FIXED, 3, List.of("선수1", "선수2", "선수3", "선수4"));
+
+            room.pick(HOST_ID, 0);
+            room.pick(GUEST_ID, 1);
+
+            assertThatThrownBy(() -> room.pick(GUEST_ID, 2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("현재 턴이 아닙니다");
+
+            DraftMember thirdPick = room.pick(HOST_ID, 2);
+
+            assertThat(thirdPick.leaderId()).isEqualTo(HOST_ID);
+            assertThat(room.snapshot().progress().currentTurnIndex()).isEqualTo(3);
+            assertThat(room.snapshot().progress().currentRoundLeaderIds()).containsExactly(HOST_ID, GUEST_ID);
+        }
+    }
+
+    private static DraftRoom waitingDraftRoom() {
+        return DraftRoom.create(
+            new DraftRoomId("ROOM01"),
+            2,
+            2,
+            DraftOrderStrategy.SNAKE,
+            List.of(
+                new DraftPlayerSpec(0, "선수1", "TOP", 0),
+                new DraftPlayerSpec(1, "선수2", "JUNGLE", 1)
+            )
+        );
+    }
+
+    private static DraftRoom startedDraftRoom() {
+        DraftRoom room = waitingDraftRoom();
+        room.addLeader(HOST_ID, "호스트");
+        room.addLeader(GUEST_ID, "게스트");
+        room.selectDraftPosition(HOST_ID, 1);
+        room.selectDraftPosition(GUEST_ID, 2);
+        room.start();
+        return room;
+    }
+
+    private static DraftRoom startedDraftRoom(
+        DraftOrderStrategy draftOrderStrategy,
+        int teamSize,
+        List<String> playerNames
+    ) {
+        DraftRoom room =
+            DraftRoom.create(
+                new DraftRoomId("ROOM02"),
+                2,
+                teamSize,
+                draftOrderStrategy,
+                List.of(
+                    new DraftPlayerSpec(0, playerNames.getFirst(), "TOP", 0),
+                    new DraftPlayerSpec(1, playerNames.get(1), "JUNGLE", 1),
+                    new DraftPlayerSpec(2, playerNames.get(2), "MID", 2),
+                    new DraftPlayerSpec(3, playerNames.get(3), "ADC", 3)
+                )
+            );
+        room.addLeader(HOST_ID, "호스트");
+        room.addLeader(GUEST_ID, "게스트");
+        room.selectDraftPosition(HOST_ID, 1);
+        room.selectDraftPosition(GUEST_ID, 2);
+        room.start();
+        return room;
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/CreateRoomTest.java
@@ -32,7 +32,9 @@ class CreateRoomTest {
                 new StubTemplateCatalog(),
                 new StubTeamLeaderIdentityIssuer(),
                 Clock.fixed(Instant.parse("2026-04-10T00:00:00Z"), ZoneOffset.UTC),
-                new StubRoomCodeGenerator("ROOM01", "ROOM02", "ROOM03")
+                new StubRoomCodeGenerator("ROOM01", "ROOM02", "ROOM03"),
+                null,
+                null
             );
 
         RoomSessionResult created = createRoom.create(UUID.randomUUID(), "호스트");
@@ -61,7 +63,9 @@ class CreateRoomTest {
                 new StubTemplateCatalog(),
                 new StubTeamLeaderIdentityIssuer(),
                 Clock.fixed(Instant.parse("2026-04-10T00:00:00Z"), ZoneOffset.UTC),
-                new StubRoomCodeGenerator("ROOM01")
+                new StubRoomCodeGenerator("ROOM01"),
+                null,
+                null
             );
 
         assertThatThrownBy(() -> createRoom.create(UUID.randomUUID(), "호스트"))
@@ -83,7 +87,9 @@ class CreateRoomTest {
                 new StubTemplateCatalog(),
                 new StubTeamLeaderIdentityIssuer(),
                 Clock.fixed(Instant.parse("2026-04-10T00:00:00Z"), ZoneOffset.UTC),
-                new StubRoomCodeGenerator("ROOM01", "ROOM02", "ROOM03")
+                new StubRoomCodeGenerator("ROOM01", "ROOM02", "ROOM03"),
+                null,
+                null
             );
 
         assertThatThrownBy(() -> createRoom.create(UUID.randomUUID(), "호스트"))

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiTestFixtures.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiTestFixtures.java
@@ -142,8 +142,8 @@ final class RoomApiTestFixtures {
         room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
         room.selectDraftPosition(new TeamLeaderId(GUEST_ID), 2);
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
-        room.pick(new TeamLeaderId(HOST_ID), "선수1");
-        room.pick(new TeamLeaderId(GUEST_ID), "선수2");
+        room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0));
+        room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(1));
         return room;
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomApiTestFixtures.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomApiTestFixtures.java
@@ -110,7 +110,7 @@ final class RoomApiTestFixtures {
         room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_TOKEN);
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
         room.placeBid(new TeamLeaderId(HOST_ID), 100, CREATED_AT.plusSeconds(1));
-        room.settleAuction(CREATED_AT.plusSeconds(15));
+        room.settleAuction(CREATED_AT.plusSeconds(16));
         return room;
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionDeadlineSchedulerTest.java
@@ -227,7 +227,7 @@ class RoomAuctionDeadlineSchedulerTest {
             );
         room.start(hostLeaderId, startedAt);
         room.placeBid(hostLeaderId, 100, startedAt.plusSeconds(1));
-        room.settleAuction(startedAt.plusSeconds(PICK_BAN_TIME));
+        room.settleAuction(startedAt.plusSeconds(PICK_BAN_TIME + 1L));
         return room;
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -187,10 +187,11 @@ class RoomAuctionTest {
         assertThat(firstBid.sequence()).isEqualTo(new BidSequence(1));
         assertThat(secondBid.sequence()).isEqualTo(new BidSequence(2));
         assertThat(settlement.outcome()).isEqualTo(AuctionOutcome.SOLD);
+        assertThat(settlement.playerId()).isEqualTo(new RoomPlayerId(0));
         assertThat(settlement.playerName()).isEqualTo("선수1");
         assertThat(room.getMembers()).singleElement()
-            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerName)
-            .containsExactly(guestLeaderId, "선수1");
+            .extracting(RoomTeamMember::teamLeaderId, RoomTeamMember::playerId)
+            .containsExactly(guestLeaderId, new RoomPlayerId(0));
         assertThat(room.getLeaders().stream().filter(it -> it.getId().equals(guestLeaderId)).findFirst().orElseThrow().getRemainingBudget())
             .isEqualTo(150);
         assertThat(room.getPlayers().getFirst().getStatus()).isEqualTo(PlayerStatus.ASSIGNED);
@@ -359,7 +360,7 @@ class RoomAuctionTest {
         rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
         PickDraft pickDraft = new PickDraft(rooms, new RoomActionAuthorizer(), noopRoomSnapshotPublisher());
 
-        assertThatThrownBy(() -> pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, "선수1"))
+        assertThatThrownBy(() -> pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, new RoomPlayerId(0)))
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -268,7 +268,10 @@ class RoomAuctionTest {
                 rooms,
                 new RoomActionAuthorizer(),
                 publisher,
-                Clock.fixed(CREATED_AT, ZoneOffset.UTC)
+                Clock.fixed(CREATED_AT, ZoneOffset.UTC),
+                null,
+                null,
+                null
             );
 
         TransactionSynchronizationManager.initSynchronization();
@@ -298,7 +301,10 @@ class RoomAuctionTest {
                 rooms,
                 new RoomActionAuthorizer(),
                 noopRoomSnapshotPublisher(),
-                Clock.fixed(CREATED_AT, ZoneOffset.UTC)
+                Clock.fixed(CREATED_AT, ZoneOffset.UTC),
+                null,
+                null,
+                null
             );
 
         assertThatThrownBy(() -> startRoom.start(room.getCode(), HOST_ACTION_TOKEN))
@@ -315,7 +321,10 @@ class RoomAuctionTest {
                 rooms,
                 new RoomActionAuthorizer(),
                 publisher,
-                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC)
+                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC),
+                null,
+                null,
+                null
             );
 
         TransactionSynchronizationManager.initSynchronization();
@@ -346,7 +355,10 @@ class RoomAuctionTest {
                 rooms,
                 new RoomActionAuthorizer(),
                 noopRoomSnapshotPublisher(),
-                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC)
+                Clock.fixed(CREATED_AT.plusSeconds(1), ZoneOffset.UTC),
+                null,
+                null,
+                null
             );
 
         assertThatThrownBy(() -> placeBid.place(room.getCode(), HOST_ACTION_TOKEN, 100))
@@ -358,7 +370,7 @@ class RoomAuctionTest {
         Room room = inProgressDraftRoomForOptimisticLock();
         InMemoryRooms rooms = new InMemoryRooms(room);
         rooms.failOnSave(new ObjectOptimisticLockingFailureException(Room.class, room.getId()));
-        PickDraft pickDraft = new PickDraft(rooms, new RoomActionAuthorizer(), noopRoomSnapshotPublisher());
+        PickDraft pickDraft = new PickDraft(rooms, new RoomActionAuthorizer(), noopRoomSnapshotPublisher(), null);
 
         assertThatThrownBy(() -> pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, new RoomPlayerId(0)))
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
@@ -372,7 +384,8 @@ class RoomAuctionTest {
         SelectDraftPosition selectDraftPosition = new SelectDraftPosition(
             rooms,
             new RoomActionAuthorizer(),
-            noopRoomSnapshotPublisher()
+            noopRoomSnapshotPublisher(),
+            null
         );
 
         assertThatThrownBy(() -> selectDraftPosition.select(room.getCode(), HOST_ACTION_TOKEN, 1))
@@ -388,7 +401,8 @@ class RoomAuctionTest {
         ClearDraftPosition clearDraftPosition = new ClearDraftPosition(
             rooms,
             new RoomActionAuthorizer(),
-            noopRoomSnapshotPublisher()
+            noopRoomSnapshotPublisher(),
+            null
         );
 
         assertThatThrownBy(() -> clearDraftPosition.clear(room.getCode(), HOST_ACTION_TOKEN))

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomAuctionTest.java
@@ -107,8 +107,23 @@ class RoomAuctionTest {
             .isInstanceOfSatisfying(BidPlaced.class, event -> {
                 assertThat(event.roomCode()).isEqualTo("ROOM01");
                 assertThat(event.amount()).isEqualTo(110);
-                assertThat(event.roundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+                assertThat(event.roundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME + 2L));
             });
+    }
+
+    @Test
+    void 유효한_입찰이_들어오면_deadline이_입찰시각부터_다시_연장된다() {
+        Room room = startedAuctionRoom();
+        TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
+        Instant bidAt = CREATED_AT.plusSeconds(2);
+
+        room.placeBid(hostLeaderId, 100, bidAt);
+
+        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(bidAt.plusSeconds(PICK_BAN_TIME));
+        assertThat(room.domainEvents()).last()
+            .isInstanceOfSatisfying(BidPlaced.class, event ->
+                assertThat(event.roundEndsAt()).isEqualTo(bidAt.plusSeconds(PICK_BAN_TIME))
+            );
     }
 
     @Test
@@ -167,7 +182,7 @@ class RoomAuctionTest {
         RoomBid firstBid = room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
         RoomBid secondBid = room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
 
-        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+        AuctionSettlement settlement = room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME + 2L));
 
         assertThat(firstBid.sequence()).isEqualTo(new BidSequence(1));
         assertThat(secondBid.sequence()).isEqualTo(new BidSequence(2));
@@ -180,12 +195,12 @@ class RoomAuctionTest {
             .isEqualTo(150);
         assertThat(room.getPlayers().getFirst().getStatus()).isEqualTo(PlayerStatus.ASSIGNED);
         assertThat(room.getCurrentAuctionRound()).isEqualTo(2);
-        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L));
+        assertThat(room.getCurrentAuctionRoundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L + 2L));
         assertThat(room.domainEvents()).last()
             .isInstanceOfSatisfying(AuctionSettled.class, event -> {
                 assertThat(event.roomCode()).isEqualTo("ROOM01");
                 assertThat(event.outcome()).isEqualTo(AuctionOutcome.SOLD.name());
-                assertThat(event.roundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L));
+                assertThat(event.roundEndsAt()).isEqualTo(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L + 2L));
             });
     }
 
@@ -195,7 +210,7 @@ class RoomAuctionTest {
         TeamLeaderId hostLeaderId = room.getLeaders().getFirst().getId();
 
         room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
-        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
 
         RoomBid nextRoundBid = room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
 
@@ -214,11 +229,11 @@ class RoomAuctionTest {
 
         room.placeBid(hostLeaderId, 100, CREATED_AT.plusSeconds(1));
         room.placeBid(guestLeaderId, 150, CREATED_AT.plusSeconds(2));
-        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME + 2L));
 
         room.placeBid(hostLeaderId, 120, CREATED_AT.plusSeconds(PICK_BAN_TIME + 1L));
         room.placeBid(guestLeaderId, 130, CREATED_AT.plusSeconds(PICK_BAN_TIME + 2L));
-        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L));
+        room.settleAuction(CREATED_AT.plusSeconds(PICK_BAN_TIME * 2L + 2L));
 
         assertThat(room.getStatus()).isEqualTo(RoomStatus.COMPLETED);
         assertThat(room.getCurrentAuctionRoundEndsAt()).isNull();

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftApiControllerWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftApiControllerWebMvcTest.java
@@ -43,7 +43,7 @@ class RoomDraftApiControllerWebMvcTest {
 
     @Test
     void pickDraft는_header가_있으면_최신_room_snapshot을_반환한다() throws Exception {
-        given(pickDraft.pick(RoomApiTestFixtures.ROOM_CODE, RoomApiTestFixtures.GUEST_TOKEN, "선수3"))
+        given(pickDraft.pick(RoomApiTestFixtures.ROOM_CODE, RoomApiTestFixtures.GUEST_TOKEN, new RoomPlayerId(2)))
             .willReturn(RoomApiTestFixtures.inProgressDraftRoom());
 
         var result = mockMvcTester().perform(
@@ -53,7 +53,7 @@ class RoomDraftApiControllerWebMvcTest {
                 .content(
                     """
                     {
-                      "playerName": "선수3"
+                      "playerId": 2
                     }
                     """
                 )
@@ -70,7 +70,7 @@ class RoomDraftApiControllerWebMvcTest {
     void pickDraft는_header가_없으면_401을_반환한다() throws Exception {
         doThrow(CoreException.of(RoomErrorType.ROOM_ACTION_TOKEN_REQUIRED))
             .when(pickDraft)
-            .pick(RoomApiTestFixtures.ROOM_CODE, null, "선수3");
+            .pick(RoomApiTestFixtures.ROOM_CODE, null, new RoomPlayerId(2));
 
         var result = mockMvcTester().perform(
             post("/api/v1/rooms/{code}/draft-picks", RoomApiTestFixtures.ROOM_CODE)
@@ -78,7 +78,7 @@ class RoomDraftApiControllerWebMvcTest {
                 .content(
                     """
                     {
-                      "playerName": "선수3"
+                      "playerId": 2
                     }
                     """
                 )
@@ -92,7 +92,7 @@ class RoomDraftApiControllerWebMvcTest {
     void pickDraft는_optimistic_lock_conflict를_409로_반환한다() throws Exception {
         doThrow(CoreException.of(RoomErrorType.ROOM_CONCURRENT_MODIFICATION))
             .when(pickDraft)
-            .pick(RoomApiTestFixtures.ROOM_CODE, RoomApiTestFixtures.GUEST_TOKEN, "선수3");
+            .pick(RoomApiTestFixtures.ROOM_CODE, RoomApiTestFixtures.GUEST_TOKEN, new RoomPlayerId(2));
 
         var result = mockMvcTester().perform(
             post("/api/v1/rooms/{code}/draft-picks", RoomApiTestFixtures.ROOM_CODE)
@@ -101,7 +101,7 @@ class RoomDraftApiControllerWebMvcTest {
                 .content(
                     """
                     {
-                      "playerName": "선수3"
+                      "playerId": 2
                     }
                     """
                 )

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomDraftTest.java
@@ -22,10 +22,10 @@ class RoomDraftTest {
         Room room = startedDraftRoom();
         TeamLeaderId currentLeaderId = new TeamLeaderId(HOST_ID);
 
-        RoomTeamMember member = room.pick(currentLeaderId, "선수1");
+        RoomTeamMember member = room.pick(currentLeaderId, new RoomPlayerId(0));
 
         assertThat(member.teamLeaderId()).isEqualTo(currentLeaderId);
-        assertThat(member.playerName()).isEqualTo("선수1");
+        assertThat(member.playerId()).isEqualTo(new RoomPlayerId(0));
         assertThat(room.getPlayers().getFirst().getStatus()).isEqualTo(PlayerStatus.ASSIGNED);
         assertThat(room.getCurrentTurnIndex()).isEqualTo(1);
     }
@@ -35,7 +35,7 @@ class RoomDraftTest {
         Room room = startedDraftRoom();
         TeamLeaderId otherLeaderId = new TeamLeaderId(GUEST_ID);
 
-        assertThatThrownBy(() -> room.pick(otherLeaderId, "선수1"))
+        assertThatThrownBy(() -> room.pick(otherLeaderId, new RoomPlayerId(0)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_OUT_OF_TURN));
     }
@@ -44,7 +44,7 @@ class RoomDraftTest {
     void 진행_중이_아니면_픽할_수_없다() {
         Room room = waitingDraftRoom();
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), "선수1"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PLAY_REQUIRES_IN_PROGRESS));
     }
@@ -53,7 +53,7 @@ class RoomDraftTest {
     void 경매_방에서는_픽할_수_없다() {
         Room room = startedAuctionRoomForDraftError();
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), "선수1"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_REQUIRES_DRAFT_MODE));
     }
@@ -62,9 +62,9 @@ class RoomDraftTest {
     void 이미_배정된_선수는_픽할_수_없다() {
         Room room = startedDraftRoom();
 
-        room.pick(new TeamLeaderId(HOST_ID), "선수1");
+        room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0));
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(GUEST_ID), "선수1"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(0)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_PLAYER_NOT_AVAILABLE));
     }
@@ -73,7 +73,7 @@ class RoomDraftTest {
     void 존재하지_않는_선수는_픽할_수_없다() {
         Room room = startedDraftRoom();
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), "없는 선수"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(99)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_PLAYER_NOT_AVAILABLE));
     }
@@ -86,7 +86,7 @@ class RoomDraftTest {
         room.selectDraftPosition(new TeamLeaderId(GUEST_ID), 1);
         room.start(new TeamLeaderId(HOST_ID), CREATED_AT);
 
-        RoomTeamMember member = room.pick(new TeamLeaderId(GUEST_ID), "선수1");
+        RoomTeamMember member = room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(0));
 
         assertThat(member.teamLeaderId()).isEqualTo(new TeamLeaderId(GUEST_ID));
         assertThat(room.getCurrentTurnIndex()).isEqualTo(1);
@@ -96,8 +96,8 @@ class RoomDraftTest {
     void 모든_픽이_완료되면_방이_완료된다() {
         Room room = startedDraftRoom();
 
-        room.pick(new TeamLeaderId(HOST_ID), "선수1");
-        room.pick(new TeamLeaderId(GUEST_ID), "선수2");
+        room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0));
+        room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(1));
 
         assertThat(room.getStatus()).isEqualTo(RoomStatus.COMPLETED);
         assertThat(room.getMembers()).hasSize(2);
@@ -107,14 +107,14 @@ class RoomDraftTest {
     void SNAKE_드래프트는_2라운드에서_역순으로_진행된다() {
         Room room = startedDraftRoom(RoomTemplateSpec.DraftOrderStrategy.SNAKE, 3, List.of("선수1", "선수2", "선수3", "선수4"));
 
-        room.pick(new TeamLeaderId(HOST_ID), "선수1");
-        room.pick(new TeamLeaderId(GUEST_ID), "선수2");
+        room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0));
+        room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(1));
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), "선수3"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(2)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_OUT_OF_TURN));
 
-        RoomTeamMember thirdPick = room.pick(new TeamLeaderId(GUEST_ID), "선수3");
+        RoomTeamMember thirdPick = room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(2));
 
         assertThat(thirdPick.teamLeaderId()).isEqualTo(new TeamLeaderId(GUEST_ID));
         assertThat(room.getCurrentTurnIndex()).isEqualTo(3);
@@ -124,14 +124,14 @@ class RoomDraftTest {
     void FIXED_드래프트는_2라운드에서도_같은_순서로_진행된다() {
         Room room = startedDraftRoom(RoomTemplateSpec.DraftOrderStrategy.FIXED, 3, List.of("선수1", "선수2", "선수3", "선수4"));
 
-        room.pick(new TeamLeaderId(HOST_ID), "선수1");
-        room.pick(new TeamLeaderId(GUEST_ID), "선수2");
+        room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(0));
+        room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(1));
 
-        assertThatThrownBy(() -> room.pick(new TeamLeaderId(GUEST_ID), "선수3"))
+        assertThatThrownBy(() -> room.pick(new TeamLeaderId(GUEST_ID), new RoomPlayerId(2)))
             .isInstanceOf(CoreException.class)
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_PICK_OUT_OF_TURN));
 
-        RoomTeamMember thirdPick = room.pick(new TeamLeaderId(HOST_ID), "선수3");
+        RoomTeamMember thirdPick = room.pick(new TeamLeaderId(HOST_ID), new RoomPlayerId(2));
 
         assertThat(thirdPick.teamLeaderId()).isEqualTo(new TeamLeaderId(HOST_ID));
         assertThat(room.getCurrentTurnIndex()).isEqualTo(3);

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
@@ -52,13 +52,14 @@ class RoomRealtimePublishingTest {
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         PickDraft pickDraft = new PickDraft(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
 
-        Room picked = pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, "선수1");
+        Room picked = pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, new RoomPlayerId(0));
 
-        assertThat(picked.getMembers().getLast().playerName()).isEqualTo("선수1");
+        assertThat(picked.getMembers().getLast().playerId()).isEqualTo(new RoomPlayerId(0));
         assertThat(publisher.events).hasSize(1);
         RoomRealtimeSnapshotEvent event = publisher.events.getFirst();
         assertPublishedRoom(event, room.getCode());
         assertThat(event.room().members()).hasSize(1);
+        assertThat(event.room().members().getFirst().playerId()).isEqualTo(0);
         assertThat(event.room().progress().currentTurnIndex()).isEqualTo(1);
     }
 
@@ -102,7 +103,7 @@ class RoomRealtimePublishingTest {
 
         AuctionSettlement settlement = settleAuctionAttempt.settle(room.getCode());
 
-        assertThat(settlement).isEqualTo(new AuctionSettlement("선수1", AuctionOutcome.PASSED));
+        assertThat(settlement).isEqualTo(new AuctionSettlement(new RoomPlayerId(0), "선수1", AuctionOutcome.PASSED));
         assertThat(publisher.events).hasSize(1);
         RoomRealtimeSnapshotEvent event = publisher.events.getFirst();
         assertPublishedRoom(event, room.getCode());

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
@@ -25,7 +25,7 @@ class RoomRealtimePublishingTest {
     void join은_저장된_room_스냅샷을_publish한다() {
         Room room = waitingAuctionRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
-        JoinRoom joinRoom = new JoinRoom(new SaveAndFlushOnlyRooms(room), fixedLeaderIdentityIssuer(), publisher);
+        JoinRoom joinRoom = new JoinRoom(new SaveAndFlushOnlyRooms(room), fixedLeaderIdentityIssuer(), publisher, null, null);
 
         RoomSessionResult joined = joinRoom.join(room.getCode(), "게스트");
 
@@ -39,7 +39,7 @@ class RoomRealtimePublishingTest {
     void join은_optimistic_lock을_room_concurrent_modification으로_번역한다() {
         Room room = waitingAuctionRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
-        JoinRoom joinRoom = new JoinRoom(new OptimisticLockFailureRooms(room), fixedLeaderIdentityIssuer(), publisher);
+        JoinRoom joinRoom = new JoinRoom(new OptimisticLockFailureRooms(room), fixedLeaderIdentityIssuer(), publisher, null, null);
 
         assertThatThrownBy(() -> joinRoom.join(room.getCode(), "게스트"))
             .isInstanceOfSatisfying(CoreException.class, ex -> assertRoomError(ex, RoomErrorType.ROOM_CONCURRENT_MODIFICATION));
@@ -50,7 +50,7 @@ class RoomRealtimePublishingTest {
     void pickDraft는_저장된_room_스냅샷을_publish한다() {
         Room room = startedDraftRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
-        PickDraft pickDraft = new PickDraft(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
+        PickDraft pickDraft = new PickDraft(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher, null);
 
         Room picked = pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, new RoomPlayerId(0));
 
@@ -68,7 +68,7 @@ class RoomRealtimePublishingTest {
         Room room = waitingDraftRoomForPositionChange();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         SelectDraftPosition selectDraftPosition =
-            new SelectDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
+            new SelectDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher, null);
 
         selectDraftPosition.select(room.getCode(), HOST_ACTION_TOKEN, 1);
 
@@ -84,7 +84,7 @@ class RoomRealtimePublishingTest {
         room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         ClearDraftPosition clearDraftPosition =
-            new ClearDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
+            new ClearDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher, null);
 
         clearDraftPosition.clear(room.getCode(), HOST_ACTION_TOKEN);
 
@@ -99,7 +99,7 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher, null, null);
 
         AuctionSettlement settlement = settleAuctionAttempt.settle(room.getCode());
 
@@ -115,7 +115,7 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher, null, null);
 
         Room settled = settleAuctionAttempt.settleIfDue(room.getCode());
 
@@ -132,7 +132,7 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(CREATED_AT.plusSeconds(10), ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(new InMemoryRooms(room), Clock.fixed(CREATED_AT.plusSeconds(10), ZoneOffset.UTC), publisher, null, null);
 
         Room current = settleAuctionAttempt.settleIfDue(room.getCode());
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimeSnapshotEventTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimeSnapshotEventTest.java
@@ -32,6 +32,7 @@ class RoomRealtimeSnapshotEventTest {
 
         assertThat(json.at("/room/code").asText()).isEqualTo("AUC002");
         assertThat(json.toString()).doesNotContain("actionToken");
+        assertThat(json.at("/room/progress/currentAuctionTarget/playerId").asInt()).isEqualTo(0);
         assertThat(json.at("/room/progress/currentAuctionTarget/name").asText()).isEqualTo("선수1");
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomResponseTest.java
@@ -94,6 +94,9 @@ class RoomResponseTest {
 
         var json = OBJECT_MAPPER.valueToTree(RoomResponse.from(room));
 
+        assertThat(json.at("/players/0/playerId").asInt()).isEqualTo(0);
+        assertThat(json.at("/players/1/playerId").asInt()).isEqualTo(1);
+        assertThat(json.at("/progress/currentAuctionTarget/playerId").asInt()).isEqualTo(0);
         assertThat(json.at("/progress/currentAuctionTarget/name").asText()).isEqualTo("선수1");
         assertThat(json.at("/progress/currentAuctionTarget/position").asText()).isEqualTo("TOP");
         assertThat(json.at("/progress/highestBidAmount").asInt()).isEqualTo(150);


### PR DESCRIPTION
## 작업 배경

기존 `room` 모듈은 방 접근/참가/인증과 드래프트/경매 게임플레이 규칙을 한 aggregate와 서비스 계층에 함께 들고 있었습니다. 이 상태에서는 `Room`이 과도하게 비대해지고, 모드 분기와 상태 필드가 얽히면서 모듈 경계가 코드에서 드러나지 않았습니다.

이번 변경은 `room`을 방 접근과 오케스트레이션의 모듈로 두고, `draft`와 `auction`을 각각의 게임플레이 모듈로 분리하는 방향으로 구조를 재정리합니다.

## 변경 사항

### 1. draft / auction 코어 모듈 추가
- `com.naminhyeok.fantazzk.draft`
- `com.naminhyeok.fantazzk.auction`

각 모듈에 다음을 도입했습니다.
- gameplay aggregate
- lifecycle / play / state reader application surface
- 모듈 단위 테스트

### 2. room 모듈에서 게임플레이 실행을 위임하도록 재배선
- `CreateRoom`, `JoinRoom`, `StartRoom`이 생성/참가/시작 시점에 `draft` 또는 `auction` lifecycle을 호출하도록 변경했습니다.
- `PickDraft`, `SelectDraftPosition`, `ClearDraftPosition`, `PlaceBid`, `SettleAuctionAttempt`가 gameplay 모듈을 우선 사용하고, 해당 상태를 `room` projection에 반영하도록 변경했습니다.
- 기존 단위 테스트 호환을 위해 fallback 경로를 남겨 서비스 테스트가 즉시 깨지지 않게 했습니다.

### 3. gameplay 상태 저장소 추가
- `draft_room`, `auction_room` 테이블을 추가했습니다.
- `draft` / `auction` 상태는 JSON snapshot 형태로 저장되도록 JPA adapter를 도입했습니다.
- Liquibase와 Hibernate schema validation이 H2/PostgreSQL 모두에서 통과하도록 컬럼 타입을 정리했습니다.

### 4. modulith 경계 반영
- `room` 모듈이 `template` 외에 `draft`, `auction`에 의존할 수 있도록 모듈 선언을 조정했습니다.
- 공개 계약 구조 테스트도 현재 구조에 맞게 정리했습니다.

## 기대 효과
- `room`은 방 접근/참가/인증/시작 오케스트레이션에 집중합니다.
- `draft`, `auction`은 각자의 게임 규칙과 상태를 독립적으로 캡슐화합니다.
- 향후 `/draft-state`, `/auction-state`, `/result` 같은 read API 재설계나 `Room` aggregate 축소를 더 안전하게 진행할 수 있는 기반이 생깁니다.

## 검증
- `./gradlew check`
- `./gradlew integrationTest`

## 후속 작업 메모
- 현재 PR에서는 기존 room API를 유지한 채 내부 모듈 경계와 저장 구조를 먼저 분리했습니다.
- 외부 REST resource를 `summary / draft-state / auction-state / result`로 재설계하는 작업은 다음 단계에서 이어질 수 있습니다.