### PR TITLE
Swagger 문서정리

### DIFF
--- a/src/main/java/com/naminhyeok/fantazzk/ApiResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/ApiResponse.java
@@ -1,11 +1,16 @@
 package com.naminhyeok.fantazzk;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "모든 API가 공통으로 사용하는 응답 envelope 입니다. 성공이면 `success`, 실패이면 `error` 를 확인합니다.")
 public final class ApiResponse<T> {
+    @Schema(description = "응답 결과 타입", implementation = ResultType.class)
     private final ResultType resultType;
+    @Schema(description = "성공 응답 payload. 실패 시 null 입니다.")
     private final T success;
+    @Schema(description = "실패 응답 정보. 성공 시 null 입니다.")
     private final ErrorMessage error;
 
     private ApiResponse(ResultType resultType, T success, ErrorMessage error) {

--- a/src/main/java/com/naminhyeok/fantazzk/ErrorMessage.java
+++ b/src/main/java/com/naminhyeok/fantazzk/ErrorMessage.java
@@ -1,6 +1,16 @@
 package com.naminhyeok.fantazzk;
 
-public record ErrorMessage(String code, String message, Object data) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 에러 응답 payload")
+public record ErrorMessage(
+    @Schema(description = "에러 코드", example = "ROOM_NOT_FOUND")
+    String code,
+    @Schema(description = "사용자 노출용 에러 메시지", example = "방을 찾을 수 없습니다")
+    String message,
+    @Schema(description = "추가 진단 정보 또는 validation 필드 에러 맵. 없으면 null 입니다.")
+    Object data
+) {
     public ErrorMessage(ErrorDescriptor descriptor) {
         this(descriptor, null);
     }

--- a/src/main/java/com/naminhyeok/fantazzk/FantazzkApplicationConfiguration.java
+++ b/src/main/java/com/naminhyeok/fantazzk/FantazzkApplicationConfiguration.java
@@ -1,7 +1,9 @@
 package com.naminhyeok.fantazzk;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 import java.time.Clock;
 import java.util.List;
@@ -34,23 +36,36 @@ public class FantazzkApplicationConfiguration {
     @Bean
     OpenAPI openApi() {
         return new OpenAPI()
+            .components(
+                new Components().addSecuritySchemes(
+                    OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME,
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name(OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER)
+                        .description(OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+                )
+            )
             .info(
                 new Info()
                     .title("Fantazzk API")
                     .version("v1")
-                    .description(
-                        """
-                        Fantazzk의 드래프트/경매 팀 빌딩 API입니다.
-                        모든 응답은 공통 envelope를 사용합니다.
-                        - 성공 응답: resultType=SUCCESS, success 에 실제 payload 가 들어갑니다.
-                        - 실패 응답: resultType=ERROR, error 에 status, errorCode, reason, data 가 들어갑니다.
-                        """.trim()
-                    )
+                    .description(OpenApiDocumentation.OPENAPI_DESCRIPTION)
             )
             .tags(
                 List.of(
-                    new Tag().name("Template").description("팀 빌딩 템플릿 생성 및 조회 API"),
-                    new Tag().name("Room").description("방 생성, 참가, 시작, 경매, 드래프트 진행 API")
+                    new Tag()
+                        .name(OpenApiDocumentation.TEMPLATE_TAG)
+                        .description("템플릿 조회/생성 API. 웹에서 첫 진입 시 사용할 룰과 선수 풀을 확인합니다."),
+                    new Tag()
+                        .name(OpenApiDocumentation.ROOM_SESSION_TAG)
+                        .description("방 생성/참가 API. 성공 응답에서 `actionToken` 을 받아 이후 mutation 요청에 사용합니다."),
+                    new Tag()
+                        .name(OpenApiDocumentation.ROOM_LOBBY_TAG)
+                        .description("대기방 로비 조회 및 시작 전 액션 API. `startedGameId` 가 생기면 Game Play API 로 전환합니다."),
+                    new Tag()
+                        .name(OpenApiDocumentation.GAME_PLAY_TAG)
+                        .description("방 시작 후 진행 화면용 API. 시작 이후 상태의 source of truth 입니다.")
                 )
             );
     }

--- a/src/main/java/com/naminhyeok/fantazzk/OpenApiDocumentation.java
+++ b/src/main/java/com/naminhyeok/fantazzk/OpenApiDocumentation.java
@@ -1,0 +1,543 @@
+package com.naminhyeok.fantazzk;
+
+public final class OpenApiDocumentation {
+    public static final String ROOM_ACTION_TOKEN_HEADER = "X-Room-Action-Token";
+    public static final String ROOM_ACTION_TOKEN_SCHEME = "roomActionToken";
+
+    public static final String TEMPLATE_TAG = "Template";
+    public static final String ROOM_SESSION_TAG = "Room Session";
+    public static final String ROOM_LOBBY_TAG = "Room Lobby";
+    public static final String GAME_PLAY_TAG = "Game Play";
+
+    public static final String ROOM_ACTION_TOKEN_DESCRIPTION =
+        "방 생성 또는 참가 성공 응답의 `teamLeaderSession.actionToken` 값을 그대로 전달합니다. "
+            + "로그인 토큰이 아니라 방/팀장 단위의 액션 권한 토큰입니다.";
+
+    public static final String ROOM_CODE_DESCRIPTION =
+        "사용자가 공유받은 방 코드입니다. 로비 조회와 참가, 시작 전 액션의 기준 식별자입니다.";
+
+    public static final String GAME_ID_DESCRIPTION =
+        "방이 시작된 뒤 발급되는 게임 ID입니다. 진행 화면의 source of truth는 `/games/{gameId}` 입니다.";
+
+    public static final String OPENAPI_DESCRIPTION = """
+        Fantazzk의 외부 웹 연동용 API 문서입니다.
+
+        ## 빠른 사용 흐름
+        1. `GET /api/v1/templates` 로 템플릿 목록을 조회합니다.
+        2. `POST /api/v1/rooms` 또는 `POST /api/v1/rooms/{code}/join` 으로 방 세션을 시작합니다.
+        3. 응답의 `teamLeaderSession.actionToken` 을 FE 세션 스토리지에 저장합니다.
+        4. 로비 화면은 `GET /api/v1/rooms/{code}` 를 source of truth 로 사용합니다.
+        5. `startedGameId` 가 생기면 진행 화면을 `GET /api/v1/games/{gameId}` 기반으로 전환합니다.
+        6. 시작 후 드래프트/경매 액션은 모두 `games` API 로 호출합니다.
+
+        ## 공통 응답 규칙
+        - 성공 응답: `resultType=SUCCESS`, 실제 payload 는 `success` 에 들어갑니다.
+        - 실패 응답: `resultType=ERROR`, 에러 정보는 `error.code`, `error.message`, `error.data` 에 들어갑니다.
+        - validation 실패 시 `error.code` 는 `BAD_REQUEST` 이고, `error.data` 에 필드별 메시지가 들어갑니다.
+
+        ## room 과 game 의 역할
+        - `rooms` API 는 로비/대기방 조회와 시작 전 액션을 담당합니다.
+        - `games` API 는 시작 후 실시간 진행 상태와 액션을 담당합니다.
+        - 즉, 시작 전에는 `room`, 시작 후에는 `game` 이 화면의 source of truth 입니다.
+
+        ## 액션 인증 방식
+        - 로그인 토큰 대신 `X-Room-Action-Token` 헤더를 사용합니다.
+        - 이 값은 방 생성/참가 응답에서만 내려오며, 이후 mutation API 호출 시 그대로 전달해야 합니다.
+        """;
+
+    public static final String TEMPLATE_LIST_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": [
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "name": "LOL 2인 드래프트",
+              "gameType": "LEAGUE_OF_LEGENDS",
+              "mode": "DRAFT",
+              "teamCount": 2,
+              "teamSize": 3,
+              "budget": null,
+              "pickBanTime": 30,
+              "minBidUnit": null,
+              "positionLimit": null,
+              "draftOrderStrategy": "SNAKE",
+              "players": [
+                {
+                  "name": "선수1",
+                  "position": "TOP",
+                  "displayOrder": 0
+                },
+                {
+                  "name": "선수2",
+                  "position": "JUNGLE",
+                  "displayOrder": 1
+                }
+              ]
+            }
+          ],
+          "error": null
+        }
+        """;
+
+    public static final String TEMPLATE_DETAIL_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "LOL 2인 드래프트",
+            "gameType": "LEAGUE_OF_LEGENDS",
+            "mode": "DRAFT",
+            "teamCount": 2,
+            "teamSize": 3,
+            "budget": null,
+            "pickBanTime": 30,
+            "minBidUnit": null,
+            "positionLimit": null,
+            "draftOrderStrategy": "SNAKE",
+            "players": [
+              {
+                "name": "선수1",
+                "position": "TOP",
+                "displayOrder": 0
+              },
+              {
+                "name": "선수2",
+                "position": "JUNGLE",
+                "displayOrder": 1
+              }
+            ]
+          },
+          "error": null
+        }
+        """;
+
+    public static final String ROOM_SESSION_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "room": {
+              "code": "ROOM01",
+              "status": "WAITING",
+              "mode": "DRAFT",
+              "teamCount": 2,
+              "teamSize": 3,
+              "budget": null,
+              "minBidUnit": null,
+              "draftOrderStrategy": "SNAKE",
+              "startReadiness": "WAITING_FOR_DRAFT_POSITIONS",
+              "startedGameId": null,
+              "draftOrderPreview": {
+                "slots": [
+                  {
+                    "draftPosition": 1,
+                    "leaderId": "leader-host",
+                    "nickname": "호스트"
+                  },
+                  {
+                    "draftPosition": 2,
+                    "leaderId": null,
+                    "nickname": null
+                  }
+                ]
+              },
+              "teamLeaders": [
+                {
+                  "id": "leader-host",
+                  "nickname": "호스트",
+                  "draftPosition": 1,
+                  "remainingBudget": null
+                }
+              ],
+              "players": [
+                {
+                  "name": "선수1",
+                  "position": "TOP",
+                  "displayOrder": 0,
+                  "status": "AVAILABLE"
+                },
+                {
+                  "name": "선수2",
+                  "position": "JUNGLE",
+                  "displayOrder": 1,
+                  "status": "AVAILABLE"
+                }
+              ]
+            },
+            "teamLeaderSession": {
+              "leaderId": "leader-host",
+              "role": "HOST",
+              "actionToken": "room-action-token"
+            }
+          },
+          "error": null
+        }
+        """;
+
+    public static final String ROOM_JOIN_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "room": {
+              "code": "ROOM01",
+              "status": "WAITING",
+              "mode": "DRAFT",
+              "teamCount": 2,
+              "teamSize": 3,
+              "budget": null,
+              "minBidUnit": null,
+              "draftOrderStrategy": "SNAKE",
+              "startReadiness": "WAITING_FOR_DRAFT_POSITIONS",
+              "startedGameId": null,
+              "draftOrderPreview": {
+                "slots": [
+                  {
+                    "draftPosition": 1,
+                    "leaderId": "leader-host",
+                    "nickname": "호스트"
+                  },
+                  {
+                    "draftPosition": 2,
+                    "leaderId": null,
+                    "nickname": null
+                  }
+                ]
+              },
+              "teamLeaders": [
+                {
+                  "id": "leader-host",
+                  "nickname": "호스트",
+                  "draftPosition": 1,
+                  "remainingBudget": null
+                },
+                {
+                  "id": "leader-guest",
+                  "nickname": "게스트",
+                  "draftPosition": null,
+                  "remainingBudget": null
+                }
+              ],
+              "players": [
+                {
+                  "name": "선수1",
+                  "position": "TOP",
+                  "displayOrder": 0,
+                  "status": "AVAILABLE"
+                },
+                {
+                  "name": "선수2",
+                  "position": "JUNGLE",
+                  "displayOrder": 1,
+                  "status": "AVAILABLE"
+                }
+              ]
+            },
+            "teamLeaderSession": {
+              "leaderId": "leader-guest",
+              "role": "LEADER",
+              "actionToken": "guest-room-action-token"
+            }
+          },
+          "error": null
+        }
+        """;
+
+    public static final String ROOM_VIEW_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "code": "ROOM01",
+            "status": "WAITING",
+            "mode": "DRAFT",
+            "teamCount": 2,
+            "teamSize": 3,
+            "budget": null,
+            "minBidUnit": null,
+            "draftOrderStrategy": "SNAKE",
+            "startReadiness": "STARTABLE",
+            "startedGameId": null,
+            "draftOrderPreview": {
+              "slots": [
+                {
+                  "draftPosition": 1,
+                  "leaderId": "leader-host",
+                  "nickname": "호스트"
+                },
+                {
+                  "draftPosition": 2,
+                  "leaderId": "leader-guest",
+                  "nickname": "게스트"
+                }
+              ]
+            },
+            "teamLeaders": [
+              {
+                "id": "leader-host",
+                "nickname": "호스트",
+                "draftPosition": 1,
+                "remainingBudget": null
+              },
+              {
+                "id": "leader-guest",
+                "nickname": "게스트",
+                "draftPosition": 2,
+                "remainingBudget": null
+              }
+            ],
+            "players": [
+              {
+                "name": "선수1",
+                "position": "TOP",
+                "displayOrder": 0,
+                "status": "AVAILABLE"
+              },
+              {
+                "name": "선수2",
+                "position": "JUNGLE",
+                "displayOrder": 1,
+                "status": "AVAILABLE"
+              }
+            ]
+          },
+          "error": null
+        }
+        """;
+
+    public static final String GAME_DRAFT_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "id": "00000000-0000-0000-0000-000000000202",
+            "roomCode": "ROOM01",
+            "mode": "DRAFT",
+            "status": "IN_PROGRESS",
+            "teamCount": 2,
+            "teamSize": 3,
+            "budget": null,
+            "minBidUnit": null,
+            "draftOrderStrategy": "SNAKE",
+            "participants": [
+              {
+                "teamLeaderId": "leader-host",
+                "nickname": "호스트",
+                "draftPosition": 1,
+                "remainingBudget": null
+              },
+              {
+                "teamLeaderId": "leader-guest",
+                "nickname": "게스트",
+                "draftPosition": 2,
+                "remainingBudget": null
+              }
+            ],
+            "players": [
+              {
+                "name": "선수1",
+                "position": "TOP",
+                "displayOrder": 0,
+                "status": "ASSIGNED"
+              },
+              {
+                "name": "선수2",
+                "position": "JUNGLE",
+                "displayOrder": 1,
+                "status": "AVAILABLE"
+              }
+            ],
+            "members": [
+              {
+                "teamLeaderId": "leader-host",
+                "playerName": "선수1",
+                "assignOrder": 0
+              }
+            ],
+            "progress": {
+              "currentTurnIndex": 1,
+              "currentRound": 1,
+              "currentLeaderId": "leader-guest",
+              "currentRoundLeaderIds": [
+                "leader-host",
+                "leader-guest"
+              ],
+              "currentAuctionRoundEndsAt": null,
+              "currentAuctionTarget": null,
+              "highestBidAmount": null,
+              "leadingLeaderId": null,
+              "bidCount": null
+            }
+          },
+          "error": null
+        }
+        """;
+
+    public static final String GAME_AUCTION_SUCCESS_EXAMPLE = """
+        {
+          "resultType": "SUCCESS",
+          "success": {
+            "id": "00000000-0000-0000-0000-000000000201",
+            "roomCode": "ROOM01",
+            "mode": "AUCTION",
+            "status": "IN_PROGRESS",
+            "teamCount": 2,
+            "teamSize": 3,
+            "budget": 300,
+            "minBidUnit": 10,
+            "draftOrderStrategy": null,
+            "participants": [
+              {
+                "teamLeaderId": "leader-host",
+                "nickname": "호스트",
+                "draftPosition": null,
+                "remainingBudget": 300
+              },
+              {
+                "teamLeaderId": "leader-guest",
+                "nickname": "게스트",
+                "draftPosition": null,
+                "remainingBudget": 200
+              }
+            ],
+            "players": [
+              {
+                "name": "선수1",
+                "position": "TOP",
+                "displayOrder": 0,
+                "status": "ASSIGNED"
+              },
+              {
+                "name": "선수2",
+                "position": "JUNGLE",
+                "displayOrder": 1,
+                "status": "AVAILABLE"
+              }
+            ],
+            "members": [
+              {
+                "teamLeaderId": "leader-guest",
+                "playerName": "선수1",
+                "assignOrder": 0
+              }
+            ],
+            "progress": {
+              "currentTurnIndex": null,
+              "currentRound": 2,
+              "currentLeaderId": null,
+              "currentRoundLeaderIds": null,
+              "currentAuctionRoundEndsAt": "2026-04-19T12:00:45Z",
+              "currentAuctionTarget": {
+                "name": "선수2",
+                "position": "JUNGLE"
+              },
+              "highestBidAmount": 150,
+              "leadingLeaderId": "leader-guest",
+              "bidCount": 2
+            }
+          },
+          "error": null
+        }
+        """;
+
+    public static final String ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "ROOM_ACTION_TOKEN_REQUIRED",
+            "message": "방 액션 토큰이 필요합니다",
+            "data": null
+          }
+        }
+        """;
+
+    public static final String ROOM_CONCURRENT_MODIFICATION_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "ROOM_CONCURRENT_MODIFICATION",
+            "message": "방 상태가 동시에 변경되었습니다. 최신 상태를 확인한 뒤 다시 시도해 주세요",
+            "data": null
+          }
+        }
+        """;
+
+    public static final String ROOM_NICKNAME_ALREADY_TAKEN_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "ROOM_NICKNAME_ALREADY_TAKEN",
+            "message": "이미 사용 중인 닉네임입니다",
+            "data": null
+          }
+        }
+        """;
+
+    public static final String BAD_REQUEST_VALIDATION_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "BAD_REQUEST",
+            "message": "요청이 올바르지 않습니다",
+            "data": {
+              "hostNickname": "호스트 이름은 비어 있을 수 없습니다"
+            }
+          }
+        }
+        """;
+
+    public static final String BAD_REQUEST_BID_VALIDATION_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "BAD_REQUEST",
+            "message": "요청이 올바르지 않습니다",
+            "data": {
+              "amount": "입찰 금액은 1 이상이어야 합니다"
+            }
+          }
+        }
+        """;
+
+    public static final String BAD_REQUEST_JOIN_VALIDATION_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "BAD_REQUEST",
+            "message": "요청이 올바르지 않습니다",
+            "data": {
+              "nickname": "닉네임은 비어 있을 수 없습니다"
+            }
+          }
+        }
+        """;
+
+    public static final String ROOM_BID_MIN_UNIT_NOT_MET_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "ROOM_BID_MIN_UNIT_NOT_MET",
+            "message": "최소 입찰 증가폭을 만족하는 금액만 입찰할 수 있습니다",
+            "data": null
+          }
+        }
+        """;
+
+    public static final String ROOM_PICK_OUT_OF_TURN_EXAMPLE = """
+        {
+          "resultType": "ERROR",
+          "success": null,
+          "error": {
+            "code": "ROOM_PICK_OUT_OF_TURN",
+            "message": "현재 턴인 팀장만 픽할 수 있습니다",
+            "data": null
+          }
+        }
+        """;
+
+    private OpenApiDocumentation() {
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/ResultType.java
+++ b/src/main/java/com/naminhyeok/fantazzk/ResultType.java
@@ -1,5 +1,8 @@
 package com.naminhyeok.fantazzk;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 응답 결과 타입")
 public enum ResultType {
     SUCCESS,
     ERROR

--- a/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/AuctionTargetResponse.java
@@ -1,7 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "현재 경매 대상 선수")
 record AuctionTargetResponse(
+    @Schema(description = "선수 이름", example = "선수2")
     String name,
+    @Schema(description = "선수 포지션", example = "JUNGLE")
     String position
 ) {
     static AuctionTargetResponse from(RoomPlayer player) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/CreateRoomRequest.java
@@ -1,11 +1,19 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
+@Schema(description = "방 생성 요청")
 record CreateRoomRequest(
+    @Schema(
+        description = "방 생성에 사용할 템플릿 ID",
+        example = "11111111-1111-1111-1111-111111111111",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "템플릿 ID는 필수입니다") UUID templateId,
+    @Schema(description = "호스트 닉네임", example = "호스트", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "호스트 이름은 비어 있을 수 없습니다") String hostNickname
 ) {
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderPreviewResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderPreviewResponse.java
@@ -1,10 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+@Schema(description = "드래프트 로비 자리 현황")
 record DraftOrderPreviewResponse(List<DraftOrderSlotResponse> slots) {
     static DraftOrderPreviewResponse from(Room room) {
         if (room.getMode() != RoomMode.DRAFT) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderSlotResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/DraftOrderSlotResponse.java
@@ -1,8 +1,14 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "드래프트 순번별 배정 현황")
 record DraftOrderSlotResponse(
+    @Schema(description = "드래프트 순번", example = "1")
     int draftPosition,
+    @Schema(description = "이 순번을 점유한 팀장 ID. 비어 있으면 null", example = "leader-host", nullable = true)
     String leaderId,
+    @Schema(description = "이 순번을 점유한 닉네임. 비어 있으면 null", example = "호스트", nullable = true)
     String nickname
 ) {
     static DraftOrderSlotResponse empty(int draftPosition) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameAuctionApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameAuctionApiController.java
@@ -1,6 +1,13 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,15 +21,57 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/games")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.GAME_PLAY_TAG)
 class GameAuctionApiController {
     private final PlaceBid placeBid;
     private final SettleAuction settleAuction;
     private final GetGame getGame;
 
     @PostMapping("/{gameId}/bids")
+    @Operation(
+        summary = "경매 입찰",
+        description = "현재 경매 대상 선수에게 입찰합니다. 성공 시 최신 `GameResponse` 를 반환하며, 입찰 시점 기준으로 라운드 마감 시간이 다시 연장됩니다.",
+        security = @SecurityRequirement(name = OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME)
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "입찰 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.GAME_AUCTION_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "0 이하 금액, 예산 초과 등 잘못된 입찰",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.BAD_REQUEST_BID_VALIDATION_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "액션 토큰이 없거나 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "최고가/최소 증가폭/포지션 제한/동시 수정 충돌 등으로 입찰이 거부됨",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_BID_MIN_UNIT_NOT_MET_EXAMPLE)
+            )
+        )
+    })
     ApiResponse<GameResponse> placeBid(
+        @Parameter(description = OpenApiDocumentation.GAME_ID_DESCRIPTION, example = "00000000-0000-0000-0000-000000000201")
         @PathVariable UUID gameId,
-        @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken,
+        @Parameter(description = OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+        @RequestHeader(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER, required = false) String actionToken,
         @Valid @RequestBody PlaceBidRequest request
     ) {
         placeBid.place(gameId, actionToken, request.amount());
@@ -30,7 +79,22 @@ class GameAuctionApiController {
     }
 
     @PostMapping("/{gameId}/auction/progress")
-    ApiResponse<GameResponse> progressAuction(@PathVariable UUID gameId) {
+    @Operation(
+        summary = "경매 진행 상태 갱신",
+        description = "현재 시각 기준으로 경매 라운드가 마감되었는지 확인하고, 필요하면 정산 후 최신 `GameResponse` 를 반환합니다. 실시간 연동이 없을 때 FE 폴링 fallback 으로 사용할 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "최신 경매 상태 반환",
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(value = OpenApiDocumentation.GAME_AUCTION_SUCCESS_EXAMPLE)
+        )
+    )
+    ApiResponse<GameResponse> progressAuction(
+        @Parameter(description = OpenApiDocumentation.GAME_ID_DESCRIPTION, example = "00000000-0000-0000-0000-000000000201")
+        @PathVariable UUID gameId
+    ) {
         return ApiResponse.success(GameResponse.from(settleAuction.settleIfDue(gameId)));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameDraftApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameDraftApiController.java
@@ -1,6 +1,13 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +21,48 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/games")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.GAME_PLAY_TAG)
 class GameDraftApiController {
     private final PickDraft pickDraft;
     private final GetGame getGame;
 
     @PostMapping("/{gameId}/draft-picks")
+    @Operation(
+        summary = "드래프트 픽",
+        description = "현재 턴인 팀장이 선수를 선택합니다. 성공 시 최신 `GameResponse` 를 다시 반환하므로 FE는 응답 그대로 화면을 갱신하면 됩니다.",
+        security = @SecurityRequirement(name = OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME)
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "픽 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.GAME_DRAFT_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "액션 토큰이 없거나 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "현재 턴이 아니거나 이미 선택된 선수를 픽하려고 시도함",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_PICK_OUT_OF_TURN_EXAMPLE)
+            )
+        )
+    })
     ApiResponse<GameResponse> pickDraft(
+        @Parameter(description = OpenApiDocumentation.GAME_ID_DESCRIPTION, example = "00000000-0000-0000-0000-000000000202")
         @PathVariable UUID gameId,
-        @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken,
+        @Parameter(description = OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+        @RequestHeader(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER, required = false) String actionToken,
         @Valid @RequestBody PickDraftRequest request
     ) {
         pickDraft.pick(gameId, actionToken, request.playerName());

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameMemberResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameMemberResponse.java
@@ -1,8 +1,14 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "확정된 팀 편성 결과")
 record GameMemberResponse(
+    @Schema(description = "선수를 배정받은 팀장 ID", example = "leader-host")
     String teamLeaderId,
+    @Schema(description = "배정된 선수 이름", example = "선수1")
     String playerName,
+    @Schema(description = "배정 순서", example = "0")
     int assignOrder
 ) {
     static GameMemberResponse from(RosterMember member) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameParticipantResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameParticipantResponse.java
@@ -1,9 +1,16 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게임 참여 팀장 정보")
 record GameParticipantResponse(
+    @Schema(description = "팀장 ID", example = "leader-host")
     String teamLeaderId,
+    @Schema(description = "닉네임", example = "호스트")
     String nickname,
+    @Schema(description = "드래프트 순번. 경매 모드에서는 null", example = "1", nullable = true)
     Integer draftPosition,
+    @Schema(description = "남은 예산. 드래프트 모드에서는 null", example = "300", nullable = true)
     Integer remainingBudget
 ) {
     static GameParticipantResponse from(GameParticipant participant) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GamePlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GamePlayerResponse.java
@@ -1,9 +1,16 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "진행 화면에 노출되는 선수 정보")
 record GamePlayerResponse(
+    @Schema(description = "선수 이름", example = "선수1")
     String name,
+    @Schema(description = "선수 포지션", example = "TOP")
     String position,
+    @Schema(description = "노출 순서. 경매 모드에서는 현재 경매 순서, 드래프트 모드에서는 원래 displayOrder 입니다.", example = "0")
     int displayOrder,
+    @Schema(description = "현재 배정 여부", example = "AVAILABLE", allowableValues = {"AVAILABLE", "ASSIGNED"})
     String status
 ) {
     static GamePlayerResponse from(GamePlayer player, int displayOrder, boolean assigned) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameProgressResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameProgressResponse.java
@@ -1,17 +1,28 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
 
+@Schema(description = "현재 진행 정보. 모드에 따라 일부 필드만 사용됩니다.")
 record GameProgressResponse(
+    @Schema(description = "드래프트에서 현재 턴 인덱스", example = "1", nullable = true)
     Integer currentTurnIndex,
+    @Schema(description = "현재 라운드 번호", example = "2", nullable = true)
     Integer currentRound,
+    @Schema(description = "드래프트에서 현재 행동 가능한 팀장 ID", example = "leader-guest", nullable = true)
     String currentLeaderId,
+    @Schema(description = "드래프트 현재 라운드의 전체 순서", nullable = true)
     List<String> currentRoundLeaderIds,
+    @Schema(description = "경매 현재 라운드 종료 시각", example = "2026-04-19T12:00:45Z", nullable = true)
     Instant currentAuctionRoundEndsAt,
+    @Schema(description = "현재 경매 대상 선수", nullable = true)
     AuctionTargetResponse currentAuctionTarget,
+    @Schema(description = "현재 최고 입찰 금액", example = "150", nullable = true)
     Integer highestBidAmount,
+    @Schema(description = "현재 최고가를 보유한 팀장 ID", example = "leader-guest", nullable = true)
     String leadingLeaderId,
+    @Schema(description = "현재 라운드 누적 입찰 수", example = "2", nullable = true)
     Integer bidCount
 ) {
     static GameProgressResponse from(Game game) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameQueryApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameQueryApiController.java
@@ -1,6 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,11 +17,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/games")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.GAME_PLAY_TAG)
 class GameQueryApiController {
     private final GetGame getGame;
 
     @GetMapping("/{gameId}")
-    ApiResponse<GameResponse> get(@PathVariable UUID gameId) {
+    @Operation(
+        summary = "게임 진행 상태 조회",
+        description = "방 시작 후 진행 화면의 source of truth 입니다. 드래프트/경매 상태, 참가자, 멤버, 현재 진행 정보를 모두 이 API 기준으로 렌더링합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "게임 상태 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(name = "draft", value = OpenApiDocumentation.GAME_DRAFT_SUCCESS_EXAMPLE),
+                    @ExampleObject(name = "auction", value = OpenApiDocumentation.GAME_AUCTION_SUCCESS_EXAMPLE)
+                }
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "게임을 찾을 수 없음"
+        )
+    })
+    ApiResponse<GameResponse> get(
+        @Parameter(description = OpenApiDocumentation.GAME_ID_DESCRIPTION, example = "00000000-0000-0000-0000-000000000201")
+        @PathVariable UUID gameId
+    ) {
         return ApiResponse.success(GameResponse.from(getGame.get(gameId)));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/GameResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/GameResponse.java
@@ -1,23 +1,38 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Schema(description = "진행 화면의 source of truth")
 record GameResponse(
+    @Schema(description = "게임 ID", example = "00000000-0000-0000-0000-000000000201")
     String id,
+    @Schema(description = "원본 방 코드", example = "ROOM01")
     String roomCode,
+    @Schema(description = "게임 모드", example = "AUCTION", allowableValues = {"DRAFT", "AUCTION"})
     String mode,
+    @Schema(description = "게임 상태", example = "IN_PROGRESS", allowableValues = {"IN_PROGRESS", "COMPLETED"})
     String status,
+    @Schema(description = "총 팀 수", example = "2")
     int teamCount,
+    @Schema(description = "팀 전체 크기", example = "3")
     int teamSize,
+    @Schema(description = "경매 예산", example = "300", nullable = true)
     Integer budget,
+    @Schema(description = "최소 입찰 증가 단위", example = "10", nullable = true)
     Integer minBidUnit,
+    @Schema(description = "드래프트 순서 전략", example = "SNAKE", allowableValues = {"SNAKE", "FIXED"}, nullable = true)
     String draftOrderStrategy,
+    @Schema(description = "참가 팀장 목록")
     List<GameParticipantResponse> participants,
+    @Schema(description = "선수 풀. 드래프트에서는 원래 displayOrder, 경매에서는 현재 경매 순서 기준으로 정렬됩니다.")
     List<GamePlayerResponse> players,
+    @Schema(description = "지금까지 확정된 멤버 목록")
     List<GameMemberResponse> members,
+    @Schema(description = "현재 진행 정보")
     GameProgressResponse progress
 ) {
     static GameResponse from(Game game) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinRoomRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinRoomRequest.java
@@ -1,6 +1,11 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-record JoinRoomRequest(@NotBlank(message = "닉네임은 비어 있을 수 없습니다") String nickname) {
+@Schema(description = "방 참가 요청")
+record JoinRoomRequest(
+    @Schema(description = "참가자 닉네임", example = "게스트", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "닉네임은 비어 있을 수 없습니다") String nickname
+) {
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/JoinableRoomResponse.java
@@ -1,11 +1,24 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메인 화면에서 보여주는 참가 가능한 방 요약")
 record JoinableRoomResponse(
+    @Schema(description = "방 코드", example = "ROOM01")
     String code,
+    @Schema(description = "게임 모드", example = "DRAFT", allowableValues = {"DRAFT", "AUCTION"})
     String mode,
+    @Schema(description = "총 팀 수", example = "2")
     int teamCount,
+    @Schema(description = "현재 참가한 팀장 수", example = "1")
     int joinedLeaderCount,
+    @Schema(description = "남은 팀장 자리 수", example = "1")
     int remainingSlotCount,
+    @Schema(
+        description = "시작 가능 여부 요약",
+        example = "WAITING_FOR_DRAFT_POSITIONS",
+        allowableValues = {"WAITING_FOR_LEADERS", "WAITING_FOR_DRAFT_POSITIONS", "STARTABLE", "NOT_WAITING"}
+    )
     String startReadiness
 ) {
     static JoinableRoomResponse from(Room room) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/PickDraftRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PickDraftRequest.java
@@ -1,8 +1,15 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "드래프트 픽 요청")
 record PickDraftRequest(
+    @Schema(
+        description = "선택할 선수 이름. `GameResponse.players` 의 사용 가능한 이름 중 하나여야 합니다.",
+        example = "선수3",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "선수 이름은 비어 있을 수 없습니다") String playerName
 ) {
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/PlaceBidRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/PlaceBidRequest.java
@@ -1,9 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "경매 입찰 요청")
 record PlaceBidRequest(
+    @Schema(description = "입찰 금액. 현재 최고가보다 높고 최소 증가폭을 만족해야 합니다.", example = "150")
     @NotNull(message = "입찰 금액은 필수입니다")
     @Positive(message = "입찰 금액은 1 이상이어야 합니다") Integer amount
 ) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomDraftApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomDraftApiController.java
@@ -1,6 +1,13 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,15 +22,45 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/rooms")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.ROOM_LOBBY_TAG)
 class RoomDraftApiController {
     private final SelectDraftPosition selectDraftPosition;
     private final ClearDraftPosition clearDraftPosition;
     private final GetRoom getRoom;
 
     @PutMapping("/{code}/draft-position")
+    @Operation(
+        summary = "드래프트 자리 선택 또는 변경",
+        description = "드래프트 모드 로비에서 현재 팀장의 드래프트 순번을 선택합니다. `startReadiness` 가 `STARTABLE` 이 되어야 호스트가 방을 시작할 수 있습니다.",
+        security = @SecurityRequirement(name = OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME)
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "자리 선택 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_VIEW_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "액션 토큰이 없거나 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "이미 선점된 자리이거나 대기 상태가 아님"
+        )
+    })
     ApiResponse<RoomViewResponse> selectDraftPosition(
+        @Parameter(description = OpenApiDocumentation.ROOM_CODE_DESCRIPTION, example = "ROOM01")
         @PathVariable String code,
-        @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken,
+        @Parameter(description = OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+        @RequestHeader(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER, required = false) String actionToken,
         @Valid @RequestBody SelectDraftPositionRequest request
     ) {
         selectDraftPosition.select(code, actionToken, request.draftPosition());
@@ -31,9 +68,34 @@ class RoomDraftApiController {
     }
 
     @DeleteMapping("/{code}/draft-position")
+    @Operation(
+        summary = "드래프트 자리 선택 취소",
+        description = "현재 팀장이 확정했던 드래프트 순번을 해제합니다.",
+        security = @SecurityRequirement(name = OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME)
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "자리 선택 취소 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_VIEW_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "액션 토큰이 없거나 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE)
+            )
+        )
+    })
     ApiResponse<RoomViewResponse> clearDraftPosition(
+        @Parameter(description = OpenApiDocumentation.ROOM_CODE_DESCRIPTION, example = "ROOM01")
         @PathVariable String code,
-        @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken
+        @Parameter(description = OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+        @RequestHeader(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER, required = false) String actionToken
     ) {
         clearDraftPosition.clear(code, actionToken);
         return ApiResponse.success(RoomViewResponse.from(getRoom.get(code)));

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomPlayerResponse.java
@@ -1,9 +1,16 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로비에 노출되는 선수 정보")
 record RoomPlayerResponse(
+    @Schema(description = "선수 이름", example = "선수1")
     String name,
+    @Schema(description = "선수 포지션", example = "TOP")
     String position,
+    @Schema(description = "노출 순서", example = "0")
     int displayOrder,
+    @Schema(description = "배정 상태", example = "AVAILABLE", allowableValues = {"AVAILABLE", "ASSIGNED"})
     String status
 ) {
     static RoomPlayerResponse from(RoomPlayer player) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomQueryApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomQueryApiController.java
@@ -1,6 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,17 +17,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/rooms")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.ROOM_LOBBY_TAG)
 class RoomQueryApiController {
     private final GetRoom getRoom;
     private final FindJoinableRooms findJoinableRooms;
 
     @GetMapping
+    @Operation(
+        summary = "참가 가능한 방 목록 조회",
+        description = "웹 메인 화면에서 노출할 최신 대기방 목록을 조회합니다. 전체 목록이 아니라 참가 가능한 최신 방만 최대 5개 반환합니다."
+    )
     ApiResponse<List<JoinableRoomResponse>> list() {
         return ApiResponse.success(findJoinableRooms.list());
     }
 
     @GetMapping("/{code}")
-    ApiResponse<RoomViewResponse> getByCode(@PathVariable String code) {
+    @Operation(
+        summary = "로비 상태 조회",
+        description = "로비 화면의 source of truth 입니다. 방이 시작된 뒤에는 `startedGameId` 값을 보고 `/games/{gameId}` 기반 화면으로 전환해야 합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "로비 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_VIEW_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "방을 찾을 수 없음"
+        )
+    })
+    ApiResponse<RoomViewResponse> getByCode(
+        @Parameter(description = OpenApiDocumentation.ROOM_CODE_DESCRIPTION, example = "ROOM01")
+        @PathVariable String code
+    ) {
         return ApiResponse.success(RoomViewResponse.from(getRoom.get(code)));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomSessionApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomSessionApiController.java
@@ -1,6 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,18 +20,83 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/rooms")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.ROOM_SESSION_TAG)
 class RoomSessionApiController {
     private final CreateRoom createRoom;
     private final JoinRoom joinRoom;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "방 생성",
+        description = "템플릿을 기준으로 새 방을 만들고, 즉시 호스트 세션을 발급합니다. 응답의 `teamLeaderSession.actionToken` 은 이후 모든 로비/게임 mutation 요청에 사용해야 합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "201",
+            description = "방 생성 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_SESSION_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "요청 validation 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.BAD_REQUEST_VALIDATION_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "템플릿을 찾을 수 없음"
+        )
+    })
     ApiResponse<RoomSessionResponse> create(@Valid @RequestBody CreateRoomRequest request) {
         return ApiResponse.success(RoomSessionResponse.from(createRoom.create(request.templateId(), request.hostNickname())));
     }
 
     @PostMapping("/{code}/join")
-    ApiResponse<RoomSessionResponse> join(@PathVariable String code, @Valid @RequestBody JoinRoomRequest request) {
+    @Operation(
+        summary = "방 참가",
+        description = "공유받은 방 코드로 로비에 참가하고, 참가자 세션을 발급합니다. 성공 시 반환되는 `actionToken` 을 저장해야 이후 자리 선택, 픽, 입찰을 수행할 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "방 참가 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_JOIN_SUCCESS_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "요청 validation 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.BAD_REQUEST_JOIN_VALIDATION_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "방을 찾을 수 없음"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "방이 가득 찼거나 닉네임이 중복됨",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_NICKNAME_ALREADY_TAKEN_EXAMPLE)
+            )
+        )
+    })
+    ApiResponse<RoomSessionResponse> join(
+        @Parameter(description = OpenApiDocumentation.ROOM_CODE_DESCRIPTION, example = "ROOM01")
+        @PathVariable String code,
+        @Valid @RequestBody JoinRoomRequest request
+    ) {
         return ApiResponse.success(RoomSessionResponse.from(joinRoom.join(code, request.nickname())));
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomSessionResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomSessionResponse.java
@@ -1,7 +1,12 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "방 생성/참가 직후 반환되는 세션 응답")
 record RoomSessionResponse(
+    @Schema(description = "현재 로비 스냅샷")
     RoomViewResponse room,
+    @Schema(description = "현재 사용자의 방 세션 정보. FE는 이 값을 저장해야 이후 액션을 수행할 수 있습니다.")
     TeamLeaderSessionResponse teamLeaderSession
 ) {
     static RoomSessionResponse from(RoomSessionResult result) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomStartApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomStartApiController.java
@@ -1,6 +1,13 @@
 package com.naminhyeok.fantazzk.room;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,13 +18,54 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/rooms")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.ROOM_LOBBY_TAG)
 class RoomStartApiController {
     private final StartRoom startRoom;
 
     @PostMapping("/{code}/start")
+    @Operation(
+        summary = "방 시작",
+        description = "호스트가 로비를 실제 게임으로 시작합니다. 성공 시 응답으로 `GameResponse` 를 반환하며, FE는 이후 `/games/{gameId}` 를 기준으로 진행 화면을 유지해야 합니다.",
+        security = @SecurityRequirement(name = OpenApiDocumentation.ROOM_ACTION_TOKEN_SCHEME)
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "방 시작 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(name = "draft", value = OpenApiDocumentation.GAME_DRAFT_SUCCESS_EXAMPLE),
+                    @ExampleObject(name = "auction", value = OpenApiDocumentation.GAME_AUCTION_SUCCESS_EXAMPLE)
+                }
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "액션 토큰이 없거나 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_REQUIRED_EXAMPLE)
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "403",
+            description = "호스트가 아닌 팀장이 시작을 시도함"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "팀장 수 또는 드래프트 자리 준비가 완료되지 않았거나 동시 수정 충돌이 발생함",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = OpenApiDocumentation.ROOM_CONCURRENT_MODIFICATION_EXAMPLE)
+            )
+        )
+    })
     ApiResponse<GameResponse> start(
+        @Parameter(description = OpenApiDocumentation.ROOM_CODE_DESCRIPTION, example = "ROOM01")
         @PathVariable String code,
-        @RequestHeader(value = "X-Room-Action-Token", required = false) String actionToken
+        @Parameter(description = OpenApiDocumentation.ROOM_ACTION_TOKEN_DESCRIPTION)
+        @RequestHeader(value = OpenApiDocumentation.ROOM_ACTION_TOKEN_HEADER, required = false) String actionToken
     ) {
         return ApiResponse.success(GameResponse.from(startRoom.start(code, actionToken)));
     }

--- a/src/main/java/com/naminhyeok/fantazzk/room/RoomViewResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/RoomViewResponse.java
@@ -1,20 +1,43 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "로비 화면의 source of truth")
 record RoomViewResponse(
+    @Schema(description = "방 코드", example = "ROOM01")
     String code,
+    @Schema(description = "방 상태", example = "WAITING", allowableValues = {"WAITING", "STARTED"})
     String status,
+    @Schema(description = "게임 모드", example = "DRAFT", allowableValues = {"DRAFT", "AUCTION"})
     String mode,
+    @Schema(description = "총 팀 수", example = "2")
     int teamCount,
+    @Schema(description = "팀 전체 크기", example = "3")
     int teamSize,
+    @Schema(description = "경매 예산", example = "300", nullable = true)
     Integer budget,
+    @Schema(description = "최소 입찰 증가 단위", example = "10", nullable = true)
     Integer minBidUnit,
+    @Schema(description = "드래프트 순서 전략", example = "SNAKE", allowableValues = {"SNAKE", "FIXED"}, nullable = true)
     String draftOrderStrategy,
+    @Schema(
+        description = "로비 기준 시작 가능 상태. FE는 이 값을 그대로 시작 버튼 활성화/안내 문구에 활용하면 됩니다.",
+        example = "STARTABLE",
+        allowableValues = {"WAITING_FOR_LEADERS", "WAITING_FOR_DRAFT_POSITIONS", "STARTABLE", "NOT_WAITING"}
+    )
     String startReadiness,
+    @Schema(
+        description = "방이 시작되면 채워지는 게임 ID. 값이 생기면 FE는 `/games/{gameId}` 기반 진행 화면으로 전환해야 합니다.",
+        example = "00000000-0000-0000-0000-000000000201",
+        nullable = true
+    )
     String startedGameId,
+    @Schema(description = "드래프트 로비에서만 제공되는 자리 현황", nullable = true)
     DraftOrderPreviewResponse draftOrderPreview,
+    @Schema(description = "참가한 팀장 목록")
     List<TeamLeaderResponse> teamLeaders,
+    @Schema(description = "로비에서 보여줄 선수 풀")
     List<RoomPlayerResponse> players
 ) {
     static RoomViewResponse from(Room room) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPositionRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/SelectDraftPositionRequest.java
@@ -1,8 +1,15 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "드래프트 자리 선택 요청")
 record SelectDraftPositionRequest(
+    @Schema(
+        description = "선택할 드래프트 순번. 1부터 teamCount 까지의 정수",
+        example = "2",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "드래프트 자리는 필수입니다") Integer draftPosition
 ) {
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderResponse.java
@@ -1,9 +1,16 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로비 또는 게임에 참가한 팀장 정보")
 record TeamLeaderResponse(
+    @Schema(description = "팀장 ID", example = "leader-host")
     String id,
+    @Schema(description = "닉네임", example = "호스트")
     String nickname,
+    @Schema(description = "드래프트 순번. 경매 모드에서는 null", example = "1", nullable = true)
     Integer draftPosition,
+    @Schema(description = "남은 예산. 드래프트 모드에서는 null", example = "300", nullable = true)
     Integer remainingBudget
 ) {
     static TeamLeaderResponse from(RoomTeamLeader leader) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderRole.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderRole.java
@@ -1,0 +1,9 @@
+package com.naminhyeok.fantazzk.room;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "현재 사용자의 방 역할")
+enum TeamLeaderRole {
+    HOST,
+    LEADER
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderSessionResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/TeamLeaderSessionResponse.java
@@ -1,14 +1,24 @@
 package com.naminhyeok.fantazzk.room;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "현재 사용자에게 발급된 방 세션 정보")
 record TeamLeaderSessionResponse(
+    @Schema(description = "현재 사용자 팀장 ID", example = "leader-host")
     String leaderId,
-    String role,
+    @Schema(description = "현재 사용자 역할. HOST 만 방 시작 권한을 가집니다.", example = "HOST")
+    TeamLeaderRole role,
+    @Schema(
+        description = "이후 모든 mutation 요청의 `X-Room-Action-Token` 헤더에 넣어야 하는 값입니다. "
+            + "로그인 토큰이 아니라 방 액션 전용 토큰입니다.",
+        example = "room-action-token"
+    )
     String actionToken
 ) {
     static TeamLeaderSessionResponse from(Room room, RoomTeamLeader leader) {
         return new TeamLeaderSessionResponse(
             leader.getId().value(),
-            room.getHostLeaderId().equals(leader.getId()) ? "HOST" : "LEADER",
+            room.getHostLeaderId().equals(leader.getId()) ? TeamLeaderRole.HOST : TeamLeaderRole.LEADER,
             leader.getActionToken()
         );
     }

--- a/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateRequest.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/CreateTemplateRequest.java
@@ -1,6 +1,7 @@
 package com.naminhyeok.fantazzk.template;
 
 import com.naminhyeok.fantazzk.CoreException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -9,21 +10,36 @@ import jakarta.validation.constraints.Positive;
 import java.util.List;
 import java.util.stream.IntStream;
 
+@Schema(description = "템플릿 생성 요청")
 record CreateTemplateRequest(
+    @Schema(description = "템플릿 이름", example = "LOL 2인 드래프트")
     @NotBlank(message = "템플릿 이름은 비어 있을 수 없습니다") String name,
+    @Schema(description = "게임 타입", example = "LEAGUE_OF_LEGENDS")
     @NotNull(message = "게임 타입은 필수입니다") TemplateCatalog.GameType gameType,
+    @Schema(description = "템플릿 모드", example = "DRAFT")
     @NotNull(message = "템플릿 모드는 필수입니다") TemplateCatalog.Mode mode,
+    @Schema(description = "팀 수", example = "2")
     @Positive(message = "팀 수는 1 이상이어야 합니다") int teamCount,
+    @Schema(description = "팀 전체 크기. 실제로 뽑아야 하는 선수 수는 `teamSize - 1` 입니다.", example = "3")
     @Positive(message = "팀 크기는 1 이상이어야 합니다") int teamSize,
+    @Schema(description = "턴 제한 시간(초)", example = "30")
     @Positive(message = "픽밴 시간은 1 이상이어야 합니다") int pickBanTime,
+    @Schema(description = "경매 모드에서만 사용되는 팀별 예산", example = "300", nullable = true)
     Integer budget,
+    @Schema(description = "경매 모드에서만 사용되는 최소 입찰 증가 단위", example = "10", nullable = true)
     Integer minBidUnit,
+    @Schema(description = "경매 모드에서만 사용되는 동일 포지션 최대 보유 인원", example = "1", nullable = true)
     Integer positionLimit,
+    @Schema(description = "드래프트 모드에서만 사용되는 라운드 순서 전략", example = "SNAKE", nullable = true)
     TemplateCatalog.DraftOrderStrategy draftOrderStrategy,
+    @Schema(description = "선수 풀 목록. 길이는 정확히 `teamCount * (teamSize - 1)` 이어야 합니다.")
     @NotEmpty(message = "선수 목록은 비어 있을 수 없습니다") List<@Valid PlayerRequest> players
 ) {
+    @Schema(description = "템플릿 선수 입력")
     record PlayerRequest(
+        @Schema(description = "선수 이름", example = "선수1")
         @NotBlank(message = "선수 이름은 비어 있을 수 없습니다") String name,
+        @Schema(description = "게임 타입에 맞는 포지션 코드", example = "TOP")
         @NotBlank(message = "선수 포지션은 비어 있을 수 없습니다") String position
     ) {
     }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateApiController.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateApiController.java
@@ -1,6 +1,12 @@
 package com.naminhyeok.fantazzk.template;
 
 import com.naminhyeok.fantazzk.ApiResponse;
+import com.naminhyeok.fantazzk.OpenApiDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -17,22 +23,62 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/templates")
 @RequiredArgsConstructor
+@Tag(name = OpenApiDocumentation.TEMPLATE_TAG)
 class TemplateApiController {
     private final CreateTemplate createTemplate;
     private final FindTemplates findTemplates;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "템플릿 생성",
+        description = "방 생성에 사용할 템플릿을 등록합니다. 운영 중 FE가 직접 호출할 가능성보다, 관리/운영 도구에서 사용하는 성격이 강합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "201",
+        description = "템플릿 생성 성공",
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(value = OpenApiDocumentation.TEMPLATE_DETAIL_SUCCESS_EXAMPLE)
+        )
+    )
     ApiResponse<TemplateResponse> create(@Valid @RequestBody CreateTemplateRequest request) {
         return ApiResponse.success(TemplateResponse.from(createTemplate.create(request.toCommand())));
     }
 
     @GetMapping("/{id}")
-    ApiResponse<TemplateResponse> getById(@PathVariable UUID id) {
+    @Operation(
+        summary = "템플릿 상세 조회",
+        description = "방 생성 전에 특정 템플릿의 상세 규칙과 선수 풀을 확인합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "템플릿 상세 조회 성공",
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(value = OpenApiDocumentation.TEMPLATE_DETAIL_SUCCESS_EXAMPLE)
+        )
+    )
+    ApiResponse<TemplateResponse> getById(
+        @Parameter(description = "조회할 템플릿 ID", example = "11111111-1111-1111-1111-111111111111")
+        @PathVariable UUID id
+    ) {
         return ApiResponse.success(TemplateResponse.from(findTemplates.getDetail(new TemplateId(id))));
     }
 
     @GetMapping
+    @Operation(
+        summary = "템플릿 목록 조회",
+        description = "웹의 첫 진입 단계에서 사용 가능한 방 룰 목록을 조회합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "템플릿 목록 조회 성공",
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(value = OpenApiDocumentation.TEMPLATE_LIST_SUCCESS_EXAMPLE)
+        )
+    )
     ApiResponse<List<TemplateResponse>> list() {
         return ApiResponse.success(findTemplates.list().stream().map(TemplateResponse::from).toList());
     }

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayerResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplatePlayerResponse.java
@@ -1,8 +1,14 @@
 package com.naminhyeok.fantazzk.template;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "템플릿 선수 정보")
 record TemplatePlayerResponse(
+    @Schema(description = "선수 이름", example = "선수1")
     String name,
+    @Schema(description = "포지션 코드", example = "TOP")
     String position,
+    @Schema(description = "화면 노출 순서", example = "0")
     int displayOrder
 ) {
     static TemplatePlayerResponse from(TemplatePlayer player) {

--- a/src/main/java/com/naminhyeok/fantazzk/template/TemplateResponse.java
+++ b/src/main/java/com/naminhyeok/fantazzk/template/TemplateResponse.java
@@ -1,19 +1,33 @@
 package com.naminhyeok.fantazzk.template;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "템플릿 조회 응답")
 record TemplateResponse(
+    @Schema(description = "템플릿 ID", example = "11111111-1111-1111-1111-111111111111")
     String id,
+    @Schema(description = "템플릿 이름", example = "LOL 2인 드래프트")
     String name,
+    @Schema(description = "게임 타입", example = "LEAGUE_OF_LEGENDS")
     TemplateCatalog.GameType gameType,
+    @Schema(description = "게임 모드", example = "DRAFT")
     TemplateCatalog.Mode mode,
+    @Schema(description = "팀 수", example = "2")
     int teamCount,
+    @Schema(description = "팀 전체 크기", example = "3")
     int teamSize,
+    @Schema(description = "경매 예산", example = "300", nullable = true)
     Integer budget,
+    @Schema(description = "턴 제한 시간(초)", example = "30")
     Integer pickBanTime,
+    @Schema(description = "최소 입찰 증가 단위", example = "10", nullable = true)
     Integer minBidUnit,
+    @Schema(description = "동일 포지션 최대 보유 인원", example = "1", nullable = true)
     Integer positionLimit,
+    @Schema(description = "드래프트 순서 전략", example = "SNAKE", nullable = true)
     TemplateCatalog.DraftOrderStrategy draftOrderStrategy,
+    @Schema(description = "선수 풀 목록")
     List<TemplatePlayerResponse> players
 ) {
     static TemplateResponse from(Template template) {

--- a/src/test/java/com/naminhyeok/fantazzk/room/RoomSessionApiControllerWebMvcTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/RoomSessionApiControllerWebMvcTest.java
@@ -63,7 +63,7 @@ class RoomSessionApiControllerWebMvcTest {
         assertThat(body.success().room().code()).isEqualTo(RoomApiTestFixtures.ROOM_CODE);
         assertThat(body.success().room().status()).isEqualTo("WAITING");
         assertThat(body.success().teamLeaderSession().leaderId()).isEqualTo(RoomApiTestFixtures.HOST_ID);
-        assertThat(body.success().teamLeaderSession().role()).isEqualTo("HOST");
+        assertThat(body.success().teamLeaderSession().role()).isEqualTo(TeamLeaderRole.HOST);
         assertThat(body.success().teamLeaderSession().actionToken()).isEqualTo(RoomApiTestFixtures.HOST_TOKEN);
     }
 
@@ -113,7 +113,7 @@ class RoomSessionApiControllerWebMvcTest {
         assertThat(body.resultType()).isEqualTo("SUCCESS");
         assertThat(body.success().room().code()).isEqualTo(RoomApiTestFixtures.ROOM_CODE);
         assertThat(body.success().teamLeaderSession().leaderId()).isEqualTo(RoomApiTestFixtures.GUEST_ID);
-        assertThat(body.success().teamLeaderSession().role()).isEqualTo("LEADER");
+        assertThat(body.success().teamLeaderSession().role()).isEqualTo(TeamLeaderRole.LEADER);
         assertThat(body.success().teamLeaderSession().actionToken()).isEqualTo(RoomApiTestFixtures.GUEST_TOKEN);
     }
 

--- a/src/test/java/com/naminhyeok/fantazzk/room/TeamLeaderSessionResponseTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/TeamLeaderSessionResponseTest.java
@@ -1,0 +1,27 @@
+package com.naminhyeok.fantazzk.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TeamLeaderSessionResponseTest {
+    @Test
+    void role_필드는_enum_타입이다() {
+        Class<?> roleType = TeamLeaderSessionResponse.class.getRecordComponents()[1].getType();
+
+        assertThat(roleType.getName()).isEqualTo("com.naminhyeok.fantazzk.room.TeamLeaderRole");
+        assertThat(roleType.isEnum()).isTrue();
+    }
+
+    @Test
+    void 호스트_세션은_enum_HOST_역할을_반환한다() throws Exception {
+        Room room = RoomApiTestFixtures.waitingAuctionRoom();
+        RoomTeamLeader host = room.getLeaders().getFirst();
+
+        TeamLeaderSessionResponse response = TeamLeaderSessionResponse.from(room, host);
+        Object role = TeamLeaderSessionResponse.class.getMethod("role").invoke(response);
+
+        assertThat(role.toString()).isEqualTo("HOST");
+        assertThat(role.getClass().isEnum()).isTrue();
+    }
+}


### PR DESCRIPTION
## 배경
AS-IS
현재 Swagger 문서는 엔드포인트 목록을 나열하는 수준에 가까워서, 외부 웹 개발자가 실제로 어떤 흐름으로 API를 호출해야 하는지 파악하기 어려웠습니다.
또한 `TeamLeaderSessionResponse.role` 이 문자열로 표현되고 있어 서버 내부 타입 안정성이 약했고, Swagger 상에서도 enum 값 목록이 일관되게 드러나지 않았습니다.

TO-BE
Swagger 첫 화면과 각 엔드포인트 상세 화면만 확인해도 템플릿 조회부터 방 생성/참가, 로비 조회, 게임 진행까지의 흐름을 이해할 수 있도록 문서를 보강합니다.
동시에 역할과 주요 상태 값은 enum 기반으로 표현하거나 enum 목록이 문서에 명시되도록 정리해 FE와의 계약을 더 분명하게 만듭니다.

## 변경 사항
### 1. OpenAPI 공통 문서 정리
- OpenAPI 상단 설명에 FE 기준 사용 흐름을 추가했습니다.
- `Template`, `Room Session`, `Room Lobby`, `Game Play` 태그로 문서 구조를 재구성했습니다.
- `X-Room-Action-Token` 헤더를 security scheme 으로 노출해 mutation API에서 공통 규칙을 바로 확인할 수 있게 했습니다.
- 공통 예시 payload 와 설명 문구를 `OpenApiDocumentation` 으로 모아 문서 일관성을 높였습니다.

### 2. 엔드포인트별 Swagger 정보 보강
- room, game, template 관련 주요 컨트롤러에 summary, description, 주요 응답 코드, 예시 응답을 추가했습니다.
- 방 생성/참가 응답에서 `actionToken` 을 저장해 이후 요청 헤더에 사용해야 한다는 점을 문서에 반영했습니다.
- 로비는 `room`, 시작 후 진행 화면은 `game` 이 source of truth 라는 점을 각 엔드포인트 설명에 반영했습니다.
- 드래프트 픽, 경매 입찰, 경매 진행 갱신처럼 FE가 자주 보는 API는 실제 화면 상태에 맞춘 응답 예시를 추가했습니다.

### 3. DTO/응답 스키마 설명 보강
- request/response record 에 필드 설명과 예시를 추가해, 각 값이 화면에서 어떤 의미인지 Swagger 만으로 파악할 수 있게 했습니다.
- `startedGameId`, `startReadiness`, `currentLeaderId`, `currentAuctionTarget` 같은 핵심 필드의 용도를 명시했습니다.
- 누락되어 있던 enum 계열 값 목록이 Swagger schema 에 드러나도록 `mode`, `startReadiness`, `draftOrderStrategy` 등을 보강했습니다.

### 4. 팀장 역할 표현 enum화
- `TeamLeaderSessionResponse.role` 을 문자열에서 `TeamLeaderRole` enum 으로 변경했습니다.
- JSON 응답 값은 그대로 `HOST`, `LEADER` 로 유지하면서 서버 내부 타입 안정성을 높였습니다.
- 관련 테스트를 추가하고 기존 WebMvc 테스트도 enum 기준으로 갱신했습니다.

## 검증
- `./gradlew check integrationTest`
- `./gradlew test --tests 'com.naminhyeok.fantazzk.room.TeamLeaderSessionResponseTest' --tests 'com.naminhyeok.fantazzk.room.RoomSessionApiControllerWebMvcTest'`
- `./gradlew openapiBootRun --args='--spring.profiles.active=openapi --server.port=18080'`
- `curl http://localhost:18080/v3/api-docs` 로 security scheme, role enum, 주요 enum 값 목록 노출 확인

## 리뷰 포인트
- Swagger 첫 화면과 엔드포인트 설명만으로 FE가 호출 순서를 이해할 수 있는지
- `TeamLeaderSessionResponse.role` enum 화가 FE 코드 생성 또는 타입 매핑에 문제를 만들지 않는지
- enum 값을 문서에 노출한 방식이 현재 팀의 API 문서 기준과 잘 맞는지
