### PR TITLE
started game orchestration seam을 정리한다

### DIFF
--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraft.java
@@ -13,6 +13,7 @@ class PickDraft {
     private final Rooms rooms;
     private final Games games;
     private final RoomActionAuthorizer roomActionAuthorizer;
+    private final StartedGameContextLoader startedGameContextLoader;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
 
     @Transactional
@@ -34,13 +35,11 @@ class PickDraft {
     @Transactional
     public RosterMember pick(UUID gameId, String actionToken, String playerName) {
         try {
-            Game game = games.findById(new GameId(gameId)).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            Room room = rooms.findById(game.getRoomId()).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            DraftGame draftGame = requireDraftGame(game);
-            RosterMember member = draftGame.pick(caller.getId(), playerName);
+            StartedGameActionContext action = startedGameContextLoader.authenticate(gameId, actionToken);
+            DraftGame draftGame = requireDraftGame(action.game());
+            RosterMember member = draftGame.pick(action.caller().getId(), playerName);
             games.save(draftGame);
-            Room saved = rooms.saveAndFlush(room);
+            Room saved = rooms.saveAndFlush(action.room());
             roomSnapshotPublisher.publishAfterCommit(new RoomDetails(saved, draftGame));
             return member;
         } catch (OptimisticLockingFailureException ex) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PlaceBid.java
@@ -15,6 +15,7 @@ class PlaceBid {
     private final Rooms rooms;
     private final Games games;
     private final RoomActionAuthorizer roomActionAuthorizer;
+    private final StartedGameContextLoader startedGameContextLoader;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
     private final Clock clock;
 
@@ -37,13 +38,11 @@ class PlaceBid {
     @Transactional
     public AuctionBid place(UUID gameId, String actionToken, int amount) {
         try {
-            Game game = games.findById(new GameId(gameId)).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            Room room = rooms.findById(game.getRoomId()).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            RoomTeamLeader caller = roomActionAuthorizer.authenticate(room, actionToken);
-            AuctionGame auctionGame = requireAuctionGame(game);
-            AuctionBid bid = auctionGame.placeBid(caller.getId(), amount, Instant.now(clock));
+            StartedGameActionContext action = startedGameContextLoader.authenticate(gameId, actionToken);
+            AuctionGame auctionGame = requireAuctionGame(action.game());
+            AuctionBid bid = auctionGame.placeBid(action.caller().getId(), amount, Instant.now(clock));
             games.save(auctionGame);
-            Room saved = rooms.saveAndFlush(room);
+            Room saved = rooms.saveAndFlush(action.room());
             roomSnapshotPublisher.publishAfterCommit(new RoomDetails(saved, auctionGame));
             return bid;
         } catch (OptimisticLockingFailureException ex) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SettleAuctionAttempt.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 class SettleAuctionAttempt {
     private final Rooms rooms;
     private final Games games;
+    private final StartedGameContextLoader startedGameContextLoader;
     private final Clock clock;
     private final RoomSnapshotPublisher roomSnapshotPublisher;
 
@@ -37,12 +38,11 @@ class SettleAuctionAttempt {
     AuctionSettlement settle(UUID gameId) {
         try {
             Instant now = Instant.now(clock);
-            Game loadedGame = games.findById(new GameId(gameId)).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            Room room = rooms.findById(loadedGame.getRoomId()).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-            AuctionGame game = requireAuctionGame(loadedGame);
+            StartedGameContext context = startedGameContextLoader.load(gameId);
+            AuctionGame game = requireAuctionGame(context.game());
             AuctionSettlement settlement = game.settleAuction(now);
             games.save(game);
-            Room saved = rooms.saveAndFlush(room);
+            Room saved = rooms.saveAndFlush(context.room());
             roomSnapshotPublisher.publishAfterCommit(new RoomDetails(saved, game));
             return settlement;
         } catch (OptimisticLockingFailureException ex) {
@@ -69,8 +69,8 @@ class SettleAuctionAttempt {
     @Transactional
     Game settleIfDue(UUID gameId) {
         Instant now = Instant.now(clock);
-        Game loadedGame = games.findById(new GameId(gameId)).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
-        Room room = rooms.findById(loadedGame.getRoomId()).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
+        StartedGameContext context = startedGameContextLoader.load(gameId);
+        Game loadedGame = context.game();
         AuctionGame game = loadAuctionGame(loadedGame);
         if (!isDue(game, now)) {
             return loadedGame;
@@ -78,7 +78,7 @@ class SettleAuctionAttempt {
 
         game.settleAuction(now);
         games.save(game);
-        Room saved = rooms.saveAndFlush(room);
+        Room saved = rooms.saveAndFlush(context.room());
         roomSnapshotPublisher.publishAfterCommit(new RoomDetails(saved, game));
         return game;
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/StartedGameContextLoader.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/StartedGameContextLoader.java
@@ -1,0 +1,49 @@
+package com.naminhyeok.fantazzk.room;
+
+import com.naminhyeok.fantazzk.CoreException;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+class StartedGameContextLoader {
+    private final Rooms rooms;
+    private final Games games;
+    private final RoomActionAuthorizer roomActionAuthorizer;
+
+    StartedGameContext load(UUID gameId) {
+        Game game = games.findById(new GameId(gameId)).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
+        Room room = rooms.findById(game.getRoomId()).orElseThrow(() -> CoreException.of(RoomErrorType.GAME_NOT_FOUND));
+        return new StartedGameContext(room, game);
+    }
+
+    StartedGameActionContext authenticate(UUID gameId, String actionToken) {
+        StartedGameContext context = load(gameId);
+        RoomTeamLeader caller = roomActionAuthorizer.authenticate(context.room(), actionToken);
+        return new StartedGameActionContext(context.room(), context.game(), caller);
+    }
+}
+
+record StartedGameContext(
+    Room room,
+    Game game
+) {
+    StartedGameContext {
+        Objects.requireNonNull(room, "room must not be null");
+        Objects.requireNonNull(game, "game must not be null");
+    }
+}
+
+record StartedGameActionContext(
+    Room room,
+    Game game,
+    RoomTeamLeader caller
+) {
+    StartedGameActionContext {
+        Objects.requireNonNull(room, "room must not be null");
+        Objects.requireNonNull(game, "game must not be null");
+        Objects.requireNonNull(caller, "caller must not be null");
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomRealtimePublishingTest.java
@@ -51,7 +51,10 @@ class RoomRealtimePublishingTest {
         Room room = startedDraftRoom();
         DraftGame game = (DraftGame) gameFor(room);
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
-        PickDraft pickDraft = new PickDraft(new InMemoryRooms(room), new InMemoryGames(game), new RoomActionAuthorizer(), publisher);
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        InMemoryGames games = new InMemoryGames(game);
+        PickDraft pickDraft =
+            new PickDraft(rooms, games, new RoomActionAuthorizer(), startedGameContextLoader(rooms, games), publisher);
 
         RosterMember picked = pickDraft.pick(room.getCode(), HOST_ACTION_TOKEN, "선수1");
 
@@ -99,8 +102,10 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         AuctionGame game = (AuctionGame) gameFor(room);
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        InMemoryGames games = new InMemoryGames(game);
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), new InMemoryGames(game), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(rooms, games, startedGameContextLoader(rooms, games), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
 
         AuctionSettlement settlement = settleAuctionAttempt.settle(room.getCode());
 
@@ -116,8 +121,10 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         AuctionGame game = (AuctionGame) gameFor(room);
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        InMemoryGames games = new InMemoryGames(game);
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), new InMemoryGames(game), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(rooms, games, startedGameContextLoader(rooms, games), Clock.fixed(PUBLISHED_AT, ZoneOffset.UTC), publisher);
 
         Room settled = settleAuctionAttempt.settleIfDue(room.getCode());
 
@@ -134,8 +141,16 @@ class RoomRealtimePublishingTest {
         Room room = startedAuctionRoom();
         AuctionGame game = (AuctionGame) gameFor(room);
         RecordingRoomSnapshotPublisher publisher = new RecordingRoomSnapshotPublisher();
+        InMemoryRooms rooms = new InMemoryRooms(room);
+        InMemoryGames games = new InMemoryGames(game);
         SettleAuctionAttempt settleAuctionAttempt =
-            new SettleAuctionAttempt(new InMemoryRooms(room), new InMemoryGames(game), Clock.fixed(CREATED_AT.plusSeconds(10), ZoneOffset.UTC), publisher);
+            new SettleAuctionAttempt(
+                rooms,
+                games,
+                startedGameContextLoader(rooms, games),
+                Clock.fixed(CREATED_AT.plusSeconds(10), ZoneOffset.UTC),
+                publisher
+            );
 
         Room current = settleAuctionAttempt.settleIfDue(room.getCode());
 
@@ -145,6 +160,10 @@ class RoomRealtimePublishingTest {
 
     private static TeamLeaderIdentityIssuer fixedLeaderIdentityIssuer() {
         return () -> new TeamLeaderIdentityIssuer.TeamLeaderIdentity(GUEST_ID, GUEST_ACTION_TOKEN);
+    }
+
+    private static StartedGameContextLoader startedGameContextLoader(InMemoryRooms rooms, InMemoryGames games) {
+        return new StartedGameContextLoader(rooms, games, new RoomActionAuthorizer());
     }
 
     private static void assertRoomError(CoreException exception, RoomErrorType errorType) {
@@ -228,17 +247,25 @@ class RoomRealtimePublishingTest {
                 room.getStartedGameId(),
                 room.getStartedAt(),
                 room.getMode(),
-                new GameRules(
-                    room.getTeamCount(),
-                    room.getTeamSize(),
-                    room.getBudget(),
-                    room.getPickBanTime(),
-                    room.getMinBidUnit(),
-                    room.getPositionLimit(),
-                    room.getDraftOrderStrategy()
-                ),
+                room.getMode() == RoomMode.AUCTION
+                    ? GameRules.auction(
+                        room.getTeamCount(),
+                        room.getTeamSize(),
+                        room.getBudget(),
+                        room.getPickBanTime(),
+                        room.getMinBidUnit(),
+                        room.getPositionLimit()
+                    )
+                    : GameRules.draft(
+                        room.getTeamCount(),
+                        room.getTeamSize(),
+                        room.getPickBanTime(),
+                        room.getDraftOrderStrategy()
+                    ),
                 room.getLeaders().stream()
-                    .map(leader -> new GameParticipant(leader.getId(), leader.getNickname(), leader.getDraftPosition(), leader.getRemainingBudget()))
+                    .map(leader -> room.getMode() == RoomMode.AUCTION
+                        ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
+                        : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
                     .toList(),
                 room.getPlayers().stream()
                     .map(player -> new GamePlayer(player.getId(), player.getName(), player.getPosition(), player.getDisplayOrder()))

--- a/src/test/java/com/naminhyeok/fantazzk/room/StartedGameContextLoaderTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/StartedGameContextLoaderTest.java
@@ -1,0 +1,175 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.naminhyeok.fantazzk.CoreException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class StartedGameContextLoaderTest {
+    private static final Instant CREATED_AT = Instant.parse("2026-04-18T00:00:00Z");
+
+    @Test
+    void gameId로_started_game_action_context를_읽고_room_기반으로_인증한다() {
+        Room room = startedAuctionRoom();
+        Game game = startedGameOf(room);
+        StartedGameContextLoader loader = new StartedGameContextLoader(
+            new InMemoryRooms(Map.of(room.getId(), room)),
+            new InMemoryGames(Map.of(game.getId(), game)),
+            new RoomActionAuthorizer()
+        );
+
+        StartedGameActionContext action = loader.authenticate(game.getId().gameId(), "host-action-token");
+
+        assertThat(action.room().getId()).isEqualTo(room.getId());
+        assertThat(action.game().getId()).isEqualTo(game.getId());
+        assertThat(action.caller().getId()).isEqualTo(new TeamLeaderId("host-1"));
+    }
+
+    @Test
+    void 없는_gameId면_GAME_NOT_FOUND를_반환한다() {
+        StartedGameContextLoader loader =
+            new StartedGameContextLoader(new InMemoryRooms(Map.of()), new InMemoryGames(Map.of()), new RoomActionAuthorizer());
+
+        assertThatThrownBy(() -> loader.load(UUID.randomUUID()))
+            .isInstanceOfSatisfying(
+                CoreException.class,
+                ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.GAME_NOT_FOUND)
+            );
+    }
+
+    @Test
+    void room이_없어도_GAME_NOT_FOUND를_반환한다() {
+        Room room = startedAuctionRoom();
+        Game game = startedGameOf(room);
+        StartedGameContextLoader loader =
+            new StartedGameContextLoader(new InMemoryRooms(Map.of()), new InMemoryGames(Map.of(game.getId(), game)), new RoomActionAuthorizer());
+
+        assertThatThrownBy(() -> loader.load(game.getId().gameId()))
+            .isInstanceOfSatisfying(
+                CoreException.class,
+                ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.GAME_NOT_FOUND)
+            );
+    }
+
+    @Test
+    void actionToken이_유효하지_않으면_room_auth_error를_반환한다() {
+        Room room = startedAuctionRoom();
+        Game game = startedGameOf(room);
+        StartedGameContextLoader loader = new StartedGameContextLoader(
+            new InMemoryRooms(Map.of(room.getId(), room)),
+            new InMemoryGames(Map.of(game.getId(), game)),
+            new RoomActionAuthorizer()
+        );
+
+        assertThatThrownBy(() -> loader.authenticate(game.getId().gameId(), "wrong-token"))
+            .isInstanceOfSatisfying(
+                CoreException.class,
+                ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_ACTION_TOKEN_INVALID)
+            );
+    }
+
+    private Room startedAuctionRoom() {
+        Room room =
+            Room.createFromTemplate(
+                "ROOM01",
+                new TeamLeaderId("host-1"),
+                "호스트",
+                "host-action-token",
+                new RoomTemplateSpec(
+                    RoomTemplateSpec.Mode.AUCTION,
+                    2,
+                    2,
+                    300,
+                    45,
+                    10,
+                    1,
+                    null,
+                    List.of(
+                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+                    )
+                ),
+                CREATED_AT
+            );
+        room.join(new TeamLeaderId("guest-1"), "게스트", "guest-action-token");
+        room.start(new TeamLeaderId("host-1"), CREATED_AT);
+        return room;
+    }
+
+    private Game startedGameOf(Room room) {
+        return new GameFactory().create(
+            new StartedGameSnapshot(
+                room.getId(),
+                room.getCode(),
+                room.getStartedGameId(),
+                room.getStartedAt(),
+                room.getMode(),
+                GameRules.auction(room.getTeamCount(), room.getTeamSize(), room.getBudget(), room.getPickBanTime(), room.getMinBidUnit(), room.getPositionLimit()),
+                List.of(
+                    GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
+                    GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
+                ),
+                List.of(
+                    new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
+                    new GamePlayer(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+                )
+            )
+        );
+    }
+
+    private static final class InMemoryRooms implements Rooms {
+        private final Map<RoomId, Room> byId;
+
+        private InMemoryRooms(Map<RoomId, Room> rooms) {
+            this.byId = new HashMap<>(rooms);
+        }
+
+        @Override
+        public Room save(Room room) {
+            byId.put(room.getId(), room);
+            return room;
+        }
+
+        @Override
+        public Room saveAndFlush(Room room) {
+            byId.put(room.getId(), room);
+            return room;
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) {
+            return Optional.ofNullable(byId.get(id));
+        }
+
+        @Override
+        public Optional<Room> findByCode(String code) {
+            return byId.values().stream().filter(room -> room.getCode().equals(code)).findFirst();
+        }
+    }
+
+    private static final class InMemoryGames implements Games {
+        private final Map<GameId, Game> byId;
+
+        private InMemoryGames(Map<GameId, Game> games) {
+            this.byId = new HashMap<>(games);
+        }
+
+        @Override
+        public Game save(Game game) {
+            byId.put(game.getId(), game);
+            return game;
+        }
+
+        @Override
+        public Optional<Game> findById(GameId id) {
+            return Optional.ofNullable(byId.get(id));
+        }
+    }
+}


### PR DESCRIPTION
## 변경 배경
앞선 PR에서 Game 내부 vocabulary와 capability seam을 정리하면서, started 이후 모델의 언어와 타입 경계는 어느 정도 정리되었습니다.

다만 application service 관점에서는 `/games/{gameId}` 진입점이 생겼음에도,
`PickDraft`, `PlaceBid`, `SettleAuctionAttempt`가 각각 `game -> room -> room auth` 흐름을 중복해서 가지고 있었습니다.
이 상태에서는 action token 책임이 Room에 있다는 사실은 맞지만,
그 책임을 started-game 흐름 안에서 어떻게 사용해야 하는지가 use case마다 흩어져 보입니다.

이번 PR은 action token 소유권은 Room에 그대로 두면서,
started 이후 `gameId` 경로 orchestration을 하나의 seam으로 모으는 데 집중합니다.

## AS-IS
- `PickDraft`, `PlaceBid`, `SettleAuctionAttempt`의 `gameId` 경로가 각각 `games.findById -> rooms.findById -> room auth`를 직접 수행하고 있었습니다.
- `gameId` 경로에서 Room 기반 auth를 쓴다는 사실이 use case 내부 중복으로 표현되고 있었습니다.
- started-game load/auth 규칙을 별도로 검증하는 전용 테스트가 없었습니다.

## TO-BE
- `StartedGameContextLoader`를 추가해 `gameId` 기준 started-game load/auth seam을 하나로 모았습니다.
- action token 인증은 여전히 `RoomActionAuthorizer`가 수행하지만, started-game 기준 orchestration에서는 새 loader를 통해 사용합니다.
- `PickDraft`, `PlaceBid`, `SettleAuctionAttempt`의 `gameId` 경로가 새 seam을 사용하도록 정리했습니다.
- room-code 경로는 이번 PR에서 유지해 기존 흐름의 에러 순서를 불필요하게 흔들지 않았습니다.

## 주요 변경사항
- `StartedGameContextLoader`를 추가했습니다.
- `StartedGameContext`, `StartedGameActionContext`를 추가했습니다.
- `PickDraft`의 `gameId` 경로가 loader 기반으로 room/game/caller를 읽도록 바꿨습니다.
- `PlaceBid`의 `gameId` 경로가 loader 기반으로 room/game/caller를 읽도록 바꿨습니다.
- `SettleAuctionAttempt`의 `gameId` 경로가 loader 기반으로 started-game context를 읽도록 바꿨습니다.
- `StartedGameContextLoaderTest`를 추가해 `GAME_NOT_FOUND`, room missing, invalid action token 흐름을 고정했습니다.
- `RoomRealtimePublishingTest`의 manual construction fixture를 새 seam에 맞게 정리했습니다.

## 의도적으로 하지 않은 것
- `RoomActionAuthorizer`를 Game 쪽으로 옮기지 않았습니다.
- room-code 경로까지 한 번에 loader로 통합하지 않았습니다.
- realtime/read model cut은 아직 하지 않았습니다.
- modulith module split이나 shared kernel 추출은 시작하지 않았습니다.

## 기대 효과
- started 이후 `gameId` 경로에서 action token/auth 책임이 Room 소유임을 유지하면서도, use case 중복은 줄었습니다.
- 다음 PR에서 realtime/snapshot/read model cut을 진행할 때, application service 쪽 started-game seam을 기준으로 정리할 수 있습니다.
- `gameId` 경로의 load/auth 규칙을 별도 테스트로 고정해 회귀 위험을 낮췄습니다.

## 검증
- `./gradlew check`
- `./gradlew integrationTest --rerun-tasks`
