### PR TITLE
Game 내부의 draft/auction capability seam을 드러낸다

### DIFF
--- a/src/integrationTest/java/com/naminhyeok/fantazzk/room/GameRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/naminhyeok/fantazzk/room/GameRepositoryIntegrationTest.java
@@ -47,10 +47,10 @@ class GameRepositoryIntegrationTest {
                         new GameId(UUID.fromString("00000000-0000-0000-0000-000000000101")),
                         STARTED_AT,
                         RoomMode.AUCTION,
-                        new GameRules(2, 2, 300, 45, 10, 1, null),
+                        GameRules.auction(2, 2, 300, 45, 10, 1),
                         List.of(
-                            new GameParticipant(new TeamLeaderId("host-1"), "호스트", null, 300),
-                            new GameParticipant(new TeamLeaderId("guest-1"), "게스트", null, 300)
+                            GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
+                            GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
                         ),
                         List.of(
                             new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
@@ -71,11 +71,11 @@ class GameRepositoryIntegrationTest {
         assertThat(reloaded.getRoomCode()).isEqualTo("ROOM01");
         assertThat(reloaded.getStatus()).isEqualTo(GameStatus.IN_PROGRESS);
         assertThat(reloaded.getStartedAt()).isEqualTo(STARTED_AT);
-        assertThat(reloaded.getRules()).isEqualTo(new GameRules(2, 2, 300, 45, 10, 1, null));
+        assertThat(reloaded.getRules()).isEqualTo(GameRules.auction(2, 2, 300, 45, 10, 1));
         assertThat(reloaded.getParticipants())
             .containsExactly(
-                new GameParticipant(new TeamLeaderId("host-1"), "호스트", null, 300),
-                new GameParticipant(new TeamLeaderId("guest-1"), "게스트", null, 300)
+                GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
+                GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
             );
         assertThat(reloaded.getPlayerPool())
             .containsExactly(
@@ -103,10 +103,10 @@ class GameRepositoryIntegrationTest {
                         new GameId(UUID.fromString("00000000-0000-0000-0000-000000000103")),
                         STARTED_AT,
                         RoomMode.AUCTION,
-                        new GameRules(2, 2, 300, 45, 10, 1, null),
+                        GameRules.auction(2, 2, 300, 45, 10, 1),
                         List.of(
-                            new GameParticipant(new TeamLeaderId("host-1"), "호스트", null, 300),
-                            new GameParticipant(new TeamLeaderId("guest-1"), "게스트", null, 300)
+                            GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
+                            GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
                         ),
                         List.of(
                             new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
@@ -148,10 +148,10 @@ class GameRepositoryIntegrationTest {
                         new GameId(UUID.fromString("00000000-0000-0000-0000-000000000102")),
                         STARTED_AT,
                         RoomMode.DRAFT,
-                        new GameRules(2, 2, null, 30, null, null, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
+                        GameRules.draft(2, 2, 30, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
                         List.of(
-                            new GameParticipant(new TeamLeaderId("host-1"), "호스트", 1, null),
-                            new GameParticipant(new TeamLeaderId("guest-1"), "게스트", 2, null)
+                            GameParticipant.draft(new TeamLeaderId("host-1"), "호스트", 1),
+                            GameParticipant.draft(new TeamLeaderId("guest-1"), "게스트", 2)
                         ),
                         List.of(
                             new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
@@ -172,11 +172,11 @@ class GameRepositoryIntegrationTest {
         assertThat(reloaded.getRoomCode()).isEqualTo("ROOM02");
         assertThat(reloaded.getStatus()).isEqualTo(GameStatus.IN_PROGRESS);
         assertThat(reloaded.getStartedAt()).isEqualTo(STARTED_AT);
-        assertThat(reloaded.getRules()).isEqualTo(new GameRules(2, 2, null, 30, null, null, RoomTemplateSpec.DraftOrderStrategy.SNAKE));
+        assertThat(reloaded.getRules()).isEqualTo(GameRules.draft(2, 2, 30, RoomTemplateSpec.DraftOrderStrategy.SNAKE));
         assertThat(reloaded.getParticipants())
             .containsExactly(
-                new GameParticipant(new TeamLeaderId("host-1"), "호스트", 1, null),
-                new GameParticipant(new TeamLeaderId("guest-1"), "게스트", 2, null)
+                GameParticipant.draft(new TeamLeaderId("host-1"), "호스트", 1),
+                GameParticipant.draft(new TeamLeaderId("guest-1"), "게스트", 2)
             );
         assertThat(reloaded.getPlayerPool())
             .containsExactly(
@@ -202,10 +202,10 @@ class GameRepositoryIntegrationTest {
                         new GameId(UUID.fromString("00000000-0000-0000-0000-000000000104")),
                         STARTED_AT,
                         RoomMode.DRAFT,
-                        new GameRules(2, 2, null, 30, null, null, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
+                        GameRules.draft(2, 2, 30, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
                         List.of(
-                            new GameParticipant(new TeamLeaderId("host-1"), "호스트", 1, null),
-                            new GameParticipant(new TeamLeaderId("guest-1"), "게스트", 2, null)
+                            GameParticipant.draft(new TeamLeaderId("host-1"), "호스트", 1),
+                            GameParticipant.draft(new TeamLeaderId("guest-1"), "게스트", 2)
                         ),
                         List.of(
                             new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionGame.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionGame.java
@@ -76,10 +76,11 @@ class AuctionGame extends Game {
         }
 
         GameParticipant leader = findParticipant(teamLeaderId, RoomErrorType.ROOM_BIDDER_NOT_FOUND);
+        GameParticipant.AuctionState bidder = leader.auctionState();
         GamePlayer target = requireCurrentAuctionTarget();
         validateAuctionPositionLimit(teamLeaderId, target);
 
-        if (leader.remainingBudget() != null && leader.remainingBudget() < amount) {
+        if (bidder.remainingBudget() < amount) {
             throw CoreException.of(RoomErrorType.ROOM_BID_BUDGET_EXCEEDED);
         }
 
@@ -91,14 +92,14 @@ class AuctionGame extends Game {
                 .orElse(null);
 
         if (highestBidAmount == null) {
-            if (amount < getMinBidUnit()) {
+            if (amount < getRules().auctionRules().minBidUnit()) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_MIN_UNIT_NOT_MET);
             }
         } else {
             if (amount <= highestBidAmount) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_TOO_LOW);
             }
-            if (amount < highestBidAmount + getMinBidUnit()) {
+            if (amount < highestBidAmount + getRules().auctionRules().minBidUnit()) {
                 throw CoreException.of(RoomErrorType.ROOM_BID_MIN_UNIT_NOT_MET);
             }
         }
@@ -213,24 +214,19 @@ class AuctionGame extends Game {
             if (!participant.teamLeaderId().equals(leaderId)) {
                 continue;
             }
-            Integer remainingBudget = participant.remainingBudget();
-            if (remainingBudget == null) {
-                throw RoomStateInvalidException.auctionWinnerBudgetMissing(leaderId);
-            }
+            int remainingBudget = participant.auctionState().remainingBudget();
             if (remainingBudget < amount) {
                 throw RoomStateInvalidException.auctionWinnerBudgetExceeded(leaderId, remainingBudget, amount);
             }
-            participants.set(
-                index,
-                new GameParticipant(participant.teamLeaderId(), participant.nickname(), participant.draftPosition(), remainingBudget - amount)
-            );
+            participants.set(index, participant.withRemainingBudget(remainingBudget - amount));
             return;
         }
         throw RoomStateInvalidException.auctionWinnerMissing(leaderId);
     }
 
     private void validateAuctionPositionLimit(TeamLeaderId leaderId, GamePlayer target) {
-        if (getPositionLimit() == null) {
+        Integer positionLimit = getRules().auctionRules().positionLimit();
+        if (positionLimit == null) {
             return;
         }
 
@@ -240,7 +236,7 @@ class AuctionGame extends Game {
                 .map(this::findAssignedPlayerPosition)
                 .filter(target.position()::equals)
                 .count();
-        if (assignedCount >= getPositionLimit()) {
+        if (assignedCount >= positionLimit) {
             throw CoreException.of(RoomErrorType.ROOM_AUCTION_POSITION_LIMIT_EXCEEDED);
         }
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftGame.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftGame.java
@@ -77,7 +77,7 @@ class DraftGame extends Game {
         }
 
         try {
-            return DraftProgress.from(getLeaderIdsInDraftOrder(), getDraftOrderStrategy(), currentTurnIndex);
+            return DraftProgress.from(getLeaderIdsInDraftOrder(), getRules().draftRules().draftOrderStrategy(), currentTurnIndex);
         } catch (IllegalArgumentException ex) {
             throw RoomStateInvalidException.draftLeaderOrderEmpty();
         }
@@ -109,6 +109,6 @@ class DraftGame extends Game {
         if (participantWithoutDraftPosition != null) {
             throw RoomStateInvalidException.draftPositionMissing(participantWithoutDraftPosition.teamLeaderId());
         }
-        return mutableParticipants().stream().sorted(Comparator.comparingInt(GameParticipant::draftPosition)).toList();
+        return mutableParticipants().stream().sorted(Comparator.comparingInt(participant -> participant.draftState().draftPosition())).toList();
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Game.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Game.java
@@ -121,7 +121,10 @@ abstract class Game implements AggregateRoot<Game, GameId> {
     }
 
     GameRules getRules() {
-        return new GameRules(teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit, draftOrderStrategy);
+        if (draftOrderStrategy != null) {
+            return GameRules.draft(teamCount, teamSize, pickBanTime, draftOrderStrategy);
+        }
+        return GameRules.auction(teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit);
     }
 
     List<GameParticipant> getParticipants() {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameFactory.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameFactory.java
@@ -15,7 +15,7 @@ class GameFactory {
                 snapshot.participants(),
                 snapshot.playerPool(),
                 1,
-                snapshot.startedAt().plusSeconds(snapshot.rules().pickBanTime())
+                snapshot.startedAt().plusSeconds(snapshot.rules().auctionRules().pickBanTime())
             );
             case DRAFT -> new DraftGame(
                 snapshot.gameId(),

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameParticipant.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameParticipant.java
@@ -32,6 +32,14 @@ final class GameParticipant implements ValueObject {
         this.remainingBudget = remainingBudget;
     }
 
+    static GameParticipant auction(TeamLeaderId teamLeaderId, String nickname, int remainingBudget) {
+        return new GameParticipant(teamLeaderId, nickname, null, remainingBudget);
+    }
+
+    static GameParticipant draft(TeamLeaderId teamLeaderId, String nickname, int draftPosition) {
+        return new GameParticipant(teamLeaderId, nickname, draftPosition, null);
+    }
+
     TeamLeaderId teamLeaderId() {
         return teamLeaderId;
     }
@@ -46,5 +54,37 @@ final class GameParticipant implements ValueObject {
 
     Integer remainingBudget() {
         return remainingBudget;
+    }
+
+    AuctionState auctionState() {
+        if (remainingBudget == null) {
+            throw RoomStateInvalidException.auctionWinnerBudgetMissing(teamLeaderId);
+        }
+        return new AuctionState(teamLeaderId, nickname, remainingBudget);
+    }
+
+    DraftState draftState() {
+        if (draftPosition == null) {
+            throw RoomStateInvalidException.draftPositionMissing(teamLeaderId);
+        }
+        return new DraftState(teamLeaderId, nickname, draftPosition);
+    }
+
+    GameParticipant withRemainingBudget(int remainingBudget) {
+        return new GameParticipant(teamLeaderId, nickname, draftPosition, remainingBudget);
+    }
+
+    record AuctionState(
+        TeamLeaderId teamLeaderId,
+        String nickname,
+        int remainingBudget
+    ) {
+    }
+
+    record DraftState(
+        TeamLeaderId teamLeaderId,
+        String nickname,
+        int draftPosition
+    ) {
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameRules.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameRules.java
@@ -1,5 +1,7 @@
 package com.naminhyeok.fantazzk.room;
 
+import java.util.Objects;
+
 record GameRules(
     int teamCount,
     int teamSize,
@@ -9,4 +11,39 @@ record GameRules(
     Integer positionLimit,
     RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy
 ) {
+    static GameRules auction(int teamCount, int teamSize, int budget, int pickBanTime, int minBidUnit, Integer positionLimit) {
+        return new GameRules(teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit, null);
+    }
+
+    static GameRules draft(int teamCount, int teamSize, int pickBanTime, RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy) {
+        return new GameRules(teamCount, teamSize, null, pickBanTime, null, null, Objects.requireNonNull(draftOrderStrategy));
+    }
+
+    AuctionRules auctionRules() {
+        if (budget == null || minBidUnit == null) {
+            throw new IllegalStateException("auction rules are not available");
+        }
+        return new AuctionRules(budget, pickBanTime, minBidUnit, positionLimit);
+    }
+
+    DraftRules draftRules() {
+        if (draftOrderStrategy == null) {
+            throw new IllegalStateException("draft rules are not available");
+        }
+        return new DraftRules(pickBanTime, draftOrderStrategy);
+    }
+
+    record AuctionRules(
+        int budget,
+        int pickBanTime,
+        int minBidUnit,
+        Integer positionLimit
+    ) {
+    }
+
+    record DraftRules(
+        int pickBanTime,
+        RoomTemplateSpec.DraftOrderStrategy draftOrderStrategy
+    ) {
+    }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/Room.java
@@ -224,9 +224,13 @@ class Room implements AggregateRoot<Room, RoomId> {
             startedGameId,
             startedAt,
             mode,
-            new GameRules(teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit, draftOrderStrategy),
+            mode == RoomMode.AUCTION
+                ? GameRules.auction(teamCount, teamSize, budget, pickBanTime, minBidUnit, positionLimit)
+                : GameRules.draft(teamCount, teamSize, pickBanTime, draftOrderStrategy),
             leaders.stream()
-                .map(leader -> new GameParticipant(leader.getId(), leader.getNickname(), leader.getDraftPosition(), leader.getRemainingBudget()))
+                .map(leader -> mode == RoomMode.AUCTION
+                    ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
+                    : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
                 .toList(),
             players.stream()
                 .sorted(Comparator.comparingInt(RoomPlayer::getDisplayOrder))

--- a/src/test/java/com/naminhyeok/fantazzk/room/AuctionGameTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/AuctionGameTest.java
@@ -100,10 +100,10 @@ class AuctionGameTest {
             new RoomId(UUID.fromString("00000000-0000-0000-0000-000000000001")),
             "ROOM01",
             STARTED_AT,
-            new GameRules(2, 2, 300, PICK_BAN_TIME, MIN_BID_UNIT, null, null),
+            GameRules.auction(2, 2, 300, PICK_BAN_TIME, MIN_BID_UNIT, null),
             List.of(
-                new GameParticipant(HOST_ID, "호스트", null, 300),
-                new GameParticipant(GUEST_ID, "게스트", null, 300)
+                GameParticipant.auction(HOST_ID, "호스트", 300),
+                GameParticipant.auction(GUEST_ID, "게스트", 300)
             ),
             List.of(
                 new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0)
@@ -119,10 +119,10 @@ class AuctionGameTest {
             new RoomId(UUID.fromString("00000000-0000-0000-0000-000000000002")),
             "ROOM02",
             STARTED_AT,
-            new GameRules(2, 2, 300, PICK_BAN_TIME, MIN_BID_UNIT, null, null),
+            GameRules.auction(2, 2, 300, PICK_BAN_TIME, MIN_BID_UNIT, null),
             List.of(
-                new GameParticipant(HOST_ID, "호스트", null, 300),
-                new GameParticipant(GUEST_ID, "게스트", null, 300)
+                GameParticipant.auction(HOST_ID, "호스트", 300),
+                GameParticipant.auction(GUEST_ID, "게스트", 300)
             ),
             List.of(
                 new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),

--- a/src/test/java/com/naminhyeok/fantazzk/room/DraftGameTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/DraftGameTest.java
@@ -112,10 +112,10 @@ class DraftGameTest {
             new RoomId(UUID.fromString("00000000-0000-0000-0000-000000000001")),
             "ROOM01",
             STARTED_AT,
-            new GameRules(2, teamSize, null, 30, null, null, draftOrderStrategy),
+            GameRules.draft(2, teamSize, 30, draftOrderStrategy),
             List.of(
-                new GameParticipant(HOST_ID, "호스트", 1, null),
-                new GameParticipant(GUEST_ID, "게스트", 2, null)
+                GameParticipant.draft(HOST_ID, "호스트", 1),
+                GameParticipant.draft(GUEST_ID, "게스트", 2)
             ),
             playerNames.stream()
                 .map(name -> new GamePlayer(new RoomPlayerId(playerNames.indexOf(name)), name, "TOP", playerNames.indexOf(name)))

--- a/src/test/java/com/naminhyeok/fantazzk/room/GameCapabilitySeamTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/GameCapabilitySeamTest.java
@@ -1,0 +1,64 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class GameCapabilitySeamTest {
+    @Test
+    void 경매_규칙은_auction_seam으로_드러난다() {
+        GameRules rules = GameRules.auction(2, 2, 300, 45, 10, 1);
+
+        assertThat(rules.auctionRules())
+            .extracting(
+                GameRules.AuctionRules::budget,
+                GameRules.AuctionRules::pickBanTime,
+                GameRules.AuctionRules::minBidUnit,
+                GameRules.AuctionRules::positionLimit
+            )
+            .containsExactly(300, 45, 10, 1);
+        assertThatThrownBy(rules::draftRules).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void 드래프트_규칙은_draft_seam으로_드러난다() {
+        GameRules rules = GameRules.draft(2, 2, 30, RoomTemplateSpec.DraftOrderStrategy.SNAKE);
+
+        assertThat(rules.draftRules())
+            .extracting(
+                GameRules.DraftRules::pickBanTime,
+                GameRules.DraftRules::draftOrderStrategy
+            )
+            .containsExactly(30, RoomTemplateSpec.DraftOrderStrategy.SNAKE);
+        assertThatThrownBy(rules::auctionRules).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void 경매_참가자는_auction_state로_예산을_드러낸다() {
+        GameParticipant participant = GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300);
+
+        assertThat(participant.auctionState())
+            .extracting(
+                GameParticipant.AuctionState::teamLeaderId,
+                GameParticipant.AuctionState::nickname,
+                GameParticipant.AuctionState::remainingBudget
+            )
+            .containsExactly(new TeamLeaderId("host-1"), "호스트", 300);
+        assertThatThrownBy(participant::draftState).isInstanceOf(RoomStateInvalidException.class);
+    }
+
+    @Test
+    void 드래프트_참가자는_draft_state로_순서를_드러낸다() {
+        GameParticipant participant = GameParticipant.draft(new TeamLeaderId("guest-1"), "게스트", 2);
+
+        assertThat(participant.draftState())
+            .extracting(
+                GameParticipant.DraftState::teamLeaderId,
+                GameParticipant.DraftState::nickname,
+                GameParticipant.DraftState::draftPosition
+            )
+            .containsExactly(new TeamLeaderId("guest-1"), "게스트", 2);
+        assertThatThrownBy(participant::auctionState).isInstanceOf(RoomStateInvalidException.class);
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/room/GameFactoryTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/GameFactoryTest.java
@@ -21,10 +21,10 @@ class GameFactoryTest {
                 new GameId(UUID.fromString("00000000-0000-0000-0000-000000000101")),
                 STARTED_AT,
                 RoomMode.AUCTION,
-                new GameRules(2, 2, 300, 45, 10, 1, null),
+                GameRules.auction(2, 2, 300, 45, 10, 1),
                 List.of(
-                    new GameParticipant(new TeamLeaderId("host-1"), "호스트", null, 300),
-                    new GameParticipant(new TeamLeaderId("guest-1"), "게스트", null, 300)
+                    GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
+                    GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
                 ),
                 List.of(
                     new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
@@ -57,10 +57,10 @@ class GameFactoryTest {
                 new GameId(UUID.fromString("00000000-0000-0000-0000-000000000102")),
                 STARTED_AT,
                 RoomMode.DRAFT,
-                new GameRules(2, 2, null, 30, null, null, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
+                GameRules.draft(2, 2, 30, RoomTemplateSpec.DraftOrderStrategy.SNAKE),
                 List.of(
-                    new GameParticipant(new TeamLeaderId("host-1"), "호스트", 1, null),
-                    new GameParticipant(new TeamLeaderId("guest-1"), "게스트", 2, null)
+                    GameParticipant.draft(new TeamLeaderId("host-1"), "호스트", 1),
+                    GameParticipant.draft(new TeamLeaderId("guest-1"), "게스트", 2)
                 ),
                 List.of(
                     new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),


### PR DESCRIPTION
## 변경 배경
이전 PR에서 started 이후 내부 vocabulary를 정리해 `RoomBid`, `RoomTeamMember`를 각각 `AuctionBid`, `RosterMember`로 정리했습니다.

다음 단계에서는 started 이후 모델 안에서 draft / auction capability 경계가 타입 수준에서 더 잘 드러나야 했습니다.
기존에는 `GameRules`, `GameParticipant`가 draft/auction 의미를 한 record 안에 nullable 필드로 함께 들고 있어,
코드를 읽을 때 실제로 어떤 capability의 규칙과 상태를 다루는지 매번 해석해야 했습니다.

이번 PR은 package split이나 module split 없이,
Game 내부에서 capability seam을 먼저 드러내는 데 집중합니다.

## AS-IS
- `GameRules`가 예산, 최소 입찰 증가폭, 포지션 제한, 드래프트 순서를 한 record에 함께 들고 있었습니다.
- `GameParticipant`가 `draftPosition`, `remainingBudget`를 함께 들고 있어 auction/draft 의미가 섞여 있었습니다.
- `AuctionGame`, `DraftGame`, `Room.start`, `GameFactory`는 started 이후 capability를 다루면서도 혼합된 raw field에 직접 의존하고 있었습니다.

## TO-BE
- `GameRules`에 `auctionRules()` / `draftRules()` seam을 추가해 capability별 규칙 접근을 분명히 했습니다.
- `GameParticipant`에 `auctionState()` / `draftState()` seam을 추가해 capability별 상태 접근을 분명히 했습니다.
- `Room.start` handoff부터 `AuctionGame`, `DraftGame`, `GameFactory`까지 새 seam을 따라 흐르도록 맞췄습니다.
- package split은 하지 않고, 타입/정책 수준에서만 경계를 드러냈습니다.

## 주요 변경사항
- `GameRules.auction(...)`, `GameRules.draft(...)` factory를 추가했습니다.
- `GameRules.AuctionRules`, `GameRules.DraftRules` nested type을 추가했습니다.
- `GameParticipant.auction(...)`, `GameParticipant.draft(...)` factory를 추가했습니다.
- `GameParticipant.AuctionState`, `GameParticipant.DraftState` nested type을 추가했습니다.
- `Room.start`가 게임 시작 handoff 시 mode에 맞는 capability-specific rules / participants를 생성하도록 바꿨습니다.
- `GameFactory`, `AuctionGame`, `DraftGame`가 capability seam을 사용하도록 정리했습니다.
- seam 자체를 고정하는 `GameCapabilitySeamTest`를 추가했습니다.
- 핵심 Game 테스트와 repository 테스트도 새 seam을 사용하는 형태로 정리했습니다.

## 의도적으로 하지 않은 것
- draft / auction을 별도 패키지로 분리하지 않았습니다.
- Game action/auth 책임 이동은 하지 않았습니다.
- realtime / snapshot / read model의 room 중심 envelope는 아직 유지합니다.
- modulith module split이나 shared kernel 추출은 시작하지 않았습니다.

## 기대 효과
- started 이후 Game 내부에서 어떤 규칙과 상태가 auction/draft에 속하는지 코드만 봐도 더 명확합니다.
- 다음 PR에서 orchestration/auth seam을 다룰 때 raw nullable field보다 capability seam을 기준으로 이동할 수 있습니다.
- 향후 package split을 검토하더라도, 먼저 타입과 정책 경계가 정리된 상태에서 판단할 수 있습니다.

## 검증
- `./gradlew check`
- `./gradlew integrationTest --rerun-tasks`
