### PR TITLE
room 도메인과 템플릿 계약 결합 정리

### DIFF
--- a/src/main/java/com/naminhyeok/fantazzk/room/application/CreateRoom.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/application/CreateRoom.java
@@ -68,7 +68,7 @@ public class CreateRoom {
         String hostActionToken,
         String hostNickname
     ) {
-        RoomTemplateSpec spec = RoomTemplateSpec.from(template);
+        RoomTemplateSpec spec = RoomTemplateSpecFactory.from(template);
         return Room.createFromTemplate(
             generateCode(),
             hostLeaderId,

--- a/src/main/java/com/naminhyeok/fantazzk/room/application/RoomTemplateSpecFactory.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/application/RoomTemplateSpecFactory.java
@@ -1,0 +1,70 @@
+package com.naminhyeok.fantazzk.room.application;
+
+import com.naminhyeok.fantazzk.room.domain.DraftOrderStrategy;
+import com.naminhyeok.fantazzk.room.domain.RoomMode;
+import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
+import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
+import com.naminhyeok.fantazzk.template.TemplateCatalog;
+import java.util.List;
+import java.util.Objects;
+
+final class RoomTemplateSpecFactory {
+    private RoomTemplateSpecFactory() {
+    }
+
+    static RoomTemplateSpec from(TemplateCatalog.TemplateBlueprint template) {
+        Objects.requireNonNull(template, "template must not be null");
+        List<RoomTemplateSpec.Player> players = template.players().stream()
+            .map(RoomTemplateSpecFactory::playerFrom)
+            .toList();
+        int requiredPlayerCount = template.teamCount() * (template.teamSize() - 1);
+        if (players.size() != requiredPlayerCount) {
+            throw new IllegalArgumentException("선수 수는 정확히 " + requiredPlayerCount + "명이어야 합니다");
+        }
+        return new RoomTemplateSpec(
+            template.gameType(),
+            roomModeFrom(template.mode()),
+            template.teamCount(),
+            template.teamSize(),
+            template.budget(),
+            requirePickBanTime(template.pickBanTime()),
+            template.minBidUnit(),
+            draftOrderStrategyFrom(template.draftOrderStrategy()),
+            players
+        );
+    }
+
+    private static RoomMode roomModeFrom(TemplateCatalog.Mode mode) {
+        return switch (Objects.requireNonNull(mode, "mode must not be null")) {
+            case AUCTION -> RoomMode.AUCTION;
+            case DRAFT -> RoomMode.DRAFT;
+        };
+    }
+
+    private static DraftOrderStrategy draftOrderStrategyFrom(TemplateCatalog.DraftOrderStrategy strategy) {
+        if (strategy == null) {
+            return null;
+        }
+        return switch (strategy) {
+            case SNAKE -> DraftOrderStrategy.SNAKE;
+            case FIXED -> DraftOrderStrategy.FIXED;
+        };
+    }
+
+    private static RoomTemplateSpec.Player playerFrom(TemplateCatalog.PlayerBlueprint player) {
+        Objects.requireNonNull(player, "player must not be null");
+        return new RoomTemplateSpec.Player(
+            new RoomPlayerId(player.playerIndex()),
+            player.name(),
+            player.position(),
+            player.playerIndex()
+        );
+    }
+
+    private static int requirePickBanTime(Integer pickBanTime) {
+        if (pickBanTime == null) {
+            throw new IllegalArgumentException("방 생성 명세에는 픽밴 시간이 필요합니다");
+        }
+        return pickBanTime;
+    }
+}

--- a/src/main/java/com/naminhyeok/fantazzk/room/domain/DraftOrderStrategy.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/domain/DraftOrderStrategy.java
@@ -1,18 +1,6 @@
 package com.naminhyeok.fantazzk.room.domain;
 
-import com.naminhyeok.fantazzk.template.TemplateCatalog;
-
 public enum DraftOrderStrategy {
     SNAKE,
-    FIXED;
-
-    public static DraftOrderStrategy from(TemplateCatalog.DraftOrderStrategy strategy) {
-        if (strategy == null) {
-            return null;
-        }
-        return switch (strategy) {
-            case SNAKE -> SNAKE;
-            case FIXED -> FIXED;
-        };
-    }
+    FIXED
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/domain/Room.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/domain/Room.java
@@ -216,26 +216,7 @@ public class Room implements AggregateRoot<Room, RoomId> {
         startedAt = Objects.requireNonNull(now, "now must not be null");
         status = RoomStatus.STARTED;
 
-        return new StartedGameSnapshot(
-            id,
-            code,
-            startedGameId,
-            startedAt,
-            gameType,
-            mode,
-            mode == RoomMode.AUCTION
-                ? GameRules.auction(teamCount, teamSize, budget, pickBanTime, minBidUnit)
-                : GameRules.draft(teamCount, teamSize, pickBanTime, draftOrderStrategy),
-            leaders.stream()
-                .map(leader -> mode == RoomMode.AUCTION
-                    ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
-                    : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
-                .toList(),
-            players.stream()
-                .sorted(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
-                .map(player -> new GamePlayer(player.getId(), player.getName(), player.getPosition(), player.getDisplayOrder()))
-                .toList()
-        );
+        return StartedGameSnapshotFactory.from(this);
     }
 
     private void validateDraftPositionChange(int draftPosition) {

--- a/src/main/java/com/naminhyeok/fantazzk/room/domain/RoomMode.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/domain/RoomMode.java
@@ -1,16 +1,6 @@
 package com.naminhyeok.fantazzk.room.domain;
 
-import com.naminhyeok.fantazzk.template.TemplateCatalog;
-import java.util.Objects;
-
 public enum RoomMode {
     AUCTION,
-    DRAFT;
-
-    public static RoomMode from(TemplateCatalog.Mode mode) {
-        return switch (Objects.requireNonNull(mode, "mode must not be null")) {
-            case AUCTION -> AUCTION;
-            case DRAFT -> DRAFT;
-        };
-    }
+    DRAFT
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/domain/RoomTemplateSpec.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/domain/RoomTemplateSpec.java
@@ -1,6 +1,5 @@
 package com.naminhyeok.fantazzk.room.domain;
 
-import com.naminhyeok.fantazzk.template.TemplateCatalog;
 import java.util.List;
 import java.util.Objects;
 
@@ -53,42 +52,6 @@ public record RoomTemplateSpec(
         }
     }
 
-    public static RoomTemplateSpec from(TemplateCatalog.TemplateBlueprint template) {
-        Objects.requireNonNull(template, "template must not be null");
-        List<Player> players = template.players().stream().map(Player::from).toList();
-        int requiredPlayerCount = template.teamCount() * (template.teamSize() - 1);
-        if (players.size() != requiredPlayerCount) {
-            throw new IllegalArgumentException("선수 수는 정확히 " + requiredPlayerCount + "명이어야 합니다");
-        }
-        return new RoomTemplateSpec(
-            template.gameType(),
-            RoomMode.from(template.mode()),
-            template.teamCount(),
-            template.teamSize(),
-            template.budget(),
-            requirePickBanTime(template.pickBanTime()),
-            template.minBidUnit(),
-            DraftOrderStrategy.from(template.draftOrderStrategy()),
-            players
-        );
-    }
-
     public record Player(RoomPlayerId id, String name, String position, int displayOrder) {
-        public static Player from(TemplateCatalog.PlayerBlueprint player) {
-            Objects.requireNonNull(player, "player must not be null");
-            return new Player(
-                new RoomPlayerId(player.playerIndex()),
-                player.name(),
-                player.position(),
-                player.playerIndex()
-            );
-        }
-    }
-
-    private static int requirePickBanTime(Integer pickBanTime) {
-        if (pickBanTime == null) {
-            throw new IllegalArgumentException("방 생성 명세에는 픽밴 시간이 필요합니다");
-        }
-        return pickBanTime;
     }
 }

--- a/src/main/java/com/naminhyeok/fantazzk/room/domain/StartedGameSnapshotFactory.java
+++ b/src/main/java/com/naminhyeok/fantazzk/room/domain/StartedGameSnapshotFactory.java
@@ -1,0 +1,47 @@
+package com.naminhyeok.fantazzk.room.domain;
+
+import java.util.Comparator;
+
+final class StartedGameSnapshotFactory {
+    private StartedGameSnapshotFactory() {
+    }
+
+    static StartedGameSnapshot from(Room room) {
+        return new StartedGameSnapshot(
+            room.getId(),
+            room.getCode(),
+            room.getStartedGameId(),
+            room.getStartedAt(),
+            room.getGameType(),
+            room.getMode(),
+            rulesOf(room),
+            room.getLeaders().stream()
+                .map(leader -> room.getMode() == RoomMode.AUCTION
+                    ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
+                    : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
+                .toList(),
+            room.getPlayers().stream()
+                .sorted(Comparator.comparingInt(RoomPlayer::getDisplayOrder))
+                .map(player -> new GamePlayer(player.getId(), player.getName(), player.getPosition(), player.getDisplayOrder()))
+                .toList()
+        );
+    }
+
+    private static GameRules rulesOf(Room room) {
+        if (room.getMode() == RoomMode.AUCTION) {
+            return GameRules.auction(
+                room.getTeamCount(),
+                room.getTeamSize(),
+                room.getBudget(),
+                room.getPickBanTime(),
+                room.getMinBidUnit()
+            );
+        }
+        return GameRules.draft(
+            room.getTeamCount(),
+            room.getTeamSize(),
+            room.getPickBanTime(),
+            room.getDraftOrderStrategy()
+        );
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/architecture/RoomInternalPackageIsolationTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/architecture/RoomInternalPackageIsolationTest.java
@@ -44,6 +44,15 @@ class RoomInternalPackageIsolationTest {
             );
 
     @ArchTest
+    static final ArchRule room_domain은_template_모듈에_의존하지_않는다 =
+        noClasses()
+            .that()
+            .resideInAnyPackage("..room.domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("..template..");
+
+    @ArchTest
     static final ArchRule room_query는_web이나_infrastructure에_의존하지_않는다 =
         noClasses()
             .that()

--- a/src/test/java/com/naminhyeok/fantazzk/room/application/RoomRealtimePublishingTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/application/RoomRealtimePublishingTest.java
@@ -11,20 +11,11 @@ import com.naminhyeok.fantazzk.room.application.RoomRealtimeEventPublisher;
 import com.naminhyeok.fantazzk.room.application.SelectDraftPosition;
 import com.naminhyeok.fantazzk.room.application.SettleAuctionAttempt;
 import com.naminhyeok.fantazzk.room.domain.AuctionGame;
-import com.naminhyeok.fantazzk.room.domain.DraftOrderStrategy;
 import com.naminhyeok.fantazzk.room.domain.Game;
-import com.naminhyeok.fantazzk.room.domain.GameFactory;
 import com.naminhyeok.fantazzk.room.domain.GameId;
-import com.naminhyeok.fantazzk.room.domain.GameParticipant;
-import com.naminhyeok.fantazzk.room.domain.GamePlayer;
-import com.naminhyeok.fantazzk.room.domain.GameRules;
 import com.naminhyeok.fantazzk.room.domain.Room;
 import com.naminhyeok.fantazzk.room.domain.RoomErrorType;
 import com.naminhyeok.fantazzk.room.domain.RoomId;
-import com.naminhyeok.fantazzk.room.domain.RoomMode;
-import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
-import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
-import com.naminhyeok.fantazzk.room.domain.StartedGameSnapshot;
 import com.naminhyeok.fantazzk.room.domain.StartedRoomSnapshot;
 import com.naminhyeok.fantazzk.room.domain.TeamLeaderId;
 import com.naminhyeok.fantazzk.room.infrastructure.realtime.RoomRealtimeEvent;
@@ -32,7 +23,7 @@ import com.naminhyeok.fantazzk.room.infrastructure.realtime.RoomRealtimeEventFac
 import com.naminhyeok.fantazzk.room.infrastructure.realtime.RoomUpdatedEvent;
 import com.naminhyeok.fantazzk.room.repository.Games;
 import com.naminhyeok.fantazzk.room.repository.Rooms;
-import java.nio.charset.StandardCharsets;
+import com.naminhyeok.fantazzk.room.support.RoomFixtureBuilder;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -43,16 +34,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 class RoomRealtimePublishingTest {
-    private static final Instant CREATED_AT = Instant.parse("2024-01-01T10:00:00Z");
+    private static final Instant CREATED_AT = RoomFixtureBuilder.CREATED_AT;
     private static final Instant PUBLISHED_AT = Instant.parse("2024-01-01T10:00:30Z");
-    private static final String HOST_ID = "leader-host";
-    private static final String HOST_ACTION_TOKEN = "host-token";
-    private static final String GUEST_ID = "leader-guest";
-    private static final String GUEST_ACTION_TOKEN = "guest-token";
 
     @Test
     void 방_참가_저장_충돌은_동시_수정_오류로_번역하고_이벤트를_발행하지_않는다() {
-        Room room = waitingAuctionRoom();
+        Room room = RoomFixtureBuilder.auction().buildRoom();
         RecordingRoomRealtimeEventPublisher publisher = new RecordingRoomRealtimeEventPublisher();
         JoinRoom joinRoom = new JoinRoom(new OptimisticLockFailureRooms(room), publisher);
 
@@ -63,29 +50,29 @@ class RoomRealtimePublishingTest {
 
     @Test
     void 드래프트_자리_선택은_로비_스냅샷을_발행한다() {
-        Room room = waitingDraftRoomForPositionChange();
+        Room room = RoomFixtureBuilder.draft().joined().buildRoom();
         RecordingRoomRealtimeEventPublisher publisher = new RecordingRoomRealtimeEventPublisher();
         SelectDraftPosition selectDraftPosition =
             new SelectDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
 
-        selectDraftPosition.select(room.getCode(), HOST_ACTION_TOKEN, 1);
+        selectDraftPosition.select(room.getCode(), RoomFixtureBuilder.HOST_TOKEN, 1);
 
         assertThat(publisher.events).hasSize(1);
         assertThat(publisher.events.getFirst()).isInstanceOf(RoomUpdatedEvent.class);
         RoomUpdatedEvent event = (RoomUpdatedEvent) publisher.events.getFirst();
         assertThat(event.roomCode()).isEqualTo(room.getCode());
-        assertThat(event.room().draftOrder().slots().getFirst().leaderId()).isEqualTo(HOST_ID);
+        assertThat(event.room().draftOrder().slots().getFirst().leaderId()).isEqualTo(RoomFixtureBuilder.HOST_ID);
     }
 
     @Test
     void 드래프트_자리_취소는_로비_스냅샷을_발행한다() {
-        Room room = waitingDraftRoomForPositionChange();
-        room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
+        Room room = RoomFixtureBuilder.draft().joined().buildRoom();
+        room.selectDraftPosition(new TeamLeaderId(RoomFixtureBuilder.HOST_ID), 1);
         RecordingRoomRealtimeEventPublisher publisher = new RecordingRoomRealtimeEventPublisher();
         ClearDraftPosition clearDraftPosition =
             new ClearDraftPosition(new InMemoryRooms(room), new RoomActionAuthorizer(), publisher);
 
-        clearDraftPosition.clear(room.getCode(), HOST_ACTION_TOKEN);
+        clearDraftPosition.clear(room.getCode(), RoomFixtureBuilder.HOST_TOKEN);
 
         assertThat(publisher.events).hasSize(1);
         assertThat(publisher.events.getFirst()).isInstanceOf(RoomUpdatedEvent.class);
@@ -95,8 +82,8 @@ class RoomRealtimePublishingTest {
 
     @Test
     void 마감_전_정산은_스냅샷을_발행하지_않는다() {
-        Room room = startedAuctionRoom();
-        AuctionGame game = (AuctionGame) gameFor(room);
+        Room room = RoomFixtureBuilder.auction().started().buildRoom();
+        AuctionGame game = (AuctionGame) RoomFixtureBuilder.gameFor(room);
         RecordingRoomRealtimeEventPublisher publisher = new RecordingRoomRealtimeEventPublisher();
         InMemoryRooms rooms = new InMemoryRooms(room);
         InMemoryGames games = new InMemoryGames(game);
@@ -115,109 +102,6 @@ class RoomRealtimePublishingTest {
 
     private static void assertRoomError(CoreException exception, RoomErrorType errorType) {
         assertThat(exception.getError()).isSameAs(errorType);
-    }
-
-    private static Room waitingAuctionRoom() {
-        return Room.createFromTemplate(
-            "ROOM01",
-            new TeamLeaderId(HOST_ID),
-            "호스트",
-            HOST_ACTION_TOKEN,
-            new RoomTemplateSpec(
-                "LEAGUE_OF_LEGENDS",
-                RoomMode.AUCTION,
-                2,
-                2,
-                300,
-                30,
-                10,
-                null,
-                List.of(
-                    new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
-                    new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
-                )
-            ),
-            CREATED_AT
-        );
-    }
-
-    private static Room joinedAuctionRoom() {
-        Room room = waitingAuctionRoom();
-        room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
-        return room;
-    }
-
-    private static Room startedAuctionRoom() {
-        Room room = joinedAuctionRoom();
-        room.start(new TeamLeaderId(HOST_ID), deterministicGameId(room), CREATED_AT);
-        return room;
-    }
-
-    private static Room waitingDraftRoomForPositionChange() {
-        Room room =
-            Room.createFromTemplate(
-                "DRF001",
-                new TeamLeaderId(HOST_ID),
-                "호스트",
-                HOST_ACTION_TOKEN,
-                new RoomTemplateSpec(
-                    "LEAGUE_OF_LEGENDS",
-                    RoomMode.DRAFT,
-                    2,
-                    2,
-                    null,
-                    30,
-                    null,
-                    DraftOrderStrategy.SNAKE,
-                    List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
-                    )
-                ),
-                CREATED_AT
-            );
-        room.join(new TeamLeaderId(GUEST_ID), "게스트", GUEST_ACTION_TOKEN);
-        return room;
-    }
-
-    private static Game gameFor(Room room) {
-        return new GameFactory().create(
-            new StartedGameSnapshot(
-                room.getId(),
-                room.getCode(),
-                room.getStartedGameId(),
-                room.getStartedAt(),
-                room.getGameType(),
-                room.getMode(),
-                room.getMode() == RoomMode.AUCTION
-                    ? GameRules.auction(
-                        room.getTeamCount(),
-                        room.getTeamSize(),
-                        room.getBudget(),
-                        room.getPickBanTime(),
-                        room.getMinBidUnit()
-                    )
-                    : GameRules.draft(
-                        room.getTeamCount(),
-                        room.getTeamSize(),
-                        room.getPickBanTime(),
-                        room.getDraftOrderStrategy()
-                    ),
-                room.getLeaders().stream()
-                    .map(leader -> room.getMode() == RoomMode.AUCTION
-                        ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
-                        : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
-                    .toList(),
-                room.getPlayers().stream()
-                    .map(player -> new GamePlayer(player.getId(), player.getName(), player.getPosition(), player.getDisplayOrder()))
-                    .toList()
-            )
-        );
-    }
-
-    private static GameId deterministicGameId(Room room) {
-        String source = "game:%s".formatted(room.getId().roomId());
-        return new GameId(java.util.UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8)));
     }
 
     private static final class RecordingRoomRealtimeEventPublisher implements RoomRealtimeEventPublisher {

--- a/src/test/java/com/naminhyeok/fantazzk/room/application/RoomTemplateSpecFactoryTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/application/RoomTemplateSpecFactoryTest.java
@@ -1,0 +1,101 @@
+package com.naminhyeok.fantazzk.room.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.naminhyeok.fantazzk.room.domain.DraftOrderStrategy;
+import com.naminhyeok.fantazzk.room.domain.RoomMode;
+import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
+import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
+import com.naminhyeok.fantazzk.template.TemplateCatalog;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RoomTemplateSpecFactoryTest {
+    @Test
+    void 템플릿_계약을_room_생성_명세로_한_번만_정제한다() {
+        RoomTemplateSpec spec =
+            RoomTemplateSpecFactory.from(
+                new TemplateCatalog.TemplateBlueprint(
+                    "LEAGUE_OF_LEGENDS",
+                    TemplateCatalog.Mode.DRAFT,
+                    2,
+                    3,
+                    null,
+                    30,
+                    null,
+                    TemplateCatalog.DraftOrderStrategy.SNAKE,
+                    List.of(
+                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
+                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1),
+                        new TemplateCatalog.PlayerBlueprint("선수3", "MID", 2),
+                        new TemplateCatalog.PlayerBlueprint("선수4", "ADC", 3)
+                    )
+                )
+            );
+
+        assertThat(spec.gameType()).isEqualTo("LEAGUE_OF_LEGENDS");
+        assertThat(spec.mode()).isEqualTo(RoomMode.DRAFT);
+        assertThat(spec.teamCount()).isEqualTo(2);
+        assertThat(spec.teamSize()).isEqualTo(3);
+        assertThat(spec.pickBanTime()).isEqualTo(30);
+        assertThat(spec.draftOrderStrategy()).isEqualTo(DraftOrderStrategy.SNAKE);
+        assertThat(spec.players())
+            .extracting(RoomTemplateSpec.Player::id, RoomTemplateSpec.Player::name, RoomTemplateSpec.Player::position, RoomTemplateSpec.Player::displayOrder)
+            .containsExactly(
+                tuple(new RoomPlayerId(0), "선수1", "TOP", 0),
+                tuple(new RoomPlayerId(1), "선수2", "JUNGLE", 1),
+                tuple(new RoomPlayerId(2), "선수3", "MID", 2),
+                tuple(new RoomPlayerId(3), "선수4", "ADC", 3)
+            );
+    }
+
+    @Test
+    void 드래프트_계약에_순서_전략이_없으면_변환을_거부한다() {
+        assertThatThrownBy(
+            () -> RoomTemplateSpecFactory.from(
+                new TemplateCatalog.TemplateBlueprint(
+                    "LEAGUE_OF_LEGENDS",
+                    TemplateCatalog.Mode.DRAFT,
+                    2,
+                    2,
+                    null,
+                    30,
+                    null,
+                    null,
+                    List.of(
+                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
+                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1)
+                    )
+                )
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("드래프트 방 생성 명세에는 순서 전략이 필요합니다");
+    }
+
+    @Test
+    void 픽밴_시간이_없으면_변환을_거부한다() {
+        assertThatThrownBy(
+            () -> RoomTemplateSpecFactory.from(
+                new TemplateCatalog.TemplateBlueprint(
+                    "LEAGUE_OF_LEGENDS",
+                    TemplateCatalog.Mode.AUCTION,
+                    2,
+                    2,
+                    300,
+                    null,
+                    10,
+                    null,
+                    List.of(
+                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
+                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1)
+                    )
+                )
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("방 생성 명세에는 픽밴 시간이 필요합니다");
+    }
+}

--- a/src/test/java/com/naminhyeok/fantazzk/room/application/StartedGameContextLoaderTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/application/StartedGameContextLoaderTest.java
@@ -4,52 +4,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.naminhyeok.fantazzk.CoreException;
-import com.naminhyeok.fantazzk.room.application.RoomActionAuthorizer;
-import com.naminhyeok.fantazzk.room.application.StartedGameActionContext;
-import com.naminhyeok.fantazzk.room.application.StartedGameContextLoader;
 import com.naminhyeok.fantazzk.room.domain.Game;
-import com.naminhyeok.fantazzk.room.domain.GameFactory;
 import com.naminhyeok.fantazzk.room.domain.GameId;
-import com.naminhyeok.fantazzk.room.domain.GameParticipant;
-import com.naminhyeok.fantazzk.room.domain.GamePlayer;
-import com.naminhyeok.fantazzk.room.domain.GameRules;
 import com.naminhyeok.fantazzk.room.domain.Room;
 import com.naminhyeok.fantazzk.room.domain.RoomErrorType;
 import com.naminhyeok.fantazzk.room.domain.RoomId;
-import com.naminhyeok.fantazzk.room.domain.RoomMode;
-import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
-import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
-import com.naminhyeok.fantazzk.room.domain.StartedGameSnapshot;
 import com.naminhyeok.fantazzk.room.domain.TeamLeaderId;
 import com.naminhyeok.fantazzk.room.repository.Games;
 import com.naminhyeok.fantazzk.room.repository.Rooms;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import com.naminhyeok.fantazzk.room.support.RoomFixtureBuilder;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class StartedGameContextLoaderTest {
-    private static final Instant CREATED_AT = Instant.parse("2026-04-18T00:00:00Z");
-
     @Test
     void 시작된_게임_행위는_방의_액션_토큰으로_인증한다() {
-        Room room = startedAuctionRoom();
-        Game game = startedGameOf(room);
+        Room room = RoomFixtureBuilder.auction().started().buildRoom();
+        Game game = RoomFixtureBuilder.gameFor(room);
         StartedGameContextLoader loader = new StartedGameContextLoader(
             new InMemoryRooms(Map.of(room.getId(), room)),
             new InMemoryGames(Map.of(game.getId(), game)),
             new RoomActionAuthorizer()
         );
 
-        StartedGameActionContext action = loader.authenticate(game.getId().gameId(), "host-action-token");
+        StartedGameActionContext action = loader.authenticate(game.getId().gameId(), RoomFixtureBuilder.HOST_TOKEN);
 
         assertThat(action.room().getId()).isEqualTo(room.getId());
         assertThat(action.game().getId()).isEqualTo(game.getId());
-        assertThat(action.caller().getId()).isEqualTo(new TeamLeaderId("host-1"));
+        assertThat(action.caller().getId()).isEqualTo(new TeamLeaderId(RoomFixtureBuilder.HOST_ID));
     }
 
     @Test
@@ -66,8 +51,8 @@ class StartedGameContextLoaderTest {
 
     @Test
     void 게임의_방이_없어도_GAME_NOT_FOUND를_반환한다() {
-        Room room = startedAuctionRoom();
-        Game game = startedGameOf(room);
+        Room room = RoomFixtureBuilder.auction().started().buildRoom();
+        Game game = RoomFixtureBuilder.gameFor(room);
         StartedGameContextLoader loader =
             new StartedGameContextLoader(new InMemoryRooms(Map.of()), new InMemoryGames(Map.of(game.getId(), game)), new RoomActionAuthorizer());
 
@@ -80,8 +65,8 @@ class StartedGameContextLoaderTest {
 
     @Test
     void 액션_토큰이_유효하지_않으면_ROOM_ACTION_TOKEN_INVALID를_반환한다() {
-        Room room = startedAuctionRoom();
-        Game game = startedGameOf(room);
+        Room room = RoomFixtureBuilder.auction().started().buildRoom();
+        Game game = RoomFixtureBuilder.gameFor(room);
         StartedGameContextLoader loader = new StartedGameContextLoader(
             new InMemoryRooms(Map.of(room.getId(), room)),
             new InMemoryGames(Map.of(game.getId(), game)),
@@ -93,61 +78,6 @@ class StartedGameContextLoaderTest {
                 CoreException.class,
                 ex -> assertThat(ex.getError()).isEqualTo(RoomErrorType.ROOM_ACTION_TOKEN_INVALID)
             );
-    }
-
-    private Room startedAuctionRoom() {
-        Room room =
-            Room.createFromTemplate(
-                "ROOM01",
-                new TeamLeaderId("host-1"),
-                "호스트",
-                "host-action-token",
-                new RoomTemplateSpec(
-                    "LEAGUE_OF_LEGENDS",
-                    RoomMode.AUCTION,
-                    2,
-                    2,
-                    300,
-                    45,
-                    10,
-                    null,
-                    List.of(
-                        new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
-                        new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
-                    )
-                ),
-                CREATED_AT
-        );
-        room.join(new TeamLeaderId("guest-1"), "게스트", "guest-action-token");
-        room.start(new TeamLeaderId("host-1"), deterministicGameId(room), CREATED_AT);
-        return room;
-    }
-
-    private Game startedGameOf(Room room) {
-        return new GameFactory().create(
-            new StartedGameSnapshot(
-                room.getId(),
-                room.getCode(),
-                room.getStartedGameId(),
-                room.getStartedAt(),
-                room.getGameType(),
-                room.getMode(),
-                GameRules.auction(room.getTeamCount(), room.getTeamSize(), room.getBudget(), room.getPickBanTime(), room.getMinBidUnit()),
-                List.of(
-                    GameParticipant.auction(new TeamLeaderId("host-1"), "호스트", 300),
-                    GameParticipant.auction(new TeamLeaderId("guest-1"), "게스트", 300)
-                ),
-                List.of(
-                    new GamePlayer(new RoomPlayerId(0), "선수1", "TOP", 0),
-                    new GamePlayer(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
-                )
-            )
-        );
-    }
-
-    private static GameId deterministicGameId(Room room) {
-        String source = "game:%s".formatted(room.getId().roomId());
-        return new GameId(UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8)));
     }
 
     private static final class InMemoryRooms implements Rooms {

--- a/src/test/java/com/naminhyeok/fantazzk/room/domain/RoomTemplateSpecTest.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/domain/RoomTemplateSpecTest.java
@@ -1,74 +1,24 @@
 package com.naminhyeok.fantazzk.room.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.naminhyeok.fantazzk.room.domain.DraftOrderStrategy;
-import com.naminhyeok.fantazzk.room.domain.RoomMode;
-import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
-import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
-import com.naminhyeok.fantazzk.template.TemplateCatalog;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class RoomTemplateSpecTest {
     @Test
-    void 템플릿_계약을_room_생성_명세로_한_번만_정제한다() {
-        RoomTemplateSpec spec =
-            RoomTemplateSpec.from(
-                new TemplateCatalog.TemplateBlueprint(
-                    "LEAGUE_OF_LEGENDS",
-                    TemplateCatalog.Mode.DRAFT,
-                    2,
-                    3,
-                    null,
-                    30,
-                    null,
-                    TemplateCatalog.DraftOrderStrategy.SNAKE,
-                    List.of(
-                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
-                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1),
-                        new TemplateCatalog.PlayerBlueprint("선수3", "MID", 2),
-                        new TemplateCatalog.PlayerBlueprint("선수4", "ADC", 3)
-                    )
-                )
-            );
-
-        assertThat(spec.gameType()).isEqualTo("LEAGUE_OF_LEGENDS");
-        assertThat(spec.mode()).isEqualTo(RoomMode.DRAFT);
-        assertThat(spec.teamCount()).isEqualTo(2);
-        assertThat(spec.teamSize()).isEqualTo(3);
-        assertThat(spec.pickBanTime()).isEqualTo(30);
-        assertThat(spec.draftOrderStrategy()).isEqualTo(DraftOrderStrategy.SNAKE);
-        assertThat(spec.players())
-            .extracting(RoomTemplateSpec.Player::id, RoomTemplateSpec.Player::name, RoomTemplateSpec.Player::position, RoomTemplateSpec.Player::displayOrder)
-            .containsExactly(
-                org.assertj.core.groups.Tuple.tuple(new RoomPlayerId(0), "선수1", "TOP", 0),
-                org.assertj.core.groups.Tuple.tuple(new RoomPlayerId(1), "선수2", "JUNGLE", 1),
-                org.assertj.core.groups.Tuple.tuple(new RoomPlayerId(2), "선수3", "MID", 2),
-                org.assertj.core.groups.Tuple.tuple(new RoomPlayerId(3), "선수4", "ADC", 3)
-            );
-    }
-
-    @Test
-    void 드래프트_계약에_순서_전략이_없으면_변환을_거부한다() {
+    void 드래프트_명세에는_순서_전략이_필요하다() {
         assertThatThrownBy(
-            () -> RoomTemplateSpec.from(
-                new TemplateCatalog.TemplateBlueprint(
-                    "LEAGUE_OF_LEGENDS",
-                    TemplateCatalog.Mode.DRAFT,
-                    2,
-                    2,
-                    null,
-                    30,
-                    null,
-                    null,
-                    List.of(
-                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
-                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1)
-                    )
-                )
+            () -> new RoomTemplateSpec(
+                "LEAGUE_OF_LEGENDS",
+                RoomMode.DRAFT,
+                2,
+                2,
+                null,
+                30,
+                null,
+                null,
+                players()
             )
         )
             .isInstanceOf(IllegalArgumentException.class)
@@ -76,26 +26,28 @@ class RoomTemplateSpecTest {
     }
 
     @Test
-    void 픽밴_시간이_없으면_변환을_거부한다() {
+    void 경매_명세에는_예산이_필요하다() {
         assertThatThrownBy(
-            () -> RoomTemplateSpec.from(
-                new TemplateCatalog.TemplateBlueprint(
-                    "LEAGUE_OF_LEGENDS",
-                    TemplateCatalog.Mode.AUCTION,
-                    2,
-                    2,
-                    300,
-                    null,
-                    10,
-                    null,
-                    List.of(
-                        new TemplateCatalog.PlayerBlueprint("선수1", "TOP", 0),
-                        new TemplateCatalog.PlayerBlueprint("선수2", "JUNGLE", 1)
-                    )
-                )
+            () -> new RoomTemplateSpec(
+                "LEAGUE_OF_LEGENDS",
+                RoomMode.AUCTION,
+                2,
+                2,
+                null,
+                30,
+                10,
+                null,
+                players()
             )
         )
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("방 생성 명세에는 픽밴 시간이 필요합니다");
+            .hasMessage("경매 방 생성 명세에는 예산이 필요합니다");
+    }
+
+    private List<RoomTemplateSpec.Player> players() {
+        return List.of(
+            new RoomTemplateSpec.Player(new RoomPlayerId(0), "선수1", "TOP", 0),
+            new RoomTemplateSpec.Player(new RoomPlayerId(1), "선수2", "JUNGLE", 1)
+        );
     }
 }

--- a/src/test/java/com/naminhyeok/fantazzk/room/support/RoomFixtureBuilder.java
+++ b/src/test/java/com/naminhyeok/fantazzk/room/support/RoomFixtureBuilder.java
@@ -1,0 +1,217 @@
+package com.naminhyeok.fantazzk.room.support;
+
+import com.naminhyeok.fantazzk.room.domain.DraftOrderStrategy;
+import com.naminhyeok.fantazzk.room.domain.Game;
+import com.naminhyeok.fantazzk.room.domain.GameFactory;
+import com.naminhyeok.fantazzk.room.domain.GameId;
+import com.naminhyeok.fantazzk.room.domain.GameParticipant;
+import com.naminhyeok.fantazzk.room.domain.GamePlayer;
+import com.naminhyeok.fantazzk.room.domain.GameRules;
+import com.naminhyeok.fantazzk.room.domain.Room;
+import com.naminhyeok.fantazzk.room.domain.RoomMode;
+import com.naminhyeok.fantazzk.room.domain.RoomPlayerId;
+import com.naminhyeok.fantazzk.room.domain.RoomTemplateSpec;
+import com.naminhyeok.fantazzk.room.domain.StartedGameSnapshot;
+import com.naminhyeok.fantazzk.room.domain.StartedRoomSnapshot;
+import com.naminhyeok.fantazzk.room.domain.TeamLeaderId;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public final class RoomFixtureBuilder {
+    public static final Instant CREATED_AT = Instant.parse("2024-01-01T10:00:00Z");
+    public static final String ROOM_CODE = "ROOM01";
+    public static final String HOST_ID = "leader-host";
+    public static final String HOST_TOKEN = "host-token";
+    public static final String GUEST_ID = "leader-guest";
+    public static final String GUEST_TOKEN = "guest-token";
+
+    private static final String GAME_TYPE = "LEAGUE_OF_LEGENDS";
+    private static final String HOST_NICKNAME = "호스트";
+    private static final String GUEST_NICKNAME = "게스트";
+
+    private final RoomMode mode;
+    private String code = ROOM_CODE;
+    private Instant createdAt = CREATED_AT;
+    private int teamCount = 2;
+    private int teamSize = 2;
+    private Integer budget;
+    private int pickBanTime;
+    private Integer minBidUnit;
+    private DraftOrderStrategy draftOrderStrategy;
+    private boolean joined;
+    private boolean draftPositionsSelected;
+    private boolean started;
+    private List<RoomTemplateSpec.Player> players;
+
+    private RoomFixtureBuilder(RoomMode mode) {
+        this.mode = mode;
+        if (mode == RoomMode.AUCTION) {
+            this.budget = 300;
+            this.pickBanTime = 30;
+            this.minBidUnit = 10;
+            this.draftOrderStrategy = null;
+        } else {
+            this.budget = null;
+            this.pickBanTime = 30;
+            this.minBidUnit = null;
+            this.draftOrderStrategy = DraftOrderStrategy.SNAKE;
+        }
+    }
+
+    public static RoomFixtureBuilder auction() {
+        return new RoomFixtureBuilder(RoomMode.AUCTION);
+    }
+
+    public static RoomFixtureBuilder draft() {
+        return new RoomFixtureBuilder(RoomMode.DRAFT);
+    }
+
+    public RoomFixtureBuilder code(String code) {
+        this.code = code;
+        return this;
+    }
+
+    public RoomFixtureBuilder createdAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public RoomFixtureBuilder teamSize(int teamSize) {
+        this.teamSize = teamSize;
+        this.players = null;
+        return this;
+    }
+
+    public RoomFixtureBuilder pickBanTime(int pickBanTime) {
+        this.pickBanTime = pickBanTime;
+        return this;
+    }
+
+    public RoomFixtureBuilder joined() {
+        this.joined = true;
+        return this;
+    }
+
+    public RoomFixtureBuilder draftPositionsSelected() {
+        this.joined = true;
+        this.draftPositionsSelected = true;
+        return this;
+    }
+
+    public RoomFixtureBuilder started() {
+        this.joined = true;
+        this.started = true;
+        if (mode == RoomMode.DRAFT) {
+            this.draftPositionsSelected = true;
+        }
+        return this;
+    }
+
+    public RoomFixtureBuilder players(List<RoomTemplateSpec.Player> players) {
+        this.players = List.copyOf(players);
+        return this;
+    }
+
+    public Room buildRoom() {
+        Room room = Room.createFromTemplate(
+            code,
+            new TeamLeaderId(HOST_ID),
+            HOST_NICKNAME,
+            HOST_TOKEN,
+            spec(),
+            createdAt
+        );
+        if (joined) {
+            room.join(new TeamLeaderId(GUEST_ID), GUEST_NICKNAME, GUEST_TOKEN);
+        }
+        if (draftPositionsSelected) {
+            room.selectDraftPosition(new TeamLeaderId(HOST_ID), 1);
+            room.selectDraftPosition(new TeamLeaderId(GUEST_ID), 2);
+        }
+        if (started) {
+            room.start(new TeamLeaderId(HOST_ID), deterministicGameId(room), createdAt);
+        }
+        return room;
+    }
+
+    public StartedRoomSnapshot buildStartedDetails() {
+        Room room = started().buildRoom();
+        return new StartedRoomSnapshot(room, gameFor(room));
+    }
+
+    public static Game gameFor(Room room) {
+        return new GameFactory().create(startedGameSnapshotOf(room));
+    }
+
+    public static GameId deterministicGameId(Room room) {
+        String source = "game:%s".formatted(room.getId().roomId());
+        return new GameId(UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private RoomTemplateSpec spec() {
+        return new RoomTemplateSpec(
+            GAME_TYPE,
+            mode,
+            teamCount,
+            teamSize,
+            budget,
+            pickBanTime,
+            minBidUnit,
+            draftOrderStrategy,
+            players == null ? defaultPlayers() : players
+        );
+    }
+
+    private List<RoomTemplateSpec.Player> defaultPlayers() {
+        List<RoomTemplateSpec.Player> defaultPlayers = new ArrayList<>();
+        int playerCount = teamCount * (teamSize - 1);
+        String[] positions = {"TOP", "JUNGLE", "MID", "ADC", "SUPPORT"};
+        for (int index = 0; index < playerCount; index++) {
+            defaultPlayers.add(
+                new RoomTemplateSpec.Player(
+                    new RoomPlayerId(index),
+                    "선수" + (index + 1),
+                    positions[index % positions.length],
+                    index
+                )
+            );
+        }
+        return defaultPlayers;
+    }
+
+    private static StartedGameSnapshot startedGameSnapshotOf(Room room) {
+        return new StartedGameSnapshot(
+            room.getId(),
+            room.getCode(),
+            room.getStartedGameId(),
+            room.getStartedAt(),
+            room.getGameType(),
+            room.getMode(),
+            room.getMode() == RoomMode.AUCTION
+                ? GameRules.auction(
+                    room.getTeamCount(),
+                    room.getTeamSize(),
+                    room.getBudget(),
+                    room.getPickBanTime(),
+                    room.getMinBidUnit()
+                )
+                : GameRules.draft(
+                    room.getTeamCount(),
+                    room.getTeamSize(),
+                    room.getPickBanTime(),
+                    room.getDraftOrderStrategy()
+                ),
+            room.getLeaders().stream()
+                .map(leader -> room.getMode() == RoomMode.AUCTION
+                    ? GameParticipant.auction(leader.getId(), leader.getNickname(), leader.getRemainingBudget())
+                    : GameParticipant.draft(leader.getId(), leader.getNickname(), leader.getDraftPosition()))
+                .toList(),
+            room.getPlayers().stream()
+                .map(player -> new GamePlayer(player.getId(), player.getName(), player.getPosition(), player.getDisplayOrder()))
+                .toList()
+        );
+    }
+}


### PR DESCRIPTION
## 배경

`room` 모듈의 도메인 타입이 `template` 모듈의 public 계약인 `TemplateCatalog` 세부 타입을 직접 알고 있었습니다. 구조 테스트는 모듈 외부에서 internal package에 접근하는 문제는 막고 있었지만, `room.domain` 내부로 다른 모듈의 계약 DTO 변환 책임이 들어오는 경우는 별도로 고정하지 못했습니다.

이 상태에서는 템플릿 계약의 enum, blueprint 형태가 바뀔 때 방 도메인 모델까지 함께 흔들리고, 실제 방 생성 규칙과 외부 모듈 계약 변환 책임이 한 타입 안에 섞여 읽기 비용이 커집니다.

## 변경 사항

- `RoomTemplateSpec.from(TemplateCatalog.TemplateBlueprint)` 변환 책임을 `room.application`의 `RoomTemplateSpecFactory`로 이동했습니다.
- `RoomMode`, `DraftOrderStrategy`, `RoomTemplateSpec`에서 `TemplateCatalog` 의존을 제거했습니다.
- `RoomInternalPackageIsolationTest`에 `room.domain`이 `template` 모듈에 직접 의존하지 않는 구조 규칙을 추가했습니다.
- `Room.start`가 시작 검증과 상태 전이에 집중하도록 `StartedGameSnapshotFactory`를 도입해 게임 시작 스냅샷 조립을 분리했습니다.
- 반복되던 테스트용 room/game 조립을 `RoomFixtureBuilder`로 일부 정리해 application 테스트의 생성 잡음을 줄였습니다.
- 템플릿 계약 변환 테스트는 `RoomTemplateSpecFactoryTest`로 옮기고, `RoomTemplateSpecTest`는 순수 방 생성 명세 invariant를 검증하도록 정리했습니다.

## AS-IS

- `room.domain`이 `template.TemplateCatalog`의 enum과 blueprint를 직접 참조했습니다.
- `RoomTemplateSpec`이 방 생성 명세 invariant와 템플릿 계약 변환을 동시에 맡았습니다.
- `Room.start` 내부에 시작 가능성 검증, 상태 전이, `StartedGameSnapshot` 상세 조립이 함께 있었습니다.
- 일부 application 테스트가 방과 게임 시작 상태를 직접 길게 조립해 리팩토링에 취약했습니다.

## TO-BE

- 템플릿 계약 해석은 `room.application` 경계에서 끝나고, `room.domain`은 순수 방 생성 명세만 받습니다.
- 구조 테스트가 `room.domain -> template` 직접 의존을 회귀로 잡습니다.
- `Room` aggregate는 시작 상태 전이와 invariant에 더 집중하고, 스냅샷 구성은 같은 도메인 패키지의 작은 factory가 맡습니다.
- application 테스트는 공용 fixture builder를 통해 핵심 시나리오만 드러내도록 정리했습니다.

## 검증

- `./gradlew clean check integrationTest`

## 리뷰 포인트

- `RoomTemplateSpecFactory`가 application 경계에 있는 것이 현재 모듈 규칙과 맞는지 확인 부탁드립니다.
- `StartedGameSnapshotFactory`는 같은 도메인 패키지의 package-private helper로 두었습니다. aggregate 밖으로 뺀 책임 범위가 적절한지 봐주시면 좋겠습니다.
- `RoomFixtureBuilder`는 우선 application 테스트의 반복 조립을 줄이는 범위로만 적용했습니다. 이후 repository/domain 테스트 fixture까지 확대할지는 별도 리팩토링으로 보는 편이 안전합니다.
